### PR TITLE
fix: supply calculator

### DIFF
--- a/packages/core-api/src/controllers/blockchain.ts
+++ b/packages/core-api/src/controllers/blockchain.ts
@@ -6,6 +6,10 @@ export class BlockchainController extends Controller {
     @Container.inject(Container.Identifiers.StateStore)
     private readonly stateStore!: Contracts.State.StateStore;
 
+    @Container.inject(Container.Identifiers.WalletRepository)
+    @Container.tagged("state", "blockchain")
+    private readonly walletRepository!: Contracts.State.WalletRepository;
+
     public async index() {
         const { data } = this.stateStore.getLastBlock();
 
@@ -15,7 +19,7 @@ export class BlockchainController extends Controller {
                     height: data.height,
                     id: data.id,
                 },
-                supply: Utils.supplyCalculator.calculate(data.height),
+                supply: Utils.supplyCalculator.calculate(this.walletRepository.allByAddress()),
             },
         };
     }

--- a/packages/core-kernel/src/utils/delegate-calculator.ts
+++ b/packages/core-kernel/src/utils/delegate-calculator.ts
@@ -1,6 +1,5 @@
 import { Wallet, WalletDelegateAttributes } from "../contracts/state";
 import { BigNumber } from "../utils";
-import { calculate as calculateSupply } from "./supply-calculator";
 
 const toDecimal = (voteBalance: BigNumber, totalSupply: BigNumber): number => {
     const decimals: number = 2;
@@ -12,8 +11,8 @@ const toDecimal = (voteBalance: BigNumber, totalSupply: BigNumber): number => {
     return +Number(div).toFixed(2);
 };
 
-export const calculateApproval = (delegate: Wallet, height: number = 1): number => {
-    const totalSupply: BigNumber = BigNumber.make(calculateSupply(height));
+export const calculateApproval = (delegate: Wallet, supply): number => {
+    const totalSupply: BigNumber = BigNumber.make(supply);
     const voteBalance: BigNumber = delegate.getAttribute("delegate.voteBalance");
 
     return toDecimal(voteBalance, totalSupply);

--- a/packages/core-kernel/src/utils/supply-calculator.ts
+++ b/packages/core-kernel/src/utils/supply-calculator.ts
@@ -1,42 +1,16 @@
-import { Interfaces, Managers, Utils } from "@arkecosystem/crypto";
+import { Utils } from "@arkecosystem/crypto";
 
-import { assert } from "./assert";
+import { Wallet } from "../contracts/state";
 
-// todo: review the implementation
-export const calculate = (height: number): string => {
-    const config: Interfaces.NetworkConfig | undefined = Managers.configManager.all();
-
-    assert.defined<Interfaces.NetworkConfig>(config);
-
-    const { genesisBlock, milestones } = config;
-
-    const totalAmount: Utils.BigNumber = Utils.BigNumber.make(genesisBlock.totalAmount);
-
-    if (height === 0 || milestones.length === 0) {
-        return totalAmount.toFixed();
-    }
-
-    let rewards: Utils.BigNumber = Utils.BigNumber.ZERO;
-    let currentHeight = 0;
-    let constantIndex = 0;
-
-    while (currentHeight < height) {
-        const constants = milestones[constantIndex];
-        const nextConstants = milestones[constantIndex + 1];
-
-        let heightJump: number = height - currentHeight;
-
-        if (nextConstants && height >= nextConstants.height && currentHeight < nextConstants.height - 1) {
-            heightJump = nextConstants.height - 1 - currentHeight;
-            constantIndex += 1;
-        }
-
-        currentHeight += heightJump;
-
-        if (currentHeight >= constants.height) {
-            rewards = rewards.plus(Utils.BigNumber.make(constants.reward).times(heightJump));
-        }
-    }
-
-    return totalAmount.plus(rewards).toFixed();
+export const calculate = (wallets: readonly Wallet[]): string => {
+    return wallets
+        .filter((wallet) => !wallet.getBalance().isNegative())
+        .reduce((partialSum, wallet) => {
+            let balance = partialSum.plus(wallet.getBalance());
+            if (wallet.hasAttribute("htlc.lockedBalance")) {
+                balance = balance.plus(wallet.getAttribute("htlc.lockedBalance"));
+            }
+            return balance;
+        }, Utils.BigNumber.ZERO)
+        .toFixed();
 };


### PR DESCRIPTION
The existing implementation of the supply calculator computes the supply by adding the inital supply to the static forging reward value multiplied by the height. This was not enough with the introduction of a burn transaction and dynamic rewards. The function has been rewritten to actually sum all the non-negative wallet balances (including locked htlc tokens) so that it will correctly return the current supply.