### PR TITLE
refactor(core-cli): use git instead of npm for reinstall and update

### DIFF
--- a/packages/core-cli/src/services/installer.ts
+++ b/packages/core-cli/src/services/installer.ts
@@ -1,5 +1,4 @@
 import { sync } from "execa";
-import * as semver from "semver";
 
 import { injectable } from "../ioc";
 
@@ -14,46 +13,21 @@ export class Installer {
      * @memberof Installer
      */
     public install(pkg: string, tag: string = "latest"): void {
-        this.installPeerDependencies(pkg, tag);
+        const coreDirectory = __dirname + "/../../../../";
 
-        const { stdout, stderr, exitCode } = sync(`yarn global add ${pkg}@${tag} --force`, { shell: true });
+        const getLastTag = (regex) => `\`git tag --sort=committerdate | grep -Px ${regex} | tail -1\``;
+        let gitTag = tag;
+        if (tag === "latest") {
+            gitTag = getLastTag('"^\\d+.\\d+.\\d+"');
+        } else if (tag === "next") {
+            gitTag = getLastTag('"^\\d+.\\d+.\\d+-next.\\d+"');
+        }
+
+        const command = `cd ${coreDirectory} && git tag -l | xargs git tag -d && git fetch --all --tags -f && git reset --hard && git checkout tags/${gitTag} && yarn setup`;
+        const { stderr, exitCode } = sync(command, { shell: true });
 
         if (exitCode !== 0) {
-            throw new Error(`"yarn global add ${pkg}@${tag} --force" exited with code ${exitCode}\n${stderr}`);
+            throw new Error(`"${command}" exited with code ${exitCode}\n${stderr}`);
         }
-
-        console.log(stdout);
-    }
-
-    public installPeerDependencies(pkg: string, tag: string = "latest"): void {
-        const { stdout, stderr, exitCode } = sync(`yarn info ${pkg}@${tag} peerDependencies --json`, { shell: true });
-
-        if (exitCode !== 0) {
-            throw new Error(
-                `"yarn info ${pkg}@${tag} peerDependencies --json" exited with code ${exitCode}\n${stderr}`,
-            );
-        }
-
-        for (const [peerPkg, peerPkgSemver] of Object.entries(JSON.parse(stdout).data ?? {})) {
-            this.installRangeLatest(peerPkg, peerPkgSemver as string);
-        }
-    }
-
-    public installRangeLatest(pkg: string, range: string): void {
-        const { stdout, stderr, exitCode } = sync(`yarn info ${pkg} versions --json`, { shell: true });
-
-        if (exitCode !== 0) {
-            throw new Error(`"yarn info ${pkg} versions --json" exited with code ${exitCode}\n${stderr}`);
-        }
-
-        const versions = (JSON.parse(stdout).data as string[])
-            .filter((v) => semver.satisfies(v, range))
-            .sort((a, b) => semver.rcompare(a, b));
-
-        if (versions.length === 0) {
-            throw new Error(`No ${pkg} version to satisfy ${range}`);
-        }
-
-        this.install(pkg, versions[0]);
     }
 }

--- a/packages/core-cli/src/services/updater.ts
+++ b/packages/core-cli/src/services/updater.ts
@@ -1,7 +1,7 @@
 import { dim, green, reset } from "kleur";
-import latestVersion from "latest-version";
 import * as semver from "semver";
 import { PackageJson } from "type-fest";
+import { sync } from "execa";
 
 import { Application } from "../application";
 import { Confirm, Spinner, Warning } from "../components";
@@ -10,8 +10,6 @@ import { Identifiers, inject, injectable } from "../ioc";
 import { Installer } from "./installer";
 import { ProcessManager } from "./process-manager";
 import * as Contracts from "../contracts";
-
-const ONE_DAY = 1000 * 60 * 60 * 24;
 
 /**
  * @export
@@ -61,13 +59,6 @@ export class Updater implements Contracts.Updater {
 
     /**
      * @private
-     * @type {*}
-     * @memberof Updater
-     */
-    private updateCheckInterval: any = ONE_DAY;
-
-    /**
-     * @private
      * @type {(string | undefined)}
      * @memberof Updater
      */
@@ -81,16 +72,10 @@ export class Updater implements Contracts.Updater {
         this.latestVersion = this.config.get("latestVersion");
 
         if (this.latestVersion) {
-            this.config.forget("latestVersion"); // ? shouldn't it be moved after lastUpdateCheck
-        }
-
-        if (Date.now() - this.config.get<number>("lastUpdateCheck") < this.updateCheckInterval) {
-            return false;
+            this.config.forget("latestVersion");
         }
 
         const latestVersion: string | undefined = await this.getLatestVersion();
-
-        this.config.set("lastUpdateCheck", Date.now());
 
         if (latestVersion === undefined) {
             return false;
@@ -132,13 +117,18 @@ export class Updater implements Contracts.Updater {
 
         spinner.start();
 
-        this.installer.install(this.packageName, this.packageChannel);
+        try {
+            this.installer.install(this.packageName, this.packageChannel);
 
-        if (updateProcessManager) {
-            this.processManager.update();
+            if (updateProcessManager) {
+                this.processManager.update();
+            }
+
+            spinner.succeed();
+        } catch (error) {
+            spinner.fail();
+            throw error;
         }
-
-        spinner.succeed();
 
         return true;
     }
@@ -149,23 +139,28 @@ export class Updater implements Contracts.Updater {
      * @memberof Updater
      */
     public async getLatestVersion(): Promise<string | undefined> {
-        try {
-            const latest: string | undefined = await latestVersion(this.packageName, {
-                version: this.packageChannel,
-            });
 
-            if (semver.lte(latest, this.packageVersion)) {
-                return undefined;
-            }
+        const coreDirectory = __dirname + "/../../../../";
+        let regex = '"^\\d+.\\d+.\\d+"';
+        if (this.packageChannel === "next") {
+            regex = '"^\\d+.\\d+.\\d+-next.\\d+"';
+        }
+        const command = `cd ${coreDirectory} && git tag -l | xargs git tag -d > /dev/null && git fetch --all --tags -fq && git tag --sort=committerdate | grep -Px ${regex} | tail -1`;
+        const { stdout, exitCode } = sync(command, { shell: true });
 
-            return latest;
-        } catch {
+        if (exitCode !== 0) {
             this.app
-                .get<Warning>(Identifiers.Warning)
-                .render(`We were unable to find any releases for the "${this.packageChannel}" channel.`);
+            .get<Warning>(Identifiers.Warning)
+            .render(`We were unable to find any releases for the "${this.packageChannel}" channel.`);
 
             return undefined;
         }
+
+        if (semver.lte(stdout, this.packageVersion)) {
+            return undefined;
+        }
+
+        return stdout;
     }
 
     private get packageName(): string {

--- a/packages/core-cli/src/services/updater.ts
+++ b/packages/core-cli/src/services/updater.ts
@@ -141,17 +141,19 @@ export class Updater implements Contracts.Updater {
     public async getLatestVersion(): Promise<string | undefined> {
 
         const coreDirectory = __dirname + "/../../../../";
+
         let regex = '"^\\d+.\\d+.\\d+"';
         if (this.packageChannel === "next") {
             regex = '"^\\d+.\\d+.\\d+-next.\\d+"';
         }
+
         const command = `cd ${coreDirectory} && git tag -l | xargs git tag -d > /dev/null && git fetch --all --tags -fq && git tag --sort=committerdate | grep -Px ${regex} | tail -1`;
         const { stdout, exitCode } = sync(command, { shell: true });
 
         if (exitCode !== 0) {
             this.app
-            .get<Warning>(Identifiers.Warning)
-            .render(`We were unable to find any releases for the "${this.packageChannel}" channel.`);
+                .get<Warning>(Identifiers.Warning)
+                .render(`We were unable to find any releases for the "${this.packageChannel}" channel.`);
 
             return undefined;
         }

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -56,9 +56,6 @@ export class CommandLineInterface {
         // Create the application we will work with
         this.app = ApplicationFactory.make(new Container.Container(), pkg);
 
-        // Check for updates
-        this.app.get<Contracts.Updater>(Container.Identifiers.Updater).check();
-
         // Parse arguments and flags
         const { args, flags } = InputParser.parseArgv(this.argv);
 

--- a/packages/core/src/commands/config-cli.ts
+++ b/packages/core/src/commands/config-cli.ts
@@ -51,7 +51,7 @@ export class Command extends Commands.Command {
             .setFlag("token", "The name of the token.", Joi.string())
             .setFlag(
                 "channel",
-                "The NPM registry channel that should be used.",
+                "Whether to install stable (latest) or prerelease (next) versions of Core.",
                 Joi.string().valid(...["next", "latest"]),
             );
     }
@@ -77,17 +77,22 @@ export class Command extends Commands.Command {
 
             this.config.set("channel", newChannel);
 
-            const spinner = this.components.spinner(`Installing ${this.pkg.name}@${newChannel}`);
+            const spinner = this.components.spinner(`Installing ${newChannel}`);
 
             spinner.start();
 
-            this.installer.install(this.pkg.name!, newChannel);
+            try {
+                this.installer.install(this.pkg.name!, newChannel);
 
-            spinner.succeed();
+                spinner.succeed();
 
-            await this.actions.restartRunningProcessWithPrompt(`${this.getFlag("token")}-core`);
-            await this.actions.restartRunningProcessWithPrompt(`${this.getFlag("token")}-relay`);
-            await this.actions.restartRunningProcessWithPrompt(`${this.getFlag("token")}-forger`);
+                await this.actions.restartRunningProcessWithPrompt(`${this.getFlag("token")}-core`);
+                await this.actions.restartRunningProcessWithPrompt(`${this.getFlag("token")}-relay`);
+                await this.actions.restartRunningProcessWithPrompt(`${this.getFlag("token")}-forger`);
+            } catch (error) {
+                spinner.fail();
+                this.components.error(error);
+            }
         }
     }
 }

--- a/packages/core/src/commands/reinstall.ts
+++ b/packages/core/src/commands/reinstall.ts
@@ -82,14 +82,19 @@ export class Command extends Commands.Command {
 
         spinner.start();
 
-        this.installer.install(this.pkg.name!, this.pkg.version!);
+        try {
+            this.installer.install(this.pkg.name!, this.pkg.version!);
 
-        this.processManager.update();
+            this.processManager.update();
 
-        spinner.succeed();
+            spinner.succeed();
 
-        await this.actions.restartRunningProcessWithPrompt(`${this.getFlag("token")}-core`);
-        await this.actions.restartRunningProcessWithPrompt(`${this.getFlag("token")}-relay`);
-        await this.actions.restartRunningProcessWithPrompt(`${this.getFlag("token")}-forger`);
+            await this.actions.restartRunningProcessWithPrompt(`${this.getFlag("token")}-core`);
+            await this.actions.restartRunningProcessWithPrompt(`${this.getFlag("token")}-relay`);
+            await this.actions.restartRunningProcessWithPrompt(`${this.getFlag("token")}-forger`);
+        } catch (error) {
+            spinner.fail();
+            this.components.error(error);
+        }
     }
 }


### PR DESCRIPTION
Updates the cli to use git instead of npm.

Also removed the restriction that limited checking for updates to once per day and now it only checks when the specific `update` command is executed (instead of every time the cli is run) to save resources.