### PR TITLE
feat(core-p2p): faster update of peers endpoint with peer version

### DIFF
--- a/packages/core-p2p/src/socket-server/plugins/version.ts
+++ b/packages/core-p2p/src/socket-server/plugins/version.ts
@@ -1,0 +1,38 @@
+import { Container, Contracts } from "@arkecosystem/core-kernel";
+
+import { getPeerIp } from "../../utils/get-peer-ip";
+import { BlocksRoute } from "../routes/blocks";
+import { PeerRoute } from "../routes/peer";
+import { TransactionsRoute } from "../routes/transactions";
+
+@Container.injectable()
+export class VersionPlugin {
+    @Container.inject(Container.Identifiers.Application)
+    protected readonly app!: Contracts.Kernel.Application;
+
+    @Container.inject(Container.Identifiers.PeerRepository)
+    private readonly peerRepository!: Contracts.P2P.PeerRepository;
+
+    public register(server) {
+        const routesConfigByPath = {
+            ...this.app.resolve(PeerRoute).getRoutesConfigByPath(),
+            ...this.app.resolve(BlocksRoute).getRoutesConfigByPath(),
+            ...this.app.resolve(TransactionsRoute).getRoutesConfigByPath(),
+        };
+
+        server.ext({
+            type: "onPostAuth",
+            method: async (request, h) => {
+                if (routesConfigByPath[request.path]) {
+                    const peerIp = request.socket ? getPeerIp(request.socket) : request.info.remoteAddress;
+                    const version = request.payload?.headers?.version;
+                    if (version && this.peerRepository.hasPeer(peerIp)) {
+                        const peer = this.peerRepository.getPeer(peerIp);
+                        peer.version = version;
+                    }
+                }
+                return h.continue;
+            },
+        });
+    }
+}

--- a/packages/core-p2p/src/socket-server/server.ts
+++ b/packages/core-p2p/src/socket-server/server.ts
@@ -8,6 +8,7 @@ import { CodecPlugin } from "./plugins/codec";
 import { IsAppReadyPlugin } from "./plugins/is-app-ready";
 import { RateLimitPlugin } from "./plugins/rate-limit";
 import { ValidatePlugin } from "./plugins/validate";
+import { VersionPlugin } from "./plugins/version";
 import { WhitelistForgerPlugin } from "./plugins/whitelist-forger";
 import { BlocksRoute } from "./routes/blocks";
 import { InternalRoute } from "./routes/internal";
@@ -81,6 +82,7 @@ export class Server {
         // onPostAuth
         this.app.resolve(CodecPlugin).register(this.server);
         this.app.resolve(ValidatePlugin).register(this.server);
+        this.app.resolve(VersionPlugin).register(this.server);
         this.app.resolve(IsAppReadyPlugin).register(this.server);
 
         // onPreHandler


### PR DESCRIPTION
The `/api/peers` endpoint previously only showed the version of Core that the peer was running when it was first added to our peer repository via the `version` property of each peer object. This meant that when a peer updated their version of Core, if they restarted and reconnected before we forgot the peer, we would still see their old version on the endpoint and it would be very slow to update to reflect the true version of Core each peer is running.

This adds a new plugin to the socket server to update the `version` property of each peer whenever they communicate with us, since most incoming messages include their version in the message header. This means `/api/peers` now updates instantly with the correct version when a peer updates (or theoretically downgrades) their version of Core.