### PR TITLE
refactor: limited double forgery mitigation

### DIFF
--- a/packages/core-kernel/src/contracts/p2p/network-state.ts
+++ b/packages/core-kernel/src/contracts/p2p/network-state.ts
@@ -9,5 +9,6 @@ export interface NetworkState {
 
     getQuorum();
     getOverHeightBlockHeaders();
+    setOverHeightBlockHeaders(overHeightBlockHeaders: Array<any>): void;
     toJson();
 }


### PR DESCRIPTION
The upstream code logs if it thinks there is attempted double forgery from our delegate via overheight block headers (i.e. if there is already a block at a higher height than our node which is purportedly from our delegate), but Core does not stop us from forging anyway in that situation, which risks forking the network. This is due to lack of cryptographic verification of the potentially double forged block, so it errs on the side of caution to prevent a bad actor halting the network by spamming each delegate with cryptographically unverified block headers at a higher height but with the delegate's own public key when they are due to forge.

Now we actually cryptographically verify the signature of the block header to definitively identify if the overheight block header is legitimately from our delegate. If yes, it is double forgery, our delegate already forged on another node, so we stop the forging process.

As with the previous PR regarding forging changes, [I suggested this to the upstream maintainers last year](https://github.com/ArkEcosystem/core/issues/4429). They didn't respond or even acknowledge the issue and it was eventually auto-closed without any human input.