### PR TITLE
feat: emoji symbols and more clarity in logs

### DIFF
--- a/packages/core-blockchain/src/blockchain.ts
+++ b/packages/core-blockchain/src/blockchain.ts
@@ -63,7 +63,7 @@ export class Blockchain implements Contracts.Blockchain.Blockchain {
 
         if (this.stateStore.getNetworkStart()) {
             this.logger.warning(
-                "ARK Core is launched in Genesis Start mode. This is usually for starting the first node on the blockchain. Unless you know what you are doing, this is likely wrong.",
+                "ARK Core is launched in Genesis Start mode. This is usually for starting the first node on the blockchain. Unless you know what you are doing, this is likely wrong :warning:",
             );
         }
 
@@ -81,7 +81,7 @@ export class Blockchain implements Contracts.Blockchain.Blockchain {
                     "block",
                     blocks.length,
                     true,
-                )} from height ${blocks[0].height.toLocaleString()} in queue.`,
+                )} from height ${blocks[0].height.toLocaleString()} in queue :skull:`,
             );
         });
     }
@@ -115,7 +115,7 @@ export class Blockchain implements Contracts.Blockchain.Blockchain {
      * @return {void}
      */
     public async boot(skipStartedCheck = false): Promise<boolean> {
-        this.logger.info("Starting Blockchain Manager");
+        this.logger.info("Starting Blockchain Manager :chains:");
 
         this.stateStore.reset(blockchainMachine);
 
@@ -145,7 +145,7 @@ export class Blockchain implements Contracts.Blockchain.Blockchain {
 
     public async dispose(): Promise<void> {
         if (!this.stopped) {
-            this.logger.info("Stopping Blockchain Manager");
+            this.logger.info("Stopping Blockchain Manager :chains:");
 
             this.stopped = true;
             this.stateStore.clearWakeUpTimeout();
@@ -205,13 +205,13 @@ export class Blockchain implements Contracts.Blockchain.Blockchain {
             const minimumMs: number = 2000;
             const timeLeftInMs: number = Crypto.Slots.getTimeInMsUntilNextSlot(blockTimeLookup);
             if (currentSlot !== receivedSlot || timeLeftInMs < minimumMs) {
-                this.logger.info(`Discarded block ${block.height.toLocaleString()} because it was received too late.`);
+                this.logger.info(`Discarded block ${block.height.toLocaleString()} because it was received too late :exclamation:`);
                 return;
             }
         }
 
         if (receivedSlot > currentSlot) {
-            this.logger.info(`Discarded block ${block.height.toLocaleString()} because it takes a future slot.`);
+            this.logger.info(`Discarded block ${block.height.toLocaleString()} because it takes a future slot :exclamation:`);
             return;
         }
 
@@ -223,7 +223,7 @@ export class Blockchain implements Contracts.Blockchain.Blockchain {
 
             this.events.dispatch(Enums.BlockEvent.Received, block);
         } else {
-            this.logger.info(`Block disregarded because blockchain is not ready`);
+            this.logger.info(`Block disregarded because blockchain is not ready :exclamation:`);
 
             this.events.dispatch(Enums.BlockEvent.Disregarded, block);
         }
@@ -352,7 +352,7 @@ export class Blockchain implements Contracts.Blockchain.Blockchain {
 
             const resetHeight: number = lastBlock.data.height - nblocks;
             this.logger.info(
-                `Removing ${Utils.pluralize("block", nblocks, true)}. Reset to height ${resetHeight.toLocaleString()}`,
+                `Removing ${Utils.pluralize("block", nblocks, true)}. Reset to height ${resetHeight.toLocaleString()} :warning:`,
             );
 
             this.stateStore.setLastDownloadedBlock(lastBlock.data);
@@ -376,7 +376,7 @@ export class Blockchain implements Contracts.Blockchain.Blockchain {
             }
         } catch (err) {
             this.logger.error(err.stack);
-            this.logger.warning("Shutting down app, because state might be corrupted");
+            this.logger.warning("Shutting down app, because state might be corrupted :boom:");
             process.exit(1);
         }
     }

--- a/packages/core-blockchain/src/process-blocks-job.ts
+++ b/packages/core-blockchain/src/process-blocks-job.ts
@@ -210,7 +210,7 @@ export class ProcessBlocksJob implements Contracts.Kernel.QueueJob {
     }
 
     private async handleCorrupted() {
-        this.logger.error("Shutting down app, because state is corrupted");
+        this.logger.error("Shutting down app, because state is corrupted :boom:");
         process.exit(1);
     }
 }

--- a/packages/core-blockchain/src/processor/block-processor.ts
+++ b/packages/core-blockchain/src/processor/block-processor.ts
@@ -295,10 +295,10 @@ export class BlockProcessor {
 
         const generatorWallet: Contracts.State.Wallet = walletRepository.findByPublicKey(block.data.generatorPublicKey);
 
-        const expectedReward = Utils.calculateReward(block.data.height, generatorWallet.getAttribute("delegate.rank"));
+        const expectedReward = AppUtils.BigNumber.make(Utils.calculateReward(block.data.height, generatorWallet.getAttribute("delegate.rank")));
 
         if (!block.data.reward.isEqualTo(expectedReward)) {
-            this.logger.warning(["Invalid block reward:", block.data.reward, "Expected:", expectedReward].join(" ") + " :bangbang:");
+            this.logger.warning(`Block rejected as reward was ${Utils.formatSatoshi(block.data.reward)}, should be ${Utils.formatSatoshi(expectedReward)} :bangbang:`);
             return false;
         }
 

--- a/packages/core-blockchain/src/processor/block-processor.ts
+++ b/packages/core-blockchain/src/processor/block-processor.ts
@@ -108,7 +108,7 @@ export class BlockProcessor {
 
                 block.verification = block.verify();
             } catch (error) {
-                this.logger.warning(`Failed to verify block, because: ${error.message}`);
+                this.logger.warning(`Failed to verify block, because: ${error.message} :bangbang:`);
                 block.verification.verified = false;
             }
         }
@@ -118,7 +118,7 @@ export class BlockProcessor {
             this.logger.warning(
                 `Block ${block.data.height.toLocaleString()} (${
                     block.data.id
-                }) disregarded because verification failed`,
+                }) disregarded because verification failed :scroll:`,
             );
 
             this.logger.warning(JSON.stringify(block.verification, undefined, 4));
@@ -158,7 +158,7 @@ export class BlockProcessor {
             /* istanbul ignore else */
             if (forgedIds.length > 0) {
                 this.logger.warning(
-                    `Block ${block.data.height.toLocaleString()} disregarded, because it contains already forged transactions`,
+                    `Block ${block.data.height.toLocaleString()} disregarded, because it contains already forged transactions :scroll:`,
                 );
 
                 this.logger.debug(`${JSON.stringify(forgedIds, undefined, 4)}`);
@@ -213,7 +213,7 @@ export class BlockProcessor {
                     `Block { height: ${block.data.height.toLocaleString()}, id: ${block.data.id} } ` +
                         `not accepted: invalid nonce order for sender ${sender}: ` +
                         `preceding nonce: ${nonceBySender[sender].toFixed()}, ` +
-                        `transaction ${data.id} has nonce ${nonce.toFixed()}.`,
+                        `transaction ${data.id} has nonce ${nonce.toFixed()} :bangbang:`,
                 );
                 return true;
             }
@@ -258,7 +258,7 @@ export class BlockProcessor {
             this.logger.debug(
                 `Could not decide if delegate ${generatorUsername} (${
                     block.data.generatorPublicKey
-                }) is allowed to forge block ${block.data.height.toLocaleString()}`,
+                }) is allowed to forge block ${block.data.height.toLocaleString()} :grey_question:`,
             );
         } /* istanbul ignore next */ else if (forgingDelegate.getPublicKey() !== block.data.generatorPublicKey) {
             AppUtils.assert.defined<string>(forgingDelegate.getPublicKey());
@@ -271,7 +271,7 @@ export class BlockProcessor {
             this.logger.warning(
                 `Delegate ${generatorUsername} (${
                     block.data.generatorPublicKey
-                }) not allowed to forge, should be ${forgingUsername} (${forgingDelegate.getPublicKey()})`,
+                }) not allowed to forge, should be ${forgingUsername} (${forgingDelegate.getPublicKey()}) :-1:`,
             );
 
             return false;
@@ -280,7 +280,7 @@ export class BlockProcessor {
         this.logger.debug(
             `Delegate ${generatorUsername} (${
                 block.data.generatorPublicKey
-            }) allowed to forge block ${block.data.height.toLocaleString()}`,
+            }) allowed to forge block ${block.data.height.toLocaleString()} :+1:`,
         );
 
         return true;
@@ -298,7 +298,7 @@ export class BlockProcessor {
         const expectedReward = Utils.calculateReward(block.data.height, generatorWallet.getAttribute("delegate.rank"));
 
         if (!block.data.reward.isEqualTo(expectedReward)) {
-            this.logger.warning(["Invalid block reward:", block.data.reward, "Expected:", expectedReward].join(" "));
+            this.logger.warning(["Invalid block reward:", block.data.reward, "Expected:", expectedReward].join(" ") + " :bangbang:");
             return false;
         }
 

--- a/packages/core-blockchain/src/processor/handlers/accept-block-handler.ts
+++ b/packages/core-blockchain/src/processor/handlers/accept-block-handler.ts
@@ -57,7 +57,9 @@ export class AcceptBlockHandler implements BlockHandler {
 
             return BlockProcessorResult.Accepted;
         } catch (error) {
-            this.logger.warning(`Refused new block ${JSON.stringify(block.data)}`);
+            this.logger.warning("Refused new block :warning: :warning: :warning:");
+            this.logger.warning(JSON.stringify(block.data));
+
             this.logger.debug(error.stack);
 
             this.blockchain.resetLastDownloadedBlock();

--- a/packages/core-blockchain/src/processor/handlers/accept-block-handler.ts
+++ b/packages/core-blockchain/src/processor/handlers/accept-block-handler.ts
@@ -33,7 +33,7 @@ export class AcceptBlockHandler implements BlockHandler {
             // Check if we recovered from a fork
             const forkedBlock = this.state.getForkedBlock();
             if (forkedBlock && forkedBlock.data.height === block.data.height) {
-                this.logger.info("Successfully recovered from fork");
+                this.logger.info("Successfully recovered from fork :star2:");
                 this.state.clearForkedBlock();
             }
 

--- a/packages/core-blockchain/src/processor/handlers/exception-handler.ts
+++ b/packages/core-blockchain/src/processor/handlers/exception-handler.ts
@@ -34,7 +34,7 @@ export class ExceptionHandler implements BlockHandler {
             return BlockProcessorResult.Rejected;
         }
 
-        this.logger.warning(`Block ${block.data.height.toLocaleString()} (${id}) forcibly accepted.`);
+        this.logger.warning(`Block ${block.data.height.toLocaleString()} (${id}) forcibly accepted :exclamation:`);
 
         return this.app.resolve<AcceptBlockHandler>(AcceptBlockHandler).execute(block);
     }

--- a/packages/core-blockchain/src/processor/handlers/unchained-handler.ts
+++ b/packages/core-blockchain/src/processor/handlers/unchained-handler.ts
@@ -73,31 +73,31 @@ export class UnchainedHandler implements BlockHandler {
         // todo: clean up this if-else-if-else-if-else mess
         if (block.data.height > lastBlock.data.height + 1) {
             this.logger.debug(
-                `Blockchain not ready to accept new block at height ${block.data.height.toLocaleString()}. Last block: ${lastBlock.data.height.toLocaleString()}`,
+                `Blockchain not ready to accept new block at height ${block.data.height.toLocaleString()}. Last block: ${lastBlock.data.height.toLocaleString()} :warning:`,
             );
 
             return UnchainedBlockStatus.NotReadyToAcceptNewHeight;
         } else if (block.data.height < lastBlock.data.height) {
-            this.logger.debug(`Block ${block.data.height.toLocaleString()} disregarded because already in blockchain`);
+            this.logger.debug(`Block ${block.data.height.toLocaleString()} disregarded because already in blockchain :warning:`);
 
             return UnchainedBlockStatus.AlreadyInBlockchain;
         } else if (block.data.height === lastBlock.data.height && block.data.id === lastBlock.data.id) {
-            this.logger.debug(`Block ${block.data.height.toLocaleString()} just received`);
+            this.logger.debug(`Block ${block.data.height.toLocaleString()} just received :chains:`);
 
             return UnchainedBlockStatus.EqualToLastBlock;
         } else if (block.data.timestamp < lastBlock.data.timestamp) {
             this.logger.debug(
-                `Block ${block.data.height.toLocaleString()} disregarded, because the timestamp is lower than the previous timestamp.`,
+                `Block ${block.data.height.toLocaleString()} disregarded, because the timestamp is lower than the previous timestamp :stopwatch:`,
             );
             return UnchainedBlockStatus.InvalidTimestamp;
         } else {
             if (this.isValidGenerator) {
-                this.logger.warning(`Detect double forging by ${block.data.generatorPublicKey}`);
+                this.logger.warning(`Detect double forging by ${block.data.generatorPublicKey} :chains:`);
                 return UnchainedBlockStatus.DoubleForging;
             }
 
             this.logger.info(
-                `Forked block disregarded because it is not allowed to be forged. Caused by delegate: ${block.data.generatorPublicKey}`,
+                `Forked block disregarded because it is not allowed to be forged. Caused by delegate: ${block.data.generatorPublicKey} :bangbang:`,
             );
 
             return UnchainedBlockStatus.GeneratorMismatch;

--- a/packages/core-blockchain/src/state-machine/actions/check-last-downloaded-block-synced.ts
+++ b/packages/core-blockchain/src/state-machine/actions/check-last-downloaded-block-synced.ts
@@ -26,13 +26,13 @@ export class CheckLastDownloadedBlockSynced implements Action {
 
         // tried to download but no luck after 5 tries (looks like network missing blocks)
         if (this.stateStore.getNoBlockCounter() > 5 && !this.blockchain.getQueue().isRunning()) {
-            this.logger.info("Tried to sync 5 times to different nodes, looks like the network is missing blocks");
+            this.logger.info("Tried to sync 5 times to different nodes, looks like the network is missing blocks :umbrella:");
 
             this.stateStore.setNoBlockCounter(0);
             event = "NETWORKHALTED";
 
             if (this.stateStore.getP2pUpdateCounter() + 1 > 3) {
-                this.logger.info("Network keeps missing blocks.");
+                this.logger.info("Network keeps missing blocks :umbrella:");
 
                 const networkStatus = await this.networkMonitor.checkNetworkHealth();
 

--- a/packages/core-blockchain/src/state-machine/actions/download-blocks.ts
+++ b/packages/core-blockchain/src/state-machine/actions/download-blocks.ts
@@ -64,7 +64,7 @@ export class DownloadBlocks implements Action {
                 this.stateStore.setLastDownloadedBlock(blocks[blocks.length - 1]);
                 this.blockchain.dispatch("DOWNLOADED");
             } catch (error) {
-                this.logger.warning(`Failed to enqueue downloaded block.`);
+                this.logger.warning("Failed to enqueue downloaded block :warning:");
 
                 this.blockchain.dispatch("NOBLOCK");
 
@@ -75,10 +75,12 @@ export class DownloadBlocks implements Action {
                 this.logger.info(
                     `Could not download any blocks from any peer from height ${(
                         lastDownloadedBlock.height + 1
-                    ).toLocaleString()}`,
+                    ).toLocaleString()} :warning:`,
                 );
             } else {
-                this.logger.warning(`Downloaded block not accepted: ${JSON.stringify(blocks[0])}`);
+                this.logger.warning("Downloaded block not accepted :warning: :warning: :warning:");
+                this.logger.warning(JSON.stringify(blocks[0]));
+
                 this.logger.warning(`Last downloaded block: ${JSON.stringify(lastDownloadedBlock)}`);
 
                 this.blockchain.clearQueue();

--- a/packages/core-blockchain/src/state-machine/actions/download-finished.ts
+++ b/packages/core-blockchain/src/state-machine/actions/download-finished.ts
@@ -17,7 +17,7 @@ export class DownloadFinished implements Action {
     private readonly stateStore!: Contracts.State.StateStore;
 
     public async handle(): Promise<void> {
-        this.logger.info("Block download finished");
+        this.logger.info("Block download finished :rocket:");
 
         if (this.stateStore.getNetworkStart()) {
             // next time we will use normal behaviour

--- a/packages/core-blockchain/src/state-machine/actions/download-paused.ts
+++ b/packages/core-blockchain/src/state-machine/actions/download-paused.ts
@@ -8,6 +8,6 @@ export class DownloadPaused implements Action {
     private readonly logger!: Contracts.Kernel.Logger;
 
     public async handle(): Promise<void> {
-        this.logger.info("Blockchain download paused");
+        this.logger.info("Blockchain download paused :clock1030:");
     }
 }

--- a/packages/core-blockchain/src/state-machine/actions/exit-app.ts
+++ b/packages/core-blockchain/src/state-machine/actions/exit-app.ts
@@ -8,6 +8,6 @@ export class ExitApp implements Action {
     public readonly app!: Contracts.Kernel.Application;
 
     public async handle(): Promise<void> {
-        this.app.terminate("Failed to startup blockchain. Exiting ARK Core!");
+        this.app.terminate("Failed to startup blockchain. Exiting ARK Core! :rotating_light:");
     }
 }

--- a/packages/core-blockchain/src/state-machine/actions/initialize.ts
+++ b/packages/core-blockchain/src/state-machine/actions/initialize.ts
@@ -36,21 +36,21 @@ export class Initialize implements Action {
             const block: Interfaces.IBlock = this.stateStore.getLastBlock();
 
             if (!this.stateStore.getRestoredDatabaseIntegrity()) {
-                this.logger.info("Verifying database integrity");
+                this.logger.info("Verifying database integrity :hourglass_flowing_sand:");
 
                 if (!(await this.databaseService.verifyBlockchain())) {
                     return this.blockchain.dispatch("ROLLBACK");
                 }
 
-                this.logger.info("Verified database integrity");
+                this.logger.info("Verified database integrity :smile_cat:");
             } else {
-                this.logger.info("Skipping database integrity check after successful database recovery");
+                this.logger.info("Skipping database integrity check after successful database recovery :smile_cat:");
             }
 
             // only genesis block? special case of first round needs to be dealt with
             if (block.data.height === 1) {
                 if (block.data.payloadHash !== Managers.configManager.get("network.nethash")) {
-                    this.logger.error("FATAL: The genesis block payload hash is different from configured the nethash");
+                    this.logger.error("FATAL: The genesis block payload hash is different from the configured nethash :rotating_light:");
 
                     return this.blockchain.dispatch("FAILURE");
                 }
@@ -75,7 +75,7 @@ export class Initialize implements Action {
             }
 
             if (process.env.NODE_ENV === "test") {
-                this.logger.notice("TEST SUITE DETECTED! SYNCING WALLETS AND STARTING IMMEDIATELY.");
+                this.logger.notice("TEST SUITE DETECTED! SYNCING WALLETS AND STARTING IMMEDIATELY :bangbang:");
 
                 await this.app.get<Contracts.State.StateBuilder>(Container.Identifiers.StateBuilder).run();
                 await this.databaseInteraction.restoreCurrentRound();

--- a/packages/core-blockchain/src/state-machine/actions/rollback-database.ts
+++ b/packages/core-blockchain/src/state-machine/actions/rollback-database.ts
@@ -26,7 +26,7 @@ export class RollbackDatabase implements Action {
     private readonly stateStore!: Contracts.State.StateStore;
 
     public async handle(): Promise<void> {
-        this.logger.info("Trying to restore database integrity");
+        this.logger.info("Trying to restore database integrity :fire_engine:");
 
         let maxBlockRewind = this.configuration.getRequired<number>("databaseRollback.maxBlockRewind");
         let steps = this.configuration.getRequired<number>("databaseRollback.steps");
@@ -60,7 +60,7 @@ export class RollbackDatabase implements Action {
         this.stateStore.setLastStoredBlockHeight(lastBlock.data.height);
 
         this.logger.info(
-            `Database integrity verified again after rollback to height ${lastBlock.data.height.toLocaleString()}`,
+            `Database integrity verified again after rollback to height ${lastBlock.data.height.toLocaleString()} :green_heart:`,
         );
 
         this.blockchain.dispatch("SUCCESS");

--- a/packages/core-blockchain/src/state-machine/actions/start-fork-recovery.ts
+++ b/packages/core-blockchain/src/state-machine/actions/start-fork-recovery.ts
@@ -17,7 +17,7 @@ export class StartForkRecovery implements Action {
     private readonly networkMonitor!: Contracts.P2P.NetworkMonitor;
 
     public async handle(): Promise<void> {
-        this.logger.info("Starting fork recovery");
+        this.logger.info("Starting fork recovery :fork_and_knife:");
 
         this.blockchain.clearAndStopQueue();
 
@@ -28,7 +28,7 @@ export class StartForkRecovery implements Action {
 
         this.stateStore.setNumberOfBlocksToRollback(0);
 
-        this.logger.info(`Removed ${AppUtils.pluralize("block", blocksToRemove, true)}`);
+        this.logger.info(`Removed ${AppUtils.pluralize("block", blocksToRemove, true)} :wastebasket:`);
 
         await this.networkMonitor.refreshPeersAfterFork();
 

--- a/packages/core-blockchain/src/state-machine/actions/stopped.ts
+++ b/packages/core-blockchain/src/state-machine/actions/stopped.ts
@@ -11,6 +11,6 @@ export class Stopped implements Action {
     private readonly logger!: Contracts.Kernel.Logger;
 
     public async handle(): Promise<void> {
-        this.logger.info("The blockchain has been stopped");
+        this.logger.info("The blockchain has been stopped :guitar:");
     }
 }

--- a/packages/core-blockchain/src/state-machine/actions/syncing-complete.ts
+++ b/packages/core-blockchain/src/state-machine/actions/syncing-complete.ts
@@ -14,7 +14,7 @@ export class SyncingComplete implements Action {
     private readonly blockchain!: Contracts.Blockchain.Blockchain;
 
     public async handle(): Promise<void> {
-        this.logger.info("Blockchain 100% in sync");
+        this.logger.info("Blockchain 100% in sync :100:");
 
         this.blockchain.dispatch("SYNCFINISHED");
     }

--- a/packages/core-blockchain/src/state-machine/state-machine.ts
+++ b/packages/core-blockchain/src/state-machine/state-machine.ts
@@ -50,7 +50,7 @@ export class StateMachine {
             if (action) {
                 setImmediate(() => action.handle());
             } else {
-                this.logger.error(`No action '${actionKey}' found`);
+                this.logger.error(`No action '${actionKey}' found :interrobang:`);
             }
         }
 

--- a/packages/core-database/src/database-service.ts
+++ b/packages/core-database/src/database-service.ts
@@ -39,7 +39,7 @@ export class DatabaseService {
             }
         } catch (error) {
             this.logger.error(error.stack);
-            this.app.terminate("Failed to initialize database service.", error);
+            this.app.terminate("Failed to initialize database service :boom:", error);
         }
     }
 
@@ -252,7 +252,7 @@ export class DatabaseService {
         const hasErrors: boolean = errors.length > 0;
 
         if (hasErrors) {
-            this.logger.error("FATAL: The database is corrupted");
+            this.logger.error("FATAL: The database is corrupted :fire:");
             this.logger.error(JSON.stringify(errors, undefined, 4));
         }
 

--- a/packages/core-forger/src/client.ts
+++ b/packages/core-forger/src/client.ts
@@ -47,7 +47,7 @@ export class Client {
             connection.connect().catch((e) => {}); // connect promise can fail when p2p is not ready, it's fine it will retry
 
             connection.onError = (e) => {
-                this.logger.error(e.message);
+                this.logger.error(`${e.message} :bangbang:`);
             };
 
             host.socket = connection;
@@ -78,9 +78,7 @@ export class Client {
      */
     public async broadcastBlock(block: Interfaces.IBlock): Promise<void> {
         this.logger.debug(
-            `Broadcasting block ${block.data.height.toLocaleString()} (${block.data.id}) with ${
-                block.data.numberOfTransactions
-            } transactions to ${this.host.hostname}`,
+            `Broadcasting block with ${Utils.pluralize("transaction", block.data.numberOfTransactions, true)} to ${this.host.hostname} :truck:`,
         );
 
         try {
@@ -91,7 +89,7 @@ export class Client {
                 }),
             });
         } catch (error) {
-            this.logger.error(`Broadcast block failed: ${error.message}`);
+            this.logger.error(`Broadcast block failed: ${error.message} :bangbang:`);
         }
     }
 
@@ -107,7 +105,7 @@ export class Client {
         try {
             await this.emit("p2p.internal.syncBlockchain");
         } catch (error) {
-            this.logger.error(`Could not sync check: ${error.message}`);
+            this.logger.error(`Could not sync check: ${error.message} :bangbang:`);
         }
     }
 
@@ -160,14 +158,14 @@ export class Client {
         );
 
         if (!host) {
-            this.logger.error("emitEvent: unable to find any local hosts.");
+            this.logger.error("emitEvent: unable to find any local hosts :bangbang:");
             return;
         }
 
         try {
             await this.emit("p2p.internal.emitEvent", { event, body });
         } catch (error) {
-            this.logger.error(`Failed to emit "${event}" to "${host.hostname}:${host.port}"`);
+            this.logger.error(`Failed to emit "${event}" to "${host.hostname}:${host.port}" :bangbang:`);
         }
     }
 
@@ -190,7 +188,7 @@ export class Client {
         this.logger.debug(
             `No open socket connection to any host: ${JSON.stringify(
                 this.hosts.map((host) => `${host.hostname}:${host.port}`),
-            )}.`,
+            )} :bangbang:`,
         );
 
         throw new HostNoResponseError(this.hosts.map((host) => host.hostname).join());

--- a/packages/core-forger/src/client.ts
+++ b/packages/core-forger/src/client.ts
@@ -77,10 +77,6 @@ export class Client {
      * @memberof Client
      */
     public async broadcastBlock(block: Interfaces.IBlock): Promise<void> {
-        this.logger.debug(
-            `Broadcasting block with ${Utils.pluralize("transaction", block.data.numberOfTransactions, true)} to ${this.host.hostname} :truck:`,
-        );
-
         try {
             await this.emit("p2p.blocks.postBlock", {
                 block: Blocks.Serializer.serializeWithTransactions({

--- a/packages/core-forger/src/errors.ts
+++ b/packages/core-forger/src/errors.ts
@@ -28,7 +28,7 @@ export class ForgerError extends Error {
  */
 export class RelayCommunicationError extends ForgerError {
     public constructor(endpoint: string, message: string) {
-        super(`Request to ${endpoint} failed, because of '${message}'.`);
+        super(`Request to ${endpoint} failed, because of '${message}' :bangbang:`);
     }
 }
 
@@ -39,6 +39,6 @@ export class RelayCommunicationError extends ForgerError {
  */
 export class HostNoResponseError extends ForgerError {
     public constructor(host: string) {
-        super(`${host} didn't respond. Trying again later.`);
+        super(`${host} didn't respond. Trying again later :sparkler:`);
     }
 }

--- a/packages/core-forger/src/forger-service.ts
+++ b/packages/core-forger/src/forger-service.ts
@@ -192,7 +192,7 @@ export class ForgerService {
                 this.logger.warning(
                     `The NetworkState height (${networkState
                         .getNodeHeight()
-                        ?.toLocaleString()}) and round height (${this.round.lastBlock.height.toLocaleString()}) are out of sync. This indicates delayed blocks on the network.`,
+                        ?.toLocaleString()}) and round height (${this.round.lastBlock.height.toLocaleString()}) are out of sync. This indicates delayed blocks on the network :zzz:`,
                 );
             }
 
@@ -271,10 +271,10 @@ export class ForgerService {
 
         const minimumMs = 2000;
         const timeLeftInMs: number = this.getRoundRemainingSlotTime(round);
-        const prettyName = `${this.usernames[delegate.publicKey]} (${delegate.publicKey})`;
+        const prettyName = this.usernames[delegate.publicKey];
 
         if (timeLeftInMs >= minimumMs) {
-            this.logger.info(`Forged new block ${block.data.id} by delegate ${prettyName}`);
+            this.logger.info(`Forged new block ${block.data.id} by delegate ${prettyName} :trident:`);
 
             await this.client.broadcastBlock(block);
 
@@ -286,10 +286,10 @@ export class ForgerService {
             }
         } else if (timeLeftInMs > 0) {
             this.logger.warning(
-                `Failed to forge new block by delegate ${prettyName}, because there were ${timeLeftInMs}ms left in the current slot (less than ${minimumMs}ms).`,
+                `Failed to forge new block by delegate ${prettyName}, because there were ${timeLeftInMs}ms left in the current slot (less than ${minimumMs}ms) :bangbang:`,
             );
         } else {
-            this.logger.warning(`Failed to forge new block by delegate ${prettyName}, because already in next slot.`);
+            this.logger.warning(`Failed to forge new block by delegate ${prettyName}, because already in next slot :bangbang:`);
         }
     }
 
@@ -308,7 +308,7 @@ export class ForgerService {
         );
         this.logger.debug(
             `Received ${AppUtils.pluralize("transaction", transactions.length, true)} ` +
-                `from the pool containing ${AppUtils.pluralize("transaction", response.poolSize, true)} total`,
+                `from the pool containing ${AppUtils.pluralize("transaction", response.poolSize, true)} total :money_with_wings:`,
         );
         return transactions;
     }
@@ -321,13 +321,13 @@ export class ForgerService {
      */
     public isForgingAllowed(networkState: Contracts.P2P.NetworkState, delegate: Delegate): boolean {
         if (networkState.status === NetworkStateStatus.Unknown) {
-            this.logger.info("Failed to get network state from client. Will not forge.");
+            this.logger.info("Failed to get network state from client. Will not forge :bomb:");
             return false;
         } else if (networkState.status === NetworkStateStatus.ColdStart) {
-            this.logger.info("Skipping slot because of cold start. Will not forge.");
+            this.logger.info("Skipping slot because of cold start. Will not forge :bomb:");
             return false;
         } else if (networkState.status === NetworkStateStatus.BelowMinimumPeers) {
-            this.logger.info("Network reach is not sufficient to get quorum. Will not forge.");
+            this.logger.info("Network reach is not sufficient to get quorum. Will not forge :bomb:");
             return false;
         }
 
@@ -340,7 +340,7 @@ export class ForgerService {
                     "distinct overheight block header",
                     overHeightBlockHeaders.length,
                     true,
-                )}.`,
+                )} :zzz:`,
             );
 
             for (const overHeightBlockHeader of overHeightBlockHeaders) {
@@ -350,14 +350,14 @@ export class ForgerService {
                     const username: string = this.usernames[delegate.publicKey];
 
                     this.logger.warning(
-                        `Possible double forging delegate: ${username} (${delegate.publicKey}) - Block: ${overHeightBlockHeader.id}.`,
+                        `Possible double forging delegate: ${username} (${delegate.publicKey}) - Block: ${overHeightBlockHeader.id} :interrobang:`,
                     );
                 }
             }
         }
 
         if (networkState.getQuorum() < 0.66) {
-            this.logger.info("Not enough quorum to forge next block. Will not forge.");
+            this.logger.info("Not enough quorum to forge next block. Will not forge :bomb:");
             this.logger.debug(`Network State: ${networkState.toJson()}`);
 
             return false;
@@ -400,7 +400,7 @@ export class ForgerService {
                 activeDelegates: this.delegates.map((delegate) => delegate.publicKey),
             });
 
-            this.logger.info(`Forger Manager started.`);
+            this.logger.info(`Forger Manager started`);
         }
 
         this.initialized = true;

--- a/packages/core-forger/src/forger-service.ts
+++ b/packages/core-forger/src/forger-service.ts
@@ -174,10 +174,11 @@ export class ForgerService {
                 AppUtils.assert.defined<string>(this.round.nextForger.publicKey);
 
                 if (this.isActiveDelegate(this.round.nextForger.publicKey)) {
+                    const blocktime = Managers.configManager.getMilestone(this.round.lastBlock.height).blocktime
                     const username = this.usernames[this.round.nextForger.publicKey];
 
                     this.logger.info(
-                        `Next forging delegate ${username} is active on this node :sparkles:`,
+                        `Delegate ${username} is due to forge in ${AppUtils.pluralize("second", blocktime, true)} from now :sparkles:`,
                     );
 
                     await this.client.syncWithNetwork();

--- a/packages/core-forger/src/forger-service.ts
+++ b/packages/core-forger/src/forger-service.ts
@@ -177,7 +177,7 @@ export class ForgerService {
                     const username = this.usernames[this.round.nextForger.publicKey];
 
                     this.logger.info(
-                        `Next forging delegate ${username} (${this.round.nextForger.publicKey}) is active on this node.`,
+                        `Next forging delegate ${username} is active on this node :sparkles:`,
                     );
 
                     await this.client.syncWithNetwork();
@@ -274,7 +274,8 @@ export class ForgerService {
         const prettyName = this.usernames[delegate.publicKey];
 
         if (timeLeftInMs >= minimumMs) {
-            this.logger.info(`Forged new block ${block.data.id} by delegate ${prettyName} :trident:`);
+            this.logger.info(`Delegate ${prettyName} forged a new block at height ${block.data.height.toLocaleString()} with ${AppUtils.pluralize("transaction", block.data.numberOfTransactions, true)} :trident:`);
+            this.logger.debug(`Block has id ${block.data.id}`);
 
             await this.client.broadcastBlock(block);
 

--- a/packages/core-forger/src/forger-service.ts
+++ b/packages/core-forger/src/forger-service.ts
@@ -129,7 +129,7 @@ export class ForgerService {
             AppUtils.assert.defined<Contracts.P2P.CurrentRound>(this.round);
             timeout = Math.max(0, this.getRoundRemainingSlotTime(this.round));
         } catch (error) {
-            this.logger.warning("Waiting for a responsive host");
+            this.logger.warning("Waiting for a responsive host :hourglass_flowing_sand:");
         } finally {
             this.checkLater(timeout);
         }
@@ -214,7 +214,7 @@ export class ForgerService {
                 if (error.message.includes("blockchain isn't ready") || error.message.includes("App is not ready")) {
                     /* istanbul ignore else */
                     if (this.logAppReady) {
-                        this.logger.info("Waiting for relay to become ready.");
+                        this.logger.info("Waiting for relay to become ready :hourglass_flowing_sand:");
                         this.logAppReady = false;
                     }
                 } else {
@@ -301,7 +301,7 @@ export class ForgerService {
     public async getTransactionsForForging(): Promise<Interfaces.ITransactionData[]> {
         const response = await this.client.getTransactions();
         if (AppUtils.isEmpty(response)) {
-            this.logger.error("Could not get unconfirmed transactions from transaction pool.");
+            this.logger.error("Could not get unconfirmed transactions from transaction pool :warning:");
             return [];
         }
         const transactions = response.transactions.map(

--- a/packages/core-forger/src/forger-service.ts
+++ b/packages/core-forger/src/forger-service.ts
@@ -275,7 +275,7 @@ export class ForgerService {
 
         if (timeLeftInMs >= minimumMs) {
             this.logger.info(`Delegate ${prettyName} forged a new block at height ${block.data.height.toLocaleString()} with ${AppUtils.pluralize("transaction", block.data.numberOfTransactions, true)} :trident:`);
-            this.logger.debug(`Block has id ${block.data.id}`);
+            this.logger.debug(`The id of the new block is ${block.data.id}`);
 
             await this.client.broadcastBlock(block);
 

--- a/packages/core-logger-pino/package.json
+++ b/packages/core-logger-pino/package.json
@@ -23,6 +23,7 @@
         "@arkecosystem/core-kernel": "3.1.1",
         "chalk": "4.1.2",
         "joi": "17.4.2",
+        "node-emoji": "1.11.0",
         "pino": "6.13.2",
         "pino-pretty": "4.8.0",
         "pump": "3.0.0",

--- a/packages/core-logger-pino/src/defaults.ts
+++ b/packages/core-logger-pino/src/defaults.ts
@@ -1,4 +1,5 @@
 export const defaults = {
+    emojify: true,
     levels: {
         console: process.env.CORE_LOG_LEVEL || "info",
         file: process.env.CORE_LOG_LEVEL_FILE || "debug",

--- a/packages/core-logger-pino/src/driver.ts
+++ b/packages/core-logger-pino/src/driver.ts
@@ -1,6 +1,7 @@
 import { Container, Contracts, Utils } from "@arkecosystem/core-kernel";
 import chalk, { Chalk } from "chalk";
 import * as console from "console";
+import { emojify } from "node-emoji";
 import pino, { PrettyOptions } from "pino";
 import PinoPretty from "pino-pretty";
 import pump from "pump";
@@ -245,7 +246,7 @@ export class PinoLogger implements Contracts.Kernel.Logger {
             message = inspect(message, { depth: 1 });
         }
 
-        this.logger[level](message);
+        this.logger[level](emojify(message));
     }
 
     /**

--- a/packages/core-logger-pino/src/driver.ts
+++ b/packages/core-logger-pino/src/driver.ts
@@ -1,4 +1,4 @@
-import { Container, Contracts, Utils } from "@arkecosystem/core-kernel";
+import { Container, Contracts, Providers, Utils } from "@arkecosystem/core-kernel";
 import chalk, { Chalk } from "chalk";
 import * as console from "console";
 import { emojify } from "node-emoji";
@@ -29,6 +29,10 @@ export class PinoLogger implements Contracts.Kernel.Logger {
 
     @Container.inject(Container.Identifiers.ConfigFlags)
     private readonly configFlags!: { processType: string };
+
+    @Container.inject(Container.Identifiers.PluginConfiguration)
+    @Container.tagged("plugin", "@arkecosystem/core-logger-pino")
+    private readonly configuration!: Providers.PluginConfiguration;
 
     /**
      * @private
@@ -246,7 +250,11 @@ export class PinoLogger implements Contracts.Kernel.Logger {
             message = inspect(message, { depth: 1 });
         }
 
-        this.logger[level](emojify(message));
+        if (this.configuration.get("emojify")) {
+            this.logger[level](emojify(message));
+        } else {
+            this.logger[level](emojify(message, undefined, () => ""));
+        }
     }
 
     /**

--- a/packages/core-p2p/src/network-monitor.ts
+++ b/packages/core-p2p/src/network-monitor.ts
@@ -125,7 +125,7 @@ export class NetworkMonitor implements Contracts.P2P.NetworkMonitor {
             max = Math.min(peers.length, peerCount);
         }
 
-        this.logger.info(`Checking ${Utils.pluralize("peer", max, true)}`);
+        this.logger.info(`Checking ${Utils.pluralize("peer", max, true)} :telescope:`);
         const peerErrors = {};
 
         // we use Promise.race to cut loose in case some communicator.ping() does not resolve within the delay
@@ -542,7 +542,7 @@ export class NetworkMonitor implements Contracts.P2P.NetworkMonitor {
 
             this.logger.info(`Your NTP connectivity has been verified by ${host}`);
 
-            this.logger.info(`Local clock is off by ${time.t < 0 ? "-" : ""}${prettyMs(Math.abs(time.t))} from NTP`);
+            this.logger.info(`Local clock is off by ${time.t < 0 ? "-" : ""}${prettyMs(Math.abs(time.t))} from NTP :alarm_clock:`);
         } catch (error) {
             this.logger.error(error.message);
         }
@@ -588,7 +588,7 @@ export class NetworkMonitor implements Contracts.P2P.NetworkMonitor {
         } catch {}
 
         if (!peerList || !peerList.length) {
-            this.app.terminate("No seed peers defined in peers.json");
+            this.app.terminate("No seed peers defined in peers.json :interrobang:");
         }
 
         const peers: Contracts.P2P.Peer[] = peerList.map((peer) => {

--- a/packages/core-p2p/src/network-monitor.ts
+++ b/packages/core-p2p/src/network-monitor.ts
@@ -55,7 +55,7 @@ export class NetworkMonitor implements Contracts.P2P.NetworkMonitor {
         await this.populateSeedPeers();
 
         if (this.config.skipDiscovery) {
-            this.logger.warning("Skipped peer discovery because the relay is in skip-discovery mode.");
+            this.logger.warning("Skipped peer discovery because the relay is in skip-discovery mode :mag:");
         } else {
             await this.updateNetworkStatus(true);
 
@@ -63,7 +63,7 @@ export class NetworkMonitor implements Contracts.P2P.NetworkMonitor {
                 // @ts-ignore
                 Utils.groupBy(this.repository.getPeers(), (peer) => peer.version),
             )) {
-                this.logger.info(`Discovered ${Utils.pluralize("peer", peers.length, true)} with v${version}.`);
+                this.logger.info(`Discovered ${Utils.pluralize("peer", peers.length, true)} with v${version}`);
             }
         }
 
@@ -80,11 +80,11 @@ export class NetworkMonitor implements Contracts.P2P.NetworkMonitor {
 
         if (this.config.networkStart) {
             this.coldStart = true;
-            this.logger.warning("Entering cold start because the relay is in genesis-start mode.");
+            this.logger.warning("Entering cold start because the relay is in genesis-start mode :snowflake:");
         }
 
         if (this.config.disableDiscovery) {
-            this.logger.warning("Skipped peer discovery because the relay is in non-discovery mode.");
+            this.logger.warning("Skipped peer discovery because the relay is in non-discovery mode :mag:");
             return;
         }
 
@@ -93,7 +93,7 @@ export class NetworkMonitor implements Contracts.P2P.NetworkMonitor {
                 await this.cleansePeers();
             }
         } catch (error) {
-            this.logger.error(`Network Status: ${error.message}`);
+            this.logger.error(`Network Status: ${error.message} :warning:`);
         }
 
         let nextRunDelaySeconds = 600;
@@ -103,7 +103,7 @@ export class NetworkMonitor implements Contracts.P2P.NetworkMonitor {
 
             nextRunDelaySeconds = 60;
 
-            this.logger.info(`Couldn't find enough peers. Falling back to seed peers.`);
+            this.logger.info(`Couldn't find enough peers. Falling back to seed peers :fire:`);
         }
 
         this.scheduleUpdateNetworkStatus(nextRunDelaySeconds);
@@ -163,7 +163,7 @@ export class NetworkMonitor implements Contracts.P2P.NetworkMonitor {
 
         for (const key of Object.keys(peerErrors)) {
             const peerCount = peerErrors[key].length;
-            this.logger.debug(`Removed ${Utils.pluralize("peer", peerCount, true)} because of "${key}"`);
+            this.logger.debug(`Removed ${Utils.pluralize("peer", peerCount, true)} because of "${key}" :wastebasket:`);
         }
 
         if (this.initializing) {
@@ -187,7 +187,7 @@ export class NetworkMonitor implements Contracts.P2P.NetworkMonitor {
                                 const hisPeers = await this.communicator.getPeers(peer);
                                 return hisPeers || [];
                             } catch (error) {
-                                this.logger.debug(`Failed to get peers from ${peer.ip}: ${error.message}`);
+                                this.logger.debug(`Failed to get peers from ${peer.ip}: ${error.message} :exclamation:`);
                                 return [];
                             }
                         }),
@@ -256,7 +256,7 @@ export class NetworkMonitor implements Contracts.P2P.NetworkMonitor {
     }
 
     public async refreshPeersAfterFork(): Promise<void> {
-        this.logger.info(`Refreshing ${Utils.pluralize("peer", this.repository.getPeers().length, true)} after fork.`);
+        this.logger.info(`Refreshing ${Utils.pluralize("peer", this.repository.getPeers().length, true)} after fork :fork_and_knife:`);
 
         await this.cleansePeers({ forcePing: true });
     }
@@ -275,7 +275,7 @@ export class NetworkMonitor implements Contracts.P2P.NetworkMonitor {
             .map((peer) => peer.verificationResult!);
 
         if (verificationResults.length === 0) {
-            this.logger.info("No verified peers available.");
+            this.logger.info("No verified peers available :no_entry_sign:");
 
             return { forked: false };
         }
@@ -299,19 +299,22 @@ export class NetworkMonitor implements Contracts.P2P.NetworkMonitor {
 
                 if (blocksToRollback > 5000) {
                     this.logger.info(
-                        `Rolling back 5000/${blocksToRollback} blocks to fork at height ${forkHeight} (${ourPeerCount} vs ${forkPeerCount}).`,
+                        `Rolling back 5000/${blocksToRollback} blocks to fork at height ${forkHeight} (${ourPeerCount} vs ${forkPeerCount}) :repeat:`,
                     );
 
                     return { forked: true, blocksToRollback: 5000 };
                 } else {
                     this.logger.info(
-                        `Rolling back ${blocksToRollback} blocks to fork at height ${forkHeight} (${ourPeerCount} vs ${forkPeerCount}).`,
+                        `Rolling back ${Utils.pluralize("block",
+                            blocksToRollback,
+                            true,
+                        )} to fork at height ${forkHeight} (${ourPeerCount} vs ${forkPeerCount}) :repeat:`,
                     );
 
                     return { forked: true, blocksToRollback };
                 }
             } else {
-                this.logger.debug(`Ignoring fork at height ${forkHeight} (${ourPeerCount} vs ${forkPeerCount}).`);
+                this.logger.debug(`Ignoring fork at height ${forkHeight} (${ourPeerCount} vs ${forkPeerCount}) :fork_and_knife:`);
             }
         }
 
@@ -325,7 +328,7 @@ export class NetworkMonitor implements Contracts.P2P.NetworkMonitor {
         const peersAll: Contracts.P2P.Peer[] = this.repository.getPeers();
 
         if (peersAll.length === 0) {
-            this.logger.error(`Could not download blocks: we have 0 peers`);
+            this.logger.error(`Could not download blocks: we have 0 peers :bangbang:`);
             return [];
         }
 
@@ -334,7 +337,7 @@ export class NetworkMonitor implements Contracts.P2P.NetworkMonitor {
         if (peersNotForked.length === 0) {
             this.logger.error(
                 `Could not download blocks: We have ${peersAll.length} peer(s) but all ` +
-                    `of them are on a different chain than us`,
+                    `of them are on a different chain than us :bangbang:`,
             );
             return [];
         }
@@ -410,13 +413,13 @@ export class NetworkMonitor implements Contracts.P2P.NetworkMonitor {
                         }
                     } catch (error) {
                         this.logger.info(
-                            `Failed to download blocks ${blocksRange} from ${peerPrint}: ${error.message}`,
+                            `Failed to download blocks ${blocksRange} from ${peerPrint}: ${error.message} :bangbang:`,
                         );
                     }
 
                     if (someJobFailed) {
                         this.logger.info(
-                            `Giving up on trying to download blocks ${blocksRange}: ` + `another download job failed`,
+                            `Giving up on trying to download blocks ${blocksRange}: ` + `another download job failed :bangbang:`,
                         );
                     }
                 }
@@ -424,7 +427,7 @@ export class NetworkMonitor implements Contracts.P2P.NetworkMonitor {
                 someJobFailed = true;
                 throw new Error(
                     `Could not download blocks ${blocksRange} from any of ${peersToTry.length} ` +
-                        `peer(s). Last attempt returned ${blocks.length} block(s) from peer ${peerPrint}.`,
+                        `peer(s). Last attempt returned ${blocks.length} block(s) from peer ${peerPrint}`,
                 );
             });
 
@@ -451,7 +454,7 @@ export class NetworkMonitor implements Contracts.P2P.NetworkMonitor {
 
         for (i = 0; i < chunksToDownload; i++) {
             if (downloadResults[i] === undefined) {
-                this.logger.error(firstFailureMessage);
+                this.logger.error(`${firstFailureMessage} :exclamation:`);
                 break;
             }
             downloadedBlocks = [...downloadedBlocks, ...downloadResults[i]];
@@ -521,7 +524,7 @@ export class NetworkMonitor implements Contracts.P2P.NetworkMonitor {
             peers = Utils.shuffle(peers).slice(0, Math.floor(peers.length / 2));
         }
 
-        this.logger.debug(`Checking ports of ${Utils.pluralize("peer", peers.length, true)}.`);
+        this.logger.debug(`Checking ports of ${Utils.pluralize("peer", peers.length, true)}`);
 
         Promise.all(peers.map((peer) => this.communicator.pingPorts(peer)));
     }
@@ -530,9 +533,9 @@ export class NetworkMonitor implements Contracts.P2P.NetworkMonitor {
         try {
             const host = await checkDNS(this.app, options);
 
-            this.logger.info(`Your network connectivity has been verified by ${host}`);
+            this.logger.info(`Your network connectivity has been verified by ${host} :white_check_mark:`);
         } catch (error) {
-            this.logger.error(error.message);
+            this.logger.error(`${error.message} :bangbang:`);
         }
     }
 
@@ -540,11 +543,11 @@ export class NetworkMonitor implements Contracts.P2P.NetworkMonitor {
         try {
             const { host, time } = await checkNTP(this.app, options);
 
-            this.logger.info(`Your NTP connectivity has been verified by ${host}`);
+            this.logger.info(`Your NTP connectivity has been verified by ${host} :white_check_mark:`);
 
             this.logger.info(`Local clock is off by ${time.t < 0 ? "-" : ""}${prettyMs(Math.abs(time.t))} from NTP :alarm_clock:`);
         } catch (error) {
-            this.logger.error(error.message);
+            this.logger.error(`${error.message} :bangbang:`);
         }
     }
 
@@ -564,7 +567,7 @@ export class NetworkMonitor implements Contracts.P2P.NetworkMonitor {
 
     private hasMinimumPeers(): boolean {
         if (this.config.ignoreMinimumNetworkReach) {
-            this.logger.warning("Ignored the minimum network reach because the relay is in seed mode.");
+            this.logger.warning("Ignored the minimum network reach because the relay is in seed mode :exclamation:");
 
             return true;
         }

--- a/packages/core-p2p/src/peer-communicator.ts
+++ b/packages/core-p2p/src/peer-communicator.ts
@@ -315,7 +315,7 @@ export class PeerCommunicator implements Contracts.P2P.PeerCommunicator {
         const msBeforeReCheck = 1000;
         while (await this.outgoingRateLimiter.hasExceededRateLimitNoConsume(peer.ip, event)) {
             this.logger.debug(
-                `Throttling outgoing requests to ${peer.ip}/${event} to avoid triggering their rate limit`,
+                `Throttling outgoing requests to ${peer.ip}/${event} to avoid triggering their rate limit :runner:`,
             );
             await delay(msBeforeReCheck);
         }
@@ -339,18 +339,18 @@ export class PeerCommunicator implements Contracts.P2P.PeerCommunicator {
 
         switch (error.name) {
             case SocketErrors.Validation:
-                this.logger.debug(`Socket data validation error (peer ${peer.ip}) : ${error.message}`);
+                this.logger.debug(`Socket data validation error (peer ${peer.ip}) : ${error.message} :warning:`);
                 break;
             case "Error":
                 /* istanbul ignore else */
                 if (process.env.CORE_P2P_PEER_VERIFIER_DEBUG_EXTRA) {
-                    this.logger.debug(`Response error (peer ${peer.ip}/${event}) : ${error.message}`);
+                    this.logger.debug(`Response error (peer ${peer.ip}/${event}) : ${error.message} :warning:`);
                 }
                 break;
             default:
                 /* istanbul ignore else */
                 if (process.env.CORE_P2P_PEER_VERIFIER_DEBUG_EXTRA) {
-                    this.logger.debug(`Socket error (peer ${peer.ip}) : ${error.message}`);
+                    this.logger.debug(`Socket error (peer ${peer.ip}) : ${error.message} :warning:`);
                 }
                 /* istanbul ignore else */
                 if (disconnect) {

--- a/packages/core-p2p/src/peer-connector.ts
+++ b/packages/core-p2p/src/peer-connector.ts
@@ -102,7 +102,7 @@ export class PeerConnector implements Contracts.P2P.PeerConnector {
         this.lastConnectionCreate.set(peer.ip, Date.now());
 
         connection.onError = (error) => {
-            this.logger.debug(`Socket error (peer ${Utils.IpAddress.normalizeAddress(peer.ip)}) : ${error.message}`);
+            this.logger.debug(`Socket error (peer ${Utils.IpAddress.normalizeAddress(peer.ip)}) : ${error.message} :warning:`);
             this.disconnect(peer);
         };
 

--- a/packages/core-p2p/src/peer-processor.ts
+++ b/packages/core-p2p/src/peer-processor.ts
@@ -106,7 +106,7 @@ export class PeerProcessor implements Contracts.P2P.PeerProcessor {
 
             /* istanbul ignore next */
             if (!options.lessVerbose || process.env.CORE_P2P_PEER_VERIFIER_DEBUG_EXTRA) {
-                this.logger.debug(`Accepted new peer ${newPeer.ip}:${newPeer.port} (v${newPeer.version})`);
+                this.logger.debug(`Accepted new peer ${newPeer.ip}:${newPeer.port} (v${newPeer.version}) :hugging_face:`);
             }
 
             this.events.dispatch(Enums.PeerEvent.Added, newPeer);

--- a/packages/core-p2p/src/peer-verifier.ts
+++ b/packages/core-p2p/src/peer-verifier.ts
@@ -117,7 +117,7 @@ export class PeerVerifier implements Contracts.P2P.PeerVerifier {
             return undefined;
         }
 
-        this.log(Severity.DEBUG_EXTRA, "success");
+        this.log(Severity.DEBUG_EXTRA, "success", true);
 
         return new PeerVerificationResult(ourHeight, claimedHeight, highestCommonBlockHeight);
     }
@@ -226,14 +226,14 @@ export class PeerVerifier implements Contracts.P2P.PeerVerifier {
                 this.log(
                     Severity.DEBUG_EXTRA,
                     `success: peer's latest block is the same as our latest ` +
-                        `block (height=${claimedHeight}, id=${claimedState.header.id}). Identical chains.`,
+                        `block (height=${claimedHeight}, id=${claimedState.header.id}). Identical chains.`, true,
                 );
             } else {
                 this.log(
                     Severity.DEBUG_EXTRA,
                     `success: peer's latest block ` +
                         `(height=${claimedHeight}, id=${claimedState.header.id}) is part of our chain. ` +
-                        `Peer is ${pluralize("block", ourHeight - claimedHeight, true)} behind us.`,
+                        `Peer is ${pluralize("block", ourHeight - claimedHeight, true)} behind us.`, true,
                 );
             }
             return true;
@@ -301,7 +301,7 @@ export class PeerVerifier implements Contracts.P2P.PeerVerifier {
 
             const msRemaining = this.throwIfPastDeadline(deadline);
 
-            this.log(Severity.DEBUG_EXTRA, `probe for common blocks in range ${rangePrint}`);
+            this.log(Severity.DEBUG_EXTRA, `probe for common blocks in range ${rangePrint}`, null);
 
             const highestCommon = await this.communicator.hasCommonBlocks(
                 this.peer,
@@ -343,7 +343,7 @@ export class PeerVerifier implements Contracts.P2P.PeerVerifier {
         if (highestCommonBlockHeight === undefined) {
             this.log(Severity.INFO, `failure: could not determine a common block`);
         } else {
-            this.log(Severity.DEBUG_EXTRA, `highest common block height: ${highestCommonBlockHeight}`);
+            this.log(Severity.DEBUG_EXTRA, `highest common block height: ${highestCommonBlockHeight}`, null);
         }
 
         return highestCommonBlockHeight;
@@ -518,7 +518,7 @@ export class PeerVerifier implements Contracts.P2P.PeerVerifier {
         if (delegatesByPublicKey[block.data.generatorPublicKey]) {
             this.log(
                 Severity.DEBUG_EXTRA,
-                `successfully verified block at height ${height}, signed by ` + block.data.generatorPublicKey,
+                `successfully verified block at height ${height}, signed by ` + block.data.generatorPublicKey, true, 
             );
 
             return true;
@@ -565,8 +565,13 @@ export class PeerVerifier implements Contracts.P2P.PeerVerifier {
      * @param {Severity} severity severity of the message, DEBUG_EXTRA messages are only
      * logged if enabled in the environment.
      */
-    private log(severity: Severity, msg: string): void {
-        const fullMsg = `${this.logPrefix} ${msg}`;
+    private log(severity: Severity, msg: string, success: boolean | null = false): void {
+        let fullMsg = `${this.logPrefix} ${msg}`;
+        if (success === true) {
+            fullMsg += " :white_check_mark:";
+        } else if(success === false) {
+            fullMsg += " :no_entry_sign:";
+        }
         switch (severity) {
             case Severity.DEBUG_EXTRA:
                 /* istanbul ignore else */

--- a/packages/core-p2p/src/peer-verifier.ts
+++ b/packages/core-p2p/src/peer-verifier.ts
@@ -518,7 +518,7 @@ export class PeerVerifier implements Contracts.P2P.PeerVerifier {
         if (delegatesByPublicKey[block.data.generatorPublicKey]) {
             this.log(
                 Severity.DEBUG_EXTRA,
-                `successfully verified block at height ${height}, signed by ` + block.data.generatorPublicKey, true, 
+                `successfully verified block at height ${height}, signed by ` + block.data.generatorPublicKey, true,
             );
 
             return true;

--- a/packages/core-p2p/src/socket-server/controllers/blocks.ts
+++ b/packages/core-p2p/src/socket-server/controllers/blocks.ts
@@ -77,7 +77,7 @@ export class BlocksController extends Controller {
 
         this.logger.info(`Received new block forged by ${generator} at height ${block.height.toLocaleString()} with ${Utils.formatSatoshi(block.reward)} reward :package:`);
 
-        this.logger.debug(`Block contained ${AppUtils.pluralize(
+        this.logger.debug(`The new block contains ${AppUtils.pluralize(
             "transaction",
             block.numberOfTransactions,
             true,

--- a/packages/core-p2p/src/socket-server/controllers/blocks.ts
+++ b/packages/core-p2p/src/socket-server/controllers/blocks.ts
@@ -1,6 +1,6 @@
 import { DatabaseService } from "@arkecosystem/core-database";
-import { Container, Contracts, Providers, Utils } from "@arkecosystem/core-kernel";
-import { Blocks, Interfaces, Managers } from "@arkecosystem/crypto";
+import { Container, Contracts, Providers, Utils as AppUtils } from "@arkecosystem/core-kernel";
+import { Blocks, Interfaces, Managers, Utils } from "@arkecosystem/crypto";
 import Hapi from "@hapi/hapi";
 
 import { constants } from "../../constants";
@@ -18,6 +18,10 @@ export class BlocksController extends Controller {
 
     @Container.inject(Container.Identifiers.DatabaseService)
     private readonly database!: DatabaseService;
+
+    @Container.inject(Container.Identifiers.WalletRepository)
+    @Container.tagged("state", "blockchain")
+    private readonly walletRepository!: Contracts.State.WalletRepository;
 
     public async postBlock(
         request: Hapi.Request,
@@ -43,7 +47,7 @@ export class BlocksController extends Controller {
             transactions: deserialized.transactions.map((tx) => tx.data),
         };
 
-        const fromForger: boolean = Utils.isWhitelisted(
+        const fromForger: boolean = AppUtils.isWhitelisted(
             this.configuration.getOptional<string[]>("remoteAccess", []),
             request.info.remoteAddress,
         );
@@ -55,20 +59,29 @@ export class BlocksController extends Controller {
 
             const lastDownloadedBlock: Interfaces.IBlockData = this.blockchain.getLastDownloadedBlock();
 
-            const blockTimeLookup = await Utils.forgingInfoCalculator.getBlockTimeLookup(this.app, block.height);
+            const blockTimeLookup = await AppUtils.forgingInfoCalculator.getBlockTimeLookup(this.app, block.height);
 
-            if (!Utils.isBlockChained(lastDownloadedBlock, block, blockTimeLookup)) {
+            if (!AppUtils.isBlockChained(lastDownloadedBlock, block, blockTimeLookup)) {
                 return { status: false, height: this.blockchain.getLastHeight() };
             }
         }
 
-        this.logger.info(
-            `Received new block at height ${block.height.toLocaleString()} with ${Utils.pluralize(
-                "transaction",
-                block.numberOfTransactions,
-                true,
-            )} from ${mapAddr(request.info.remoteAddress)}`,
-        );
+        const generatorWallet: Contracts.State.Wallet = this.walletRepository.findByPublicKey(block.generatorPublicKey);
+
+        let generator: string;
+        try {
+            generator = `delegate ${generatorWallet.getAttribute("delegate.username")} (#${generatorWallet.getAttribute("delegate.rank")})`;
+        } catch {
+            generator = "an unknown delegate";
+        }
+
+        this.logger.info(`Received new block forged by ${generator} at height ${block.height.toLocaleString()} with ${Utils.formatSatoshi(block.reward)} reward :package:`);
+
+        this.logger.debug(`Block contained ${AppUtils.pluralize(
+            "transaction",
+            block.numberOfTransactions,
+            true,
+        )} and was received from ${mapAddr(request.info.remoteAddress)}`);
 
         await this.blockchain.handleIncomingBlock(block, fromForger);
 
@@ -106,7 +119,7 @@ export class BlocksController extends Controller {
         }
 
         this.logger.info(
-            `${mapAddr(request.info.remoteAddress)} has downloaded ${Utils.pluralize(
+            `${mapAddr(request.info.remoteAddress)} has downloaded ${AppUtils.pluralize(
                 "block",
                 blocksToReturn.length,
                 true,

--- a/packages/core-p2p/src/socket-server/controllers/internal.ts
+++ b/packages/core-p2p/src/socket-server/controllers/internal.ts
@@ -86,7 +86,7 @@ export class InternalController extends Controller {
     }
 
     public syncBlockchain(request: Hapi.Request, h: Hapi.ResponseToolkit): boolean {
-        this.logger.debug("Blockchain sync check WAKEUP requested by forger");
+        this.logger.debug("Blockchain sync check WAKEUP requested by forger :bed:");
 
         this.blockchain.forceWakeup();
 

--- a/packages/core-p2p/src/transaction-broadcaster.ts
+++ b/packages/core-p2p/src/transaction-broadcaster.ts
@@ -29,7 +29,7 @@ export class TransactionBroadcaster implements Contracts.P2P.TransactionBroadcas
 
         const transactionsStr = Utils.pluralize("transaction", transactions.length, true);
         const peersStr = Utils.pluralize("peer", peers.length, true);
-        this.logger.debug(`Broadcasting ${transactionsStr} to ${peersStr}`);
+        this.logger.debug(`Broadcasting ${transactionsStr} to ${peersStr} :moneybag:`);
 
         const transactionsBroadcast: Buffer[] = transactions.map((t) => Transactions.Serializer.serialize(t));
         const promises = peers.map((p) => this.communicator.postTransactions(p, transactionsBroadcast));

--- a/packages/core-state/src/database-interactions.ts
+++ b/packages/core-state/src/database-interactions.ts
@@ -138,7 +138,7 @@ export class DatabaseInteraction {
         lastBlock = await getLastBlock();
 
         if (!lastBlock) {
-            this.logger.warning("No block found in database");
+            this.logger.warning("No block found in database :hushed:");
             lastBlock = await this.createGenesisBlock();
         }
 

--- a/packages/core-state/src/round-state.ts
+++ b/packages/core-state/src/round-state.ts
@@ -134,7 +134,7 @@ export class RoundState {
             this.logger.debug(
                 `Delegate ${delegate.getAttribute(
                     "delegate.username",
-                )} (${delegate.getPublicKey()}) just missed a block.`,
+                )} (${delegate.getPublicKey()}) just missed a block :pensive:`,
             );
 
             this.events.dispatch(Enums.ForgerEvent.Missing, {
@@ -192,7 +192,7 @@ export class RoundState {
                 this.logger.debug(
                     `Delegate ${wallet.getAttribute(
                         "delegate.username",
-                    )} (${wallet.getPublicKey()}) just missed a round.`,
+                    )} (${wallet.getPublicKey()}) just missed a round :cold_sweat:`,
                 );
 
                 this.events.dispatch(Enums.RoundEvent.Missed, {

--- a/packages/core-state/src/round-state.ts
+++ b/packages/core-state/src/round-state.ts
@@ -147,7 +147,7 @@ export class RoundState {
         if (height === 1 || AppUtils.roundCalculator.isNewRound(height + 1)) {
             const roundInfo = this.getRound(height + 1);
 
-            this.logger.info(`Starting Round ${roundInfo.round.toLocaleString()}`);
+            this.logger.info(`Starting Round ${roundInfo.round.toLocaleString()} :dove_of_peace:`);
 
             this.detectMissedRound();
 
@@ -169,7 +169,7 @@ export class RoundState {
         const { round, nextRound } = roundInfo;
 
         if (nextRound === round + 1) {
-            this.logger.info(`Back to previous round: ${round.toLocaleString()}`);
+            this.logger.info(`Back to previous round: ${round.toLocaleString()} :back:`);
 
             await this.setForgingDelegatesOfRound(
                 roundInfo,

--- a/packages/core-transaction-pool/src/collator.ts
+++ b/packages/core-transaction-pool/src/collator.ts
@@ -69,7 +69,7 @@ export class Collator implements Contracts.TransactionPool.Collator {
                 bytesLeft -= 4;
                 bytesLeft -= transaction.serialized.length;
             } catch (error) {
-                this.logger.warning(`${transaction} failed to collate: ${error.message}`);
+                this.logger.warning(`${transaction} failed to collate: ${error.message} :warning:`);
                 failedTransactions.push(transaction);
             }
         }

--- a/packages/core-transaction-pool/src/dynamic-fee-matcher.ts
+++ b/packages/core-transaction-pool/src/dynamic-fee-matcher.ts
@@ -40,25 +40,25 @@ export class DynamicFeeMatcher implements Contracts.TransactionPool.DynamicFeeMa
             const minFeeStr = Utils.formatSatoshi(minFeePool);
 
             if (transaction.data.fee.isGreaterThanEqual(minFeePool)) {
-                this.logger.debug(`${transaction} eligible to enter pool (fee ${feeStr} >= ${minFeeStr})`);
+                this.logger.debug(`${transaction} eligible to enter pool (fee ${feeStr} >= ${minFeeStr}) :money_with_wings:`);
                 return;
             }
 
-            this.logger.notice(`${transaction} not eligible to enter pool (fee ${feeStr} < ${minFeeStr})`);
+            this.logger.notice(`${transaction} not eligible to enter pool (fee ${feeStr} < ${minFeeStr}) :zap:`);
             throw new TransactionFeeToLowError(transaction);
         } else {
             const staticFeeStr = Utils.formatSatoshi(transaction.staticFee);
 
             if (transaction.data.fee.isEqualTo(transaction.staticFee)) {
-                this.logger.debug(`${transaction} eligible to enter pool (fee ${feeStr} = ${staticFeeStr})`);
+                this.logger.debug(`${transaction} eligible to enter pool (fee ${feeStr} = ${staticFeeStr}) :money_with_wings:`);
                 return;
             }
             if (transaction.data.fee.isLessThan(transaction.staticFee)) {
-                this.logger.notice(`${transaction} not eligible to enter pool (fee ${feeStr} < ${staticFeeStr})`);
+                this.logger.notice(`${transaction} not eligible to enter pool (fee ${feeStr} < ${staticFeeStr}) :zap:`);
                 throw new TransactionFeeToLowError(transaction);
             }
 
-            this.logger.notice(`${transaction} not eligible to enter pool (fee ${feeStr} > ${staticFeeStr})`);
+            this.logger.notice(`${transaction} not eligible to enter pool (fee ${feeStr} > ${staticFeeStr}) :zap:`);
             throw new TransactionFeeToHighError(transaction);
         }
     }
@@ -83,11 +83,11 @@ export class DynamicFeeMatcher implements Contracts.TransactionPool.DynamicFeeMa
             const minFeeStr = Utils.formatSatoshi(minFeeBroadcast);
 
             if (transaction.data.fee.isGreaterThanEqual(minFeeBroadcast)) {
-                this.logger.debug(`${transaction} eligible for broadcast (fee ${feeStr} >= ${minFeeStr})`);
+                this.logger.debug(`${transaction} eligible for broadcast (fee ${feeStr} >= ${minFeeStr}) :earth_africa:`);
                 return;
             }
 
-            this.logger.notice(`${transaction} not eligible for broadcast (fee ${feeStr} < ${minFeeStr})`);
+            this.logger.notice(`${transaction} not eligible for broadcast (fee ${feeStr} < ${minFeeStr}) :zap:`);
             throw new TransactionFeeToLowError(transaction);
         } else {
             const staticFeeStr = Utils.formatSatoshi(transaction.staticFee);
@@ -97,11 +97,11 @@ export class DynamicFeeMatcher implements Contracts.TransactionPool.DynamicFeeMa
                 return;
             }
             if (transaction.data.fee.isLessThan(transaction.staticFee)) {
-                this.logger.notice(`${transaction} not eligible to enter pool (fee ${feeStr} < ${staticFeeStr})`);
+                this.logger.notice(`${transaction} not eligible to enter pool (fee ${feeStr} < ${staticFeeStr}) :zap:`);
                 throw new TransactionFeeToLowError(transaction);
             }
 
-            this.logger.notice(`${transaction} not eligible to enter pool (fee ${feeStr} > ${staticFeeStr})`);
+            this.logger.notice(`${transaction} not eligible to enter pool (fee ${feeStr} > ${staticFeeStr}) :zap:`);
             throw new TransactionFeeToHighError(transaction);
         }
     }

--- a/packages/core-transaction-pool/src/service.ts
+++ b/packages/core-transaction-pool/src/service.ts
@@ -105,7 +105,7 @@ export class Service implements Contracts.TransactionPool.Service {
                 this.events.dispatch(Enums.TransactionEvent.AddedToPool, transaction.data);
             } catch (error) {
                 this.storage.removeTransaction(transaction.id);
-                this.logger.warning(`${transaction} failed to enter pool: ${error.message}`);
+                this.logger.warning(`${transaction} failed to enter pool: ${error.message} :warning:`);
                 this.events.dispatch(Enums.TransactionEvent.RejectedByPool, transaction.data);
 
                 throw error instanceof Contracts.TransactionPool.PoolError
@@ -151,7 +151,7 @@ export class Service implements Contracts.TransactionPool.Service {
 
                     previouslyForgedSuccesses++;
                 } catch (error) {
-                    this.logger.debug(`Failed to re-add previously forged transaction ${id}: ${error.message}`);
+                    this.logger.debug(`Failed to re-add previously forged transaction ${id}: ${error.message} :warning:`);
                     previouslyForgedFailures++;
                 }
             }
@@ -172,7 +172,7 @@ export class Service implements Contracts.TransactionPool.Service {
                         previouslyStoredSuccesses++;
                     } catch (error) {
                         this.storage.removeTransaction(id);
-                        this.logger.debug(`Failed to re-add previously stored transaction ${id}: ${error.message}`);
+                        this.logger.debug(`Failed to re-add previously stored transaction ${id}: ${error.message} :warning:`);
                         previouslyStoredFailures++;
                     }
                 } else {
@@ -183,19 +183,19 @@ export class Service implements Contracts.TransactionPool.Service {
             }
 
             if (previouslyForgedSuccesses >= 1) {
-                this.logger.info(`${previouslyForgedSuccesses} previously forged transactions re-added`);
+                this.logger.info(`${previouslyForgedSuccesses} previously forged transactions re-added :money_with_wings:`);
             }
             if (previouslyForgedFailures >= 1) {
-                this.logger.warning(`${previouslyForgedFailures} previously forged transactions failed re-adding`);
+                this.logger.warning(`${previouslyForgedFailures} previously forged transactions failed re-adding :warning:`);
             }
             if (previouslyStoredSuccesses >= 1) {
-                this.logger.info(`${previouslyStoredSuccesses} previously stored transactions re-added`);
+                this.logger.info(`${previouslyStoredSuccesses} previously stored transactions re-added :money_with_wings:`);
             }
             if (previouslyStoredExpirations >= 1) {
-                this.logger.info(`${previouslyStoredExpirations} previously stored transactions expired`);
+                this.logger.info(`${previouslyStoredExpirations} previously stored transactions expired :zap:`);
             }
             if (previouslyStoredFailures >= 1) {
-                this.logger.warning(`${previouslyStoredFailures} previously stored transactions failed re-adding`);
+                this.logger.warning(`${previouslyStoredFailures} previously stored transactions failed re-adding :warning:`);
             }
         });
     }
@@ -210,7 +210,7 @@ export class Service implements Contracts.TransactionPool.Service {
             AppUtils.assert.defined<string>(transaction.data.senderPublicKey);
 
             if (this.storage.hasTransaction(transaction.id) === false) {
-                this.logger.error(`Failed to remove ${transaction} that isn't in pool`);
+                this.logger.error(`Failed to remove ${transaction} that isn't in pool :warning:`);
                 return;
             }
 

--- a/packages/core/src/commands/config-log.ts
+++ b/packages/core/src/commands/config-log.ts
@@ -1,0 +1,86 @@
+import { Commands, Container } from "@arkecosystem/core-cli";
+import { Networks } from "@arkecosystem/crypto";
+import { readJSONSync, writeJSONSync } from "fs-extra";
+import Joi from "joi";
+
+/**
+ * @export
+ * @class Command
+ * @extends {Commands.Command}
+ */
+@Container.injectable()
+export class Command extends Commands.Command {
+    /**
+     * The console command signature.
+     *
+     * @type {string}
+     * @memberof Command
+     */
+    public signature: string = "config:log";
+
+    /**
+     * The console command description.
+     *
+     * @type {string}
+     * @memberof Command
+     */
+    public description: string = "Update the logger configuration.";
+
+    /**
+     * Configure the console command.
+     *
+     * @returns {void}
+     * @memberof Command
+     */
+    public configure(): void {
+        this.definition
+            .setFlag("token", "The name of the token.", Joi.string())
+            .setFlag("network", "The name of the network.", Joi.string().valid(...Object.keys(Networks)))
+            .setFlag("emojify", "Whether to add emoji to the logs of Core.", Joi.boolean());
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @returns {Promise<void>}
+     * @memberof Command
+     */
+    public async execute(): Promise<void> {
+        if (this.hasFlag("token")) {
+            this.config.set("token", this.getFlag("token"));
+        }
+
+        if (this.hasFlag("emojify")) {
+            const appJsonFile = this.app.getCorePath("config", "app.json");
+            const appJson = readJSONSync(appJsonFile);
+
+            for (const app of Object.keys(appJson)) {
+                const loggerConfig = appJson[app].plugins.filter(
+                    (plugin) => plugin.package === "@arkecosystem/core-logger-pino",
+                )[0];
+                const emojify = this.getFlag("emojify");
+
+                if (loggerConfig) {
+                    if (loggerConfig.options) {
+                        if (emojify) {
+                            delete loggerConfig.options.emojify;
+                        }
+                    }
+
+                    if (!emojify) {
+                        if (!loggerConfig.options) {
+                            loggerConfig.options = {};
+                        }
+                        loggerConfig.options.emojify = emojify;
+                    }
+
+                    if (Object.keys(loggerConfig.options).length === 0) {
+                        delete loggerConfig.options;
+                    }
+                }
+            }
+
+            writeJSONSync(appJsonFile, appJson, { spaces: 4 });
+        }
+    }
+}


### PR DESCRIPTION
Reinstates the emoji symbols that were previously included in the logs of ARK Core v2.0-2.2 and adds some extra ones too. This is not just for nostalgic reasons, because they can greatly speed up looking for certain events when skimming through many hundreds of log lines because our eyes can rapidly pick out emoji symbols much faster than reading and digesting text.

Since I suspect some people won't like having emoji symbols in their logs, a new command has been added to the `solar` CLI to disable them: `solar config:log --emojify=false`.

Further changes have also been made to various log lines to make them easier to understand. Some lines have been reworded, others containing irrelevant or unnecessary details have been removed and some additional information has been added that could be useful, e.g. the reward for each incoming block since Solar uses dynamic rewards based on delegate rank position.
