### PR TITLE
feat(core-p2p): faster port discovery for new peers

### DIFF
--- a/packages/core-p2p/src/peer-processor.ts
+++ b/packages/core-p2p/src/peer-processor.ts
@@ -101,6 +101,7 @@ export class PeerProcessor implements Contracts.P2P.PeerProcessor {
             const verifyTimeout = this.configuration.getRequired<number>("verifyTimeout");
 
             await this.communicator.ping(newPeer, verifyTimeout);
+            await this.communicator.pingPorts(newPeer);
 
             this.repository.setPeer(newPeer);
 


### PR DESCRIPTION
The `ports` object of a newly added peer is always empty until Core decides to ping the new peer's ports at a point in time in the future. This can lead to inconsistent results and unexpected behaviour if a peer requires a plugin or service's port to always be discoverable.

This changes that behaviour so Core immediately pings the ports of a new peer, so the `ports` object will always contain the expected data from the moment the peer is accepted.