### PR TITLE
refactor: retry forging throughout slot

### DIFF
--- a/packages/core-forger/src/actions/forge-new-block.ts
+++ b/packages/core-forger/src/actions/forge-new-block.ts
@@ -6,9 +6,9 @@ export class ForgeNewBlockAction extends Services.Triggers.Action {
     public async execute(args: Types.ActionArguments): Promise<void> {
         const forgerService: ForgerService = args.forgerService;
         const delegate: Delegate = args.delegate;
+        const firstAttempt: boolean = args.firstAttempt;
         const round: Contracts.P2P.CurrentRound = args.round;
-        const networkState: Contracts.P2P.NetworkState = args.networkState;
 
-        return forgerService.forgeNewBlock(delegate, round, networkState);
+        return forgerService.forgeNewBlock(delegate, firstAttempt, round);
     }
 }

--- a/packages/core-kernel/src/contracts/p2p/network-monitor.ts
+++ b/packages/core-kernel/src/contracts/p2p/network-monitor.ts
@@ -18,15 +18,17 @@ export interface NetworkMonitor {
     cleansePeers({
         fast,
         forcePing,
+        log,
         peerCount,
     }?: {
         fast?: boolean;
         forcePing?: boolean;
+        log?: boolean;
         peerCount?: number;
     }): Promise<void>;
     discoverPeers(initialRun?: boolean): Promise<boolean>;
     getNetworkHeight(): number;
-    getNetworkState(): Promise<NetworkState>;
+    getNetworkState(log?: boolean): Promise<NetworkState>;
     refreshPeersAfterFork(): Promise<void>;
     checkNetworkHealth(): Promise<NetworkStatus>;
     downloadBlocksFromHeight(fromBlockHeight: number, maxParallelDownloads?: number): Promise<Interfaces.IBlockData[]>;

--- a/packages/core-kernel/src/contracts/p2p/server.ts
+++ b/packages/core-kernel/src/contracts/p2p/server.ts
@@ -27,6 +27,14 @@ export interface ForgingTransactions {
     count: number;
 }
 
+export interface Status {
+    state: {
+        header: {
+            timestamp: number
+        }
+    };
+}
+
 export interface UnconfirmedTransactions {
     transactions: string[];
     poolSize: number;

--- a/packages/core-p2p/src/network-monitor.ts
+++ b/packages/core-p2p/src/network-monitor.ts
@@ -123,8 +123,9 @@ export class NetworkMonitor implements Contracts.P2P.NetworkMonitor {
     public async cleansePeers({
         fast = false,
         forcePing = false,
+        log = true,
         peerCount,
-    }: { fast?: boolean; forcePing?: boolean; peerCount?: number } = {}): Promise<void> {
+    }: { fast?: boolean; forcePing?: boolean; log?: boolean; peerCount?: number } = {}): Promise<void> {
         let peers = this.repository.getPeers();
         let max = peers.length;
 
@@ -136,7 +137,9 @@ export class NetworkMonitor implements Contracts.P2P.NetworkMonitor {
             max = Math.min(peers.length, peerCount);
         }
 
-        this.logger.info(`Checking ${Utils.pluralize("peer", max, true)} :telescope:`);
+        if (log) {
+            this.logger.info(`Checking ${Utils.pluralize("peer", max, true)} :telescope:`);
+        }
         const peerErrors = {};
 
         // we use Promise.race to cut loose in case some communicator.ping() does not resolve within the delay
@@ -260,8 +263,8 @@ export class NetworkMonitor implements Contracts.P2P.NetworkMonitor {
         return medians[Math.floor(medians.length / 2)] || 0;
     }
 
-    public async getNetworkState(): Promise<Contracts.P2P.NetworkState> {
-        await this.cleansePeers({ fast: true, forcePing: true });
+    public async getNetworkState(log: boolean = true): Promise<Contracts.P2P.NetworkState> {
+        await this.cleansePeers({ fast: true, forcePing: true, log });
 
         return await NetworkState.analyze(this, this.repository);
     }

--- a/packages/core-p2p/src/socket-server/controllers/internal.ts
+++ b/packages/core-p2p/src/socket-server/controllers/internal.ts
@@ -82,7 +82,7 @@ export class InternalController extends Controller {
     }
 
     public async getNetworkState(request: Hapi.Request, h: Hapi.ResponseToolkit): Promise<Contracts.P2P.NetworkState> {
-        return this.peerNetworkMonitor.getNetworkState();
+        return this.peerNetworkMonitor.getNetworkState(!!request.payload.log);
     }
 
     public syncBlockchain(request: Hapi.Request, h: Hapi.ResponseToolkit): boolean {

--- a/packages/core-p2p/src/utils/build-rate-limiter.ts
+++ b/packages/core-p2p/src/utils/build-rate-limiter.ts
@@ -23,7 +23,7 @@ export const buildRateLimiter = (options) =>
                     endpoint: "p2p.peer.getPeers",
                 },
                 {
-                    rateLimit: 2,
+                    rateLimit: 9,
                     endpoint: "p2p.peer.getStatus",
                 },
                 {

--- a/packages/core/bin/config/devnet/app.json
+++ b/packages/core/bin/config/devnet/app.json
@@ -82,6 +82,9 @@
                 "package": "@arkecosystem/core-logger-pino"
             },
             {
+                "package": "@arkecosystem/core-database"
+            },
+            {
                 "package": "@arkecosystem/core-transactions"
             },
             {

--- a/packages/core/bin/config/mainnet/app.json
+++ b/packages/core/bin/config/mainnet/app.json
@@ -76,6 +76,9 @@
                 "package": "@arkecosystem/core-logger-pino"
             },
             {
+                "package": "@arkecosystem/core-database"
+            },
+            {
                 "package": "@arkecosystem/core-transactions"
             },
             {

--- a/packages/core/bin/config/testnet/app.json
+++ b/packages/core/bin/config/testnet/app.json
@@ -82,6 +82,9 @@
                 "package": "@arkecosystem/core-logger-pino"
             },
             {
+                "package": "@arkecosystem/core-database"
+            },
+            {
                 "package": "@arkecosystem/core-transactions"
             },
             {


### PR DESCRIPTION
The upstream code only attempts to forge a new block once, at the start of the slot. If, due to network latency or other factors, the node didn't receive the previous block by this time, it will fail to forge due to insufficient quorum and it will miss a block. This means even if the node regains sync during the slot, it will still miss. Since a slot lasts for 8 seconds, there is a lot of wasted opportunity by not trying again to forge throughout this time window.

This PR changes this behaviour so the forger will retry forging if it fails. It will attempt to forge once per second, until our forging slot is over or until it succeeds and the block is accepted by our node.

Some of the code may seem redundant, such as `currentSlot`, `lastBlockSlot` and `state` being set multiple times with the same values inside the same function, but this is necessary in case some of the client calls take too long to respond meaning the slot or state data changes and we need to update these variables in time for the final checks so we don't end up forging too late or out of our slot.

Another change introduced by this PR is that the forger now requests the last block from the relay before forging. If the block's timestamp is from the current slot, it does not forge. This catches cases where a different node by our delegate has already forged a block and propagated it to us, helping to prevent accidental double forgery in cases where the block propagation from node A occurs after node B's network state checks are complete but before node B's block is forged e.g. if node A is more powerful than node B or if there is minor clock drift on node B.

For full disclosure, [I suggested this to the upstream maintainers last year](https://github.com/ArkEcosystem/core/issues/4447). They didn't respond or even acknowledge the issue and it was eventually auto-closed without any human input.