### PR TITLE
refactor(core-p2p): only use active delegates in calculations

### DIFF
--- a/packages/core-forger/src/forger-service.ts
+++ b/packages/core-forger/src/forger-service.ts
@@ -422,6 +422,9 @@ export class ForgerService {
         } else if (networkState.status === NetworkStateStatus.ColdStart) {
             this.logger.info("Skipping slot because of cold start. Will not forge :bomb:");
             return false;
+        } else if (networkState.status === NetworkStateStatus.BelowMinimumDelegates) {
+            this.logger.info("Not peered with enough delegates to get quorum. Will not forge :bomb:");
+            return false;
         } else if (networkState.status === NetworkStateStatus.BelowMinimumPeers) {
             this.logger.info("Network reach is not sufficient to get quorum. Will not forge :bomb:");
             return false;
@@ -473,7 +476,7 @@ export class ForgerService {
             }
         }
 
-        if (networkState.getQuorum() < 0.66) {
+        if (!networkState.canForge()) {
             networkState.setOverHeightBlockHeaders(distinctOverHeightBlockHeaders);
 
             this.logger.info("Not enough quorum to forge next block. Will not forge :bomb:");

--- a/packages/core-forger/src/forger-service.ts
+++ b/packages/core-forger/src/forger-service.ts
@@ -3,7 +3,7 @@ import { NetworkStateStatus } from "@arkecosystem/core-p2p";
 import { Handlers } from "@arkecosystem/core-transactions";
 import { Blocks, Crypto, Interfaces, Managers, Transactions, Utils } from "@arkecosystem/crypto";
 import delay from "delay";
-
+import { writeFileSync } from "fs";
 import { Client } from "./client";
 import { HostNoResponseError, RelayCommunicationError } from "./errors";
 import { Delegate } from "./interfaces";
@@ -538,6 +538,15 @@ export class ForgerService {
         });
 
         if (!this.initialized) {
+            AppUtils.sendForgerSignal("SIGTERM");
+
+            const pidFile: string = `${process.env.CORE_PATH_TEMP}/forger.pid`;
+            try {
+                writeFileSync(pidFile, process.pid.toString());
+            } catch {
+                this.app.terminate(`Could not save forger pid to ${pidFile}`);
+            }
+
             this.printLoadedDelegates();
 
             // @ts-ignore

--- a/packages/core-kernel/src/contracts/p2p/network-state.ts
+++ b/packages/core-kernel/src/contracts/p2p/network-state.ts
@@ -4,6 +4,8 @@ export interface NetworkState {
     // static analyze(monitor: NetworkMonitor, repository: PeerRepository): NetworkState;
     // static parse(data: any): NetworkState;
 
+    canForge();
+
     getNodeHeight(): number | undefined;
     getLastBlockId(): string | undefined;
 

--- a/packages/core-kernel/src/contracts/p2p/peer-communicator.ts
+++ b/packages/core-kernel/src/contracts/p2p/peer-communicator.ts
@@ -1,4 +1,4 @@
-import { Interfaces } from "@arkecosystem/crypto";
+import { Crypto, Interfaces } from "@arkecosystem/crypto";
 
 import { Peer } from "./peer";
 
@@ -9,7 +9,7 @@ export interface PeerCommunicator {
 
     postTransactions(peer: Peer, transactions: Buffer[]): Promise<any>;
 
-    ping(peer: Peer, timeoutMsec: number, force?: boolean): Promise<any>;
+    ping(peer: Peer, timeoutMsec: number, blockTimeLookup?: Crypto.GetBlockTimeStampLookup, force?: boolean): Promise<any>;
 
     pingPorts(peer: Peer): Promise<void>;
 

--- a/packages/core-kernel/src/contracts/p2p/peer.ts
+++ b/packages/core-kernel/src/contracts/p2p/peer.ts
@@ -18,12 +18,14 @@ export interface Peer {
     version: string | undefined;
     latency: number | undefined;
 
-    state: PeerState;
-    plugins: PeerPlugins;
     lastPinged: Dayjs | undefined;
+    plugins: PeerPlugins;
+    publicKeys: string[];
     sequentialErrorCounter: number;
+    state: PeerState;
     verificationResult: PeerVerificationResult | undefined;
 
+    isActiveDelegate(): boolean;
     isVerified(): boolean;
     isForked(): boolean;
     recentlyPinged(): boolean;
@@ -66,6 +68,8 @@ export interface PeerConfig {
 export interface PeerPingResponse {
     state: PeerState;
     config: PeerConfig;
+    publicKeys?: string[];
+    signatures?: string[];
 }
 
 export interface PeerVerificationResult {

--- a/packages/core-kernel/src/utils/index.ts
+++ b/packages/core-kernel/src/utils/index.ts
@@ -5,12 +5,13 @@ import { formatTimestamp } from "./format-timestamp";
 import { getBlockTimeLookup } from "./get-blocktime-lookup";
 import { isBlacklisted } from "./is-blacklisted";
 import { getBlockNotChainedErrorMessage, isBlockChained } from "./is-block-chained";
+import { isForgerRunning, sendForgerSignal } from "./is-forger-running";
 import { isWhitelisted } from "./is-whitelisted";
 import { calculateRound, isNewRound } from "./round-calculator";
 export * as IpAddress from "./ip-address";
 export * as Search from "./search";
-import { calculate } from "./supply-calculator";
 import { stringify } from "./stringify";
+import { calculate } from "./supply-calculator";
 
 export * from "@arkecosystem/utils";
 export * from "./expiration-calculator";
@@ -25,4 +26,13 @@ export const roundCalculator = { calculateRound, isNewRound };
 export const supplyCalculator = { calculate };
 export const forgingInfoCalculator = { calculateForgingInfo, getBlockTimeLookup };
 
-export { formatTimestamp, isBlockChained, getBlockNotChainedErrorMessage, isBlacklisted, isWhitelisted, stringify };
+export {
+    formatTimestamp,
+    isBlockChained,
+    isForgerRunning,
+    getBlockNotChainedErrorMessage,
+    isBlacklisted,
+    isWhitelisted,
+    sendForgerSignal,
+    stringify,
+};

--- a/packages/core-kernel/src/utils/index.ts
+++ b/packages/core-kernel/src/utils/index.ts
@@ -10,6 +10,7 @@ import { calculateRound, isNewRound } from "./round-calculator";
 export * as IpAddress from "./ip-address";
 export * as Search from "./search";
 import { calculate } from "./supply-calculator";
+import { stringify } from "./stringify";
 
 export * from "@arkecosystem/utils";
 export * from "./expiration-calculator";
@@ -24,4 +25,4 @@ export const roundCalculator = { calculateRound, isNewRound };
 export const supplyCalculator = { calculate };
 export const forgingInfoCalculator = { calculateForgingInfo, getBlockTimeLookup };
 
-export { formatTimestamp, isBlockChained, getBlockNotChainedErrorMessage, isBlacklisted, isWhitelisted };
+export { formatTimestamp, isBlockChained, getBlockNotChainedErrorMessage, isBlacklisted, isWhitelisted, stringify };

--- a/packages/core-kernel/src/utils/is-forger-running.ts
+++ b/packages/core-kernel/src/utils/is-forger-running.ts
@@ -1,0 +1,15 @@
+import { readFileSync } from "fs";
+
+export const isForgerRunning = (): boolean => {
+    return sendForgerSignal(0);
+}
+
+export const sendForgerSignal = (signal: string | number): boolean => {
+    try {
+        const forgerPid: number = +readFileSync(`${process.env.CORE_PATH_TEMP}/forger.pid`).toString();
+        process.kill(forgerPid, signal);
+        return true;
+    } catch {
+        return false;
+    }
+}

--- a/packages/core-kernel/src/utils/stringify.ts
+++ b/packages/core-kernel/src/utils/stringify.ts
@@ -1,0 +1,13 @@
+export const stringify = (object): string => {
+    const keys: any = [];
+    const seen: object = {};
+    JSON.stringify(object, (key, value) => {
+        if (!(key in seen)) {
+            keys.push(key);
+            seen[key] = undefined;
+        }
+        return value;
+    });
+    keys.sort();
+    return JSON.stringify(object, keys);
+}

--- a/packages/core-p2p/src/enums.ts
+++ b/packages/core-p2p/src/enums.ts
@@ -15,6 +15,7 @@ export enum Severity {
 
 export enum NetworkStateStatus {
     Default,
+    BelowMinimumDelegates,
     BelowMinimumPeers,
     Test,
     ColdStart,

--- a/packages/core-p2p/src/network-monitor.ts
+++ b/packages/core-p2p/src/network-monitor.ts
@@ -621,10 +621,12 @@ export class NetworkMonitor implements Contracts.P2P.NetworkMonitor {
         );
         const delegatesOnThisNode: string[] = [];
 
-        for (const secret of this.app.config("delegates.secrets")) {
-            const keys: Interfaces.IKeyPair = Identities.Keys.fromPassphrase(secret);
-            if (delegates.includes(keys.publicKey)) {
-                delegatesOnThisNode.push(keys.publicKey);
+        if (Utils.isForgerRunning()) {
+            for (const secret of this.app.config("delegates.secrets")) {
+                const keys: Interfaces.IKeyPair = Identities.Keys.fromPassphrase(secret);
+                if (delegates.includes(keys.publicKey)) {
+                    delegatesOnThisNode.push(keys.publicKey);
+                }
             }
         }
 

--- a/packages/core-p2p/src/network-monitor.ts
+++ b/packages/core-p2p/src/network-monitor.ts
@@ -1,5 +1,6 @@
 import { Container, Contracts, Enums, Providers, Services, Utils } from "@arkecosystem/core-kernel";
-import { Interfaces } from "@arkecosystem/crypto";
+import { DatabaseInteraction } from "@arkecosystem/core-state";
+import { Identities, Interfaces, Managers } from "@arkecosystem/crypto";
 import delay from "delay";
 import prettyMs from "pretty-ms";
 import { gt, lt } from "semver";
@@ -7,6 +8,7 @@ import { gt, lt } from "semver";
 import { NetworkState } from "./network-state";
 import { Peer } from "./peer";
 import { PeerCommunicator } from "./peer-communicator";
+import { PeerVerificationResult } from "./peer-verifier";
 import { checkDNS, checkNTP } from "./utils";
 
 const defaultDownloadChunkSize = 400;
@@ -15,7 +17,10 @@ const defaultDownloadChunkSize = 400;
 @Container.injectable()
 export class NetworkMonitor implements Contracts.P2P.NetworkMonitor {
     @Container.inject(Container.Identifiers.Application)
-    private readonly app!: Contracts.Kernel.Application;
+    public readonly app!: Contracts.Kernel.Application;
+
+    @Container.inject(Container.Identifiers.DatabaseInteraction)
+    private readonly databaseInteraction!: DatabaseInteraction;
 
     @Container.inject(Container.Identifiers.PluginConfiguration)
     @Container.tagged("plugin", "@arkecosystem/core-p2p")
@@ -142,12 +147,16 @@ export class NetworkMonitor implements Contracts.P2P.NetworkMonitor {
         }
         const peerErrors = {};
 
+        const lastBlock: Interfaces.IBlock = this.app
+            .get<Contracts.State.StateStore>(Container.Identifiers.StateStore)
+            .getLastBlock();
+        const blockTimeLookup = await Utils.forgingInfoCalculator.getBlockTimeLookup(this.app, lastBlock.data.height);
+
         // we use Promise.race to cut loose in case some communicator.ping() does not resolve within the delay
         // in that case we want to keep on with our program execution while ping promises can finish in the background
         await new Promise<void>((resolve) => {
             let isResolved = false;
 
-            // Simulates Promise.race, but doesn't cause "multipleResolvers" process error
             const resolvesFirst = () => {
                 if (!isResolved) {
                     isResolved = true;
@@ -158,7 +167,7 @@ export class NetworkMonitor implements Contracts.P2P.NetworkMonitor {
             Promise.all(
                 peers.map(async (peer) => {
                     try {
-                        await this.communicator.ping(peer, pingDelay, forcePing);
+                        await this.communicator.ping(peer, pingDelay, blockTimeLookup, forcePing);
                     } catch (error) {
                         unresponsivePeers++;
 
@@ -265,8 +274,7 @@ export class NetworkMonitor implements Contracts.P2P.NetworkMonitor {
 
     public async getNetworkState(log: boolean = true): Promise<Contracts.P2P.NetworkState> {
         await this.cleansePeers({ fast: true, forcePing: true, log });
-
-        return await NetworkState.analyze(this, this.repository);
+        return await NetworkState.analyze(this, this.repository, await this.getDelegatesOnThisNode());
     }
 
     public async refreshPeersAfterFork(): Promise<void> {
@@ -283,8 +291,41 @@ export class NetworkMonitor implements Contracts.P2P.NetworkMonitor {
             .get<Contracts.State.StateStore>(Container.Identifiers.StateStore)
             .getLastBlock();
 
-        const verificationResults: Contracts.P2P.PeerVerificationResult[] = this.repository
-            .getPeers()
+        const delegatesAndPeers: Contracts.P2P.Peer[] = [];
+        const peers: Contracts.P2P.Peer[] = this.repository.getPeers();
+
+        const milestone = Managers.configManager.getMilestone();
+        if (milestone.onlyActiveDelegatesInCalculations) {
+            const localPeer: Contracts.P2P.Peer = new Peer(
+                "127.0.0.1",
+                this.configuration.getRequired<number>("server.port"),
+            );
+            localPeer.publicKeys = await this.getDelegatesOnThisNode();
+            localPeer.verificationResult = new PeerVerificationResult(
+                lastBlock.data.height,
+                lastBlock.data.height,
+                lastBlock.data.height,
+            );
+
+            peers.forEach((peer) => {
+                peer.publicKeys = peer.publicKeys.filter((publicKey) => !localPeer.publicKeys.includes(publicKey));
+            });
+            peers.push(localPeer);
+
+            for (const peer of peers) {
+                if (peer.isActiveDelegate()) {
+                    for (let i = 0; i < peer.publicKeys.length; i++) {
+                        delegatesAndPeers.push(peer);
+                    }
+                } else if (peer.state && peer.state.height! >= lastBlock.data.height) {
+                    delegatesAndPeers.push(peer);
+                }
+            }
+        } else {
+            delegatesAndPeers.push(...peers);
+        }
+
+        const verificationResults: Contracts.P2P.PeerVerificationResult[] = delegatesAndPeers
             .filter((peer) => peer.verificationResult)
             .map((peer) => peer.verificationResult!);
 
@@ -306,8 +347,10 @@ export class NetworkMonitor implements Contracts.P2P.NetworkMonitor {
 
         for (const forkHeight of forkHeights) {
             const forkPeerCount = forkVerificationResults.filter((vr) => vr.highestCommonHeight === forkHeight).length;
-            const ourPeerCount = verificationResults.filter((vr) => vr.highestCommonHeight > forkHeight).length + 1;
-
+            let ourPeerCount = verificationResults.filter((vr) => vr.highestCommonHeight > forkHeight).length;
+            if (!milestone.onlyActiveDelegatesInCalculations) {
+                ourPeerCount++;
+            }
             if (forkPeerCount > ourPeerCount) {
                 const blocksToRollback = lastBlock.data.height - forkHeight;
 
@@ -563,6 +606,29 @@ export class NetworkMonitor implements Contracts.P2P.NetworkMonitor {
         } catch (error) {
             this.logger.error(`${error.message} :bangbang:`);
         }
+    }
+
+    private async getDelegatesOnThisNode(): Promise<string[]> {
+        const lastBlock: Interfaces.IBlock = this.app
+            .get<Contracts.State.StateStore>(Container.Identifiers.StateStore)
+            .getLastBlock();
+
+        const height = lastBlock.data.height + 1;
+        const roundInfo = Utils.roundCalculator.calculateRound(height);
+
+        const delegates = (await this.databaseInteraction.getActiveDelegates(roundInfo)).map(
+            (wallet: Contracts.State.Wallet) => wallet.getPublicKey(),
+        );
+        const delegatesOnThisNode: string[] = [];
+
+        for (const secret of this.app.config("delegates.secrets")) {
+            const keys: Interfaces.IKeyPair = Identities.Keys.fromPassphrase(secret);
+            if (delegates.includes(keys.publicKey)) {
+                delegatesOnThisNode.push(keys.publicKey);
+            }
+        }
+
+        return delegatesOnThisNode;
     }
 
     private async scheduleUpdateNetworkStatus(nextUpdateInSeconds): Promise<void> {

--- a/packages/core-p2p/src/peer-communicator.ts
+++ b/packages/core-p2p/src/peer-communicator.ts
@@ -308,12 +308,6 @@ export class PeerCommunicator implements Contracts.P2P.PeerCommunicator {
             this.logger.error(`Cannot validate reply from "${endpoint}": none of the predefined schemas matches :bangbang:`);
             return false;
         }
-        if (endpoint === "p2p.peer.getStatus") {
-            const milestone = Managers.configManager.getMilestone();
-
-            schema.properties.publicKeys.maxItems = milestone.activeDelegates;
-            schema.properties.signatures.maxItems = milestone.activeDelegates;
-        }
 
         const { error } = Validation.validator.validate(schema, reply);
         if (error) {

--- a/packages/core-p2p/src/peer.ts
+++ b/packages/core-p2p/src/peer.ts
@@ -34,10 +34,22 @@ export class Peer implements Contracts.P2P.Peer {
     public lastPinged: Dayjs | undefined;
 
     /**
+     * @type {(string[])}
+     * @memberof Peer
+     */
+     public publicKeys: string[] = [];
+
+    /**
      * @type {(number)}
      * @memberof Peer
      */
     public sequentialErrorCounter: number = 0;
+
+    /**
+     * @type {(string[])}
+     * @memberof Peer
+     */
+     public signatures: string[] = [];
 
     /**
      * @type {(PeerVerificationResult | undefined)}
@@ -92,6 +104,14 @@ export class Peer implements Contracts.P2P.Peer {
      */
     public isForked(): boolean {
         return !!(this.isVerified() && this.verificationResult && this.verificationResult.forked);
+    }
+
+    /**
+     * @returns {boolean}
+     * @memberof Peer
+     */
+     public isActiveDelegate(): boolean {
+        return this.publicKeys.length > 0;
     }
 
     /**

--- a/packages/core-p2p/src/schemas.ts
+++ b/packages/core-p2p/src/schemas.ts
@@ -1,4 +1,10 @@
+import { Managers } from "@arkecosystem/crypto";
+
 import { constants } from "./constants";
+
+const maxDelegates = Managers.configManager
+    .getMilestones()
+    .reduce((acc, curr) => Math.max(acc, curr.activeDelegates), 0);
 
 export const replySchemas = {
     "p2p.peer.getCommonBlocks": {
@@ -177,9 +183,8 @@ export const replySchemas = {
             },
             publicKeys: {
                 type: "array",
-                maxItems: 0, // set dynamically by milestone
-                items:
-                {
+                maxItems: maxDelegates,
+                items: {
                     allOf: [
                         {
                             $ref: "hex",
@@ -189,13 +194,12 @@ export const replySchemas = {
                             maxLength: 66,
                         },
                     ],
-                }
+                },
             },
             signatures: {
                 type: "array",
-                maxItems: 0, // set dynamically by milestone
-                items:
-                {
+                maxItems: maxDelegates,
+                items: {
                     allOf: [
                         {
                             $ref: "hex",
@@ -205,8 +209,8 @@ export const replySchemas = {
                             maxLength: 128,
                         },
                     ],
-                }
-            }
+                },
+            },
         },
     },
     "p2p.blocks.getBlocks": {

--- a/packages/core-p2p/src/schemas.ts
+++ b/packages/core-p2p/src/schemas.ts
@@ -55,7 +55,7 @@ export const replySchemas = {
     },
     "p2p.peer.getStatus": {
         type: "object",
-        required: ["state", "config"],
+        required: ["state", "config", "signatures"],
         additionalProperties: false,
         properties: {
             state: {
@@ -175,6 +175,38 @@ export const replySchemas = {
                     },
                 },
             },
+            publicKeys: {
+                type: "array",
+                maxItems: 0, // set dynamically by milestone
+                items:
+                {
+                    allOf: [
+                        {
+                            $ref: "hex",
+                        },
+                        {
+                            minLength: 66,
+                            maxLength: 66,
+                        },
+                    ],
+                }
+            },
+            signatures: {
+                type: "array",
+                maxItems: 0, // set dynamically by milestone
+                items:
+                {
+                    allOf: [
+                        {
+                            $ref: "hex",
+                        },
+                        {
+                            minLength: 128,
+                            maxLength: 128,
+                        },
+                    ],
+                }
+            }
         },
     },
     "p2p.blocks.getBlocks": {

--- a/packages/core-p2p/src/socket-server/codecs/peer.ts
+++ b/packages/core-p2p/src/socket-server/codecs/peer.ts
@@ -64,7 +64,9 @@ export const getStatus = {
                         totalFee,
                         reward,
                     }
-                }
+                },
+                publicKeys: decoded.publicKeys,
+                signatures: decoded.signatures
             } as Contracts.P2P.PeerPingResponse;
         },
     },

--- a/packages/core-p2p/src/socket-server/codecs/proto/peer.proto
+++ b/packages/core-p2p/src/socket-server/codecs/proto/peer.proto
@@ -85,4 +85,6 @@ message GetStatusResponse {
 
     State state = 1;
     Config config = 2;
+    repeated string publicKeys = 3;
+    repeated string signatures = 4;
 }

--- a/packages/core-p2p/src/socket-server/codecs/proto/protos.d.ts
+++ b/packages/core-p2p/src/socket-server/codecs/proto/protos.d.ts
@@ -1247,6 +1247,12 @@ export namespace peer {
 
         /** GetStatusResponse config */
         config?: (peer.GetStatusResponse.IConfig|null);
+
+        /** GetStatusResponse publicKeys */
+        publicKeys?: (string[]|null);
+
+        /** GetStatusResponse signatures */
+        signatures?: (string[]|null);
     }
 
     /** Represents a GetStatusResponse. */
@@ -1263,6 +1269,12 @@ export namespace peer {
 
         /** GetStatusResponse config. */
         public config?: (peer.GetStatusResponse.IConfig|null);
+
+        /** GetStatusResponse publicKeys. */
+        public publicKeys: string[];
+
+        /** GetStatusResponse signatures. */
+        public signatures: string[];
 
         /**
          * Creates a new GetStatusResponse instance using the specified properties.

--- a/packages/core-p2p/src/socket-server/codecs/proto/protos.js
+++ b/packages/core-p2p/src/socket-server/codecs/proto/protos.js
@@ -2911,6 +2911,8 @@ $root.peer = (function() {
          * @interface IGetStatusResponse
          * @property {peer.GetStatusResponse.IState|null} [state] GetStatusResponse state
          * @property {peer.GetStatusResponse.IConfig|null} [config] GetStatusResponse config
+         * @property {Array.<string>|null} [publicKeys] GetStatusResponse publicKeys
+         * @property {Array.<string>|null} [signatures] GetStatusResponse signatures
          */
 
         /**
@@ -2922,6 +2924,8 @@ $root.peer = (function() {
          * @param {peer.IGetStatusResponse=} [properties] Properties to set
          */
         function GetStatusResponse(properties) {
+            this.publicKeys = [];
+            this.signatures = [];
             if (properties)
                 for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
                     if (properties[keys[i]] != null)
@@ -2943,6 +2947,22 @@ $root.peer = (function() {
          * @instance
          */
         GetStatusResponse.prototype.config = null;
+
+        /**
+         * GetStatusResponse publicKeys.
+         * @member {Array.<string>} publicKeys
+         * @memberof peer.GetStatusResponse
+         * @instance
+         */
+        GetStatusResponse.prototype.publicKeys = $util.emptyArray;
+
+        /**
+         * GetStatusResponse signatures.
+         * @member {Array.<string>} signatures
+         * @memberof peer.GetStatusResponse
+         * @instance
+         */
+        GetStatusResponse.prototype.signatures = $util.emptyArray;
 
         /**
          * Creates a new GetStatusResponse instance using the specified properties.
@@ -2972,6 +2992,12 @@ $root.peer = (function() {
                 $root.peer.GetStatusResponse.State.encode(message.state, writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
             if (message.config != null && Object.hasOwnProperty.call(message, "config"))
                 $root.peer.GetStatusResponse.Config.encode(message.config, writer.uint32(/* id 2, wireType 2 =*/18).fork()).ldelim();
+            if (message.publicKeys != null && message.publicKeys.length)
+                for (var i = 0; i < message.publicKeys.length; ++i)
+                    writer.uint32(/* id 3, wireType 2 =*/26).string(message.publicKeys[i]);
+            if (message.signatures != null && message.signatures.length)
+                for (var i = 0; i < message.signatures.length; ++i)
+                    writer.uint32(/* id 4, wireType 2 =*/34).string(message.signatures[i]);
             return writer;
         };
 
@@ -3011,6 +3037,16 @@ $root.peer = (function() {
                     break;
                 case 2:
                     message.config = $root.peer.GetStatusResponse.Config.decode(reader, reader.uint32());
+                    break;
+                case 3:
+                    if (!(message.publicKeys && message.publicKeys.length))
+                        message.publicKeys = [];
+                    message.publicKeys.push(reader.string());
+                    break;
+                case 4:
+                    if (!(message.signatures && message.signatures.length))
+                        message.signatures = [];
+                    message.signatures.push(reader.string());
                     break;
                 default:
                     reader.skipType(tag & 7);
@@ -3057,6 +3093,20 @@ $root.peer = (function() {
                 if (error)
                     return "config." + error;
             }
+            if (message.publicKeys != null && message.hasOwnProperty("publicKeys")) {
+                if (!Array.isArray(message.publicKeys))
+                    return "publicKeys: array expected";
+                for (var i = 0; i < message.publicKeys.length; ++i)
+                    if (!$util.isString(message.publicKeys[i]))
+                        return "publicKeys: string[] expected";
+            }
+            if (message.signatures != null && message.hasOwnProperty("signatures")) {
+                if (!Array.isArray(message.signatures))
+                    return "signatures: array expected";
+                for (var i = 0; i < message.signatures.length; ++i)
+                    if (!$util.isString(message.signatures[i]))
+                        return "signatures: string[] expected";
+            }
             return null;
         };
 
@@ -3082,6 +3132,20 @@ $root.peer = (function() {
                     throw TypeError(".peer.GetStatusResponse.config: object expected");
                 message.config = $root.peer.GetStatusResponse.Config.fromObject(object.config);
             }
+            if (object.publicKeys) {
+                if (!Array.isArray(object.publicKeys))
+                    throw TypeError(".peer.GetStatusResponse.publicKeys: array expected");
+                message.publicKeys = [];
+                for (var i = 0; i < object.publicKeys.length; ++i)
+                    message.publicKeys[i] = String(object.publicKeys[i]);
+            }
+            if (object.signatures) {
+                if (!Array.isArray(object.signatures))
+                    throw TypeError(".peer.GetStatusResponse.signatures: array expected");
+                message.signatures = [];
+                for (var i = 0; i < object.signatures.length; ++i)
+                    message.signatures[i] = String(object.signatures[i]);
+            }
             return message;
         };
 
@@ -3098,6 +3162,10 @@ $root.peer = (function() {
             if (!options)
                 options = {};
             var object = {};
+            if (options.arrays || options.defaults) {
+                object.publicKeys = [];
+                object.signatures = [];
+            }
             if (options.defaults) {
                 object.state = null;
                 object.config = null;
@@ -3106,6 +3174,16 @@ $root.peer = (function() {
                 object.state = $root.peer.GetStatusResponse.State.toObject(message.state, options);
             if (message.config != null && message.hasOwnProperty("config"))
                 object.config = $root.peer.GetStatusResponse.Config.toObject(message.config, options);
+            if (message.publicKeys && message.publicKeys.length) {
+                object.publicKeys = [];
+                for (var j = 0; j < message.publicKeys.length; ++j)
+                    object.publicKeys[j] = message.publicKeys[j];
+            }
+            if (message.signatures && message.signatures.length) {
+                object.signatures = [];
+                for (var j = 0; j < message.signatures.length; ++j)
+                    object.signatures[j] = message.signatures[j];
+            }
             return object;
         };
 

--- a/packages/core-p2p/src/socket-server/controllers/peer.ts
+++ b/packages/core-p2p/src/socket-server/controllers/peer.ts
@@ -1,6 +1,6 @@
-import { Container, Contracts, Utils } from "@arkecosystem/core-kernel";
-import { DatabaseInterceptor } from "@arkecosystem/core-state";
-import { Crypto, Interfaces } from "@arkecosystem/crypto";
+import { Container, Contracts, Utils as AppUtils } from "@arkecosystem/core-kernel";
+import { DatabaseInteraction, DatabaseInterceptor } from "@arkecosystem/core-state";
+import { Crypto, Identities, Interfaces } from "@arkecosystem/crypto";
 import Hapi from "@hapi/hapi";
 
 import { constants } from "../../constants";
@@ -13,11 +13,16 @@ export class PeerController extends Controller {
     @Container.inject(Container.Identifiers.PeerRepository)
     private readonly peerRepository!: Contracts.P2P.PeerRepository;
 
+    @Container.inject(Container.Identifiers.DatabaseInteraction)
+    private readonly databaseInteraction!: DatabaseInteraction;
+
     @Container.inject(Container.Identifiers.DatabaseInterceptor)
     private readonly databaseInterceptor!: DatabaseInterceptor;
 
     @Container.inject(Container.Identifiers.BlockchainService)
     private readonly blockchain!: Contracts.Blockchain.Blockchain;
+
+    private cachedHeader: Contracts.P2P.PeerPingResponse | undefined;
 
     public getPeers(request: Hapi.Request, h: Hapi.ResponseToolkit): Contracts.P2P.PeerBroadcast[] {
         const peerIp = getPeerIp(request.socket);
@@ -27,8 +32,8 @@ export class PeerController extends Controller {
             .filter((peer) => peer.ip !== peerIp)
             .filter((peer) => peer.port !== -1)
             .sort((a, b) => {
-                Utils.assert.defined<number>(a.latency);
-                Utils.assert.defined<number>(b.latency);
+                AppUtils.assert.defined<number>(a.latency);
+                AppUtils.assert.defined<number>(b.latency);
 
                 return a.latency - b.latency;
             })
@@ -60,10 +65,22 @@ export class PeerController extends Controller {
     public async getStatus(request: Hapi.Request, h: Hapi.ResponseToolkit): Promise<Contracts.P2P.PeerPingResponse> {
         const lastBlock: Interfaces.IBlock = this.blockchain.getLastBlock();
 
-        const blockTimeLookup = await Utils.forgingInfoCalculator.getBlockTimeLookup(this.app, lastBlock.data.height);
+        const blockTimeLookup = await AppUtils.forgingInfoCalculator.getBlockTimeLookup(
+            this.app,
+            lastBlock.data.height,
+        );
         const slotInfo = Crypto.Slots.getSlotInfo(blockTimeLookup);
 
-        return {
+        if (
+            this.cachedHeader &&
+            this.cachedHeader.state.header.id === lastBlock.data.id &&
+            this.cachedHeader.state.forgingAllowed === slotInfo.forgingStatus &&
+            this.cachedHeader.state.currentSlot === slotInfo.slotNumber
+        ) {
+            return this.cachedHeader;
+        }
+
+        const header: Contracts.P2P.PeerPingResponse = {
             state: {
                 height: lastBlock.data.height,
                 forgingAllowed: slotInfo.forgingStatus,
@@ -72,5 +89,29 @@ export class PeerController extends Controller {
             },
             config: getPeerConfig(this.app),
         };
+
+        const stateBuffer = Buffer.from(AppUtils.stringify(header));
+
+        header.publicKeys = [];
+        header.signatures = [];
+
+        const height = lastBlock.data.height + 1;
+        const roundInfo = AppUtils.roundCalculator.calculateRound(height);
+
+        const delegates = (await this.databaseInteraction.getActiveDelegates(roundInfo)).map(
+            (wallet: Contracts.State.Wallet) => wallet.getPublicKey(),
+        );
+
+        for (const secret of this.app.config("delegates.secrets")) {
+            const keys: Interfaces.IKeyPair = Identities.Keys.fromPassphrase(secret);
+            if (delegates.includes(keys.publicKey)) {
+                header.publicKeys.push(keys.publicKey);
+                header.signatures.push(Crypto.Hash.signSchnorr(stateBuffer, keys));
+            }
+        }
+
+        this.cachedHeader = header;
+
+        return header;
     }
 }


### PR DESCRIPTION
Core calculates network quorum (used for consensus) and general network health (used for determining rollbacks) by analysing the state of the entire network; that is, all nodes, whether they are active delegates, inactive delegates, former delegates or just relays.

This PR revises that behaviour to only consider the responses of active delegates in most of these cases in order to ensure that only active delegates elected to control the network can influence these important calculations which can have significant impacts on the network going forward. In the case of network quorum, only the responses of active delegates are considered. In the case of analysing network health for determining rollbacks, we will accept state data from active delegates or other relays, but in the latter case, we only consider them if their nodes are at a cryptographically verified higher or equal height than us.

To do this, the `p2p.peer.getStatus` response is now signed if the peer has one or more passphrases in their `delegates.json` file. For each public key that corresponds to an active delegate in the current round, their weight is equal to 1. That is to say, if two delegates are forging on the same node, their weight in quorum and analysis is 2, since two delegates should have twice the network influence as one delegate. The entire response is signed, including the `currentSlot` value which must be the same as our own slot in order to be considered. This prevents the replaying of stale signed states by malicious users. The response generation for this endpoint is now also cached to prevent needless expensive cryptographic signing routines.

It is activated by milestone, and once active, the quorum threshold will change from a fixed 66% to a variable amount depending on the number of delegates we are peering with. In the case that we are connected to all delegates, at least 50.1% of them (including our own delegates) must agree with our state in order to forge. If we are not connected to all delegates for any reason, this percentage required to agree with us will rise incrementally. There will be a minimum requirement of 50%+1 delegates that must be responding, and in such a scenario, 100% of delegates must agree with our state.

It also considers the possibility that there could be multiple nodes online for the same delegate for whatever reason (e.g. if a backup relay is running with the passphrase in `delegates.json` even if the forger process is offline), and therefore only considers one node per delegate. Which node it considers depends on set criteria and it will always try to pick the node whose state matches ours. If that is not possible, it will try to find one that isn't forked and at a higher or equal height to us, and failing that, it will take whichever other node it finds, whether forked or not.

With this change, it is perhaps apparent that by recording the responses from this endpoint from different nodes it is possible to identify forging node IP addresses and who they belong to, but this information is ordinarily available via log file analysis anyway due to the way block propagation works and most threats can be mitigated by suitably configuring a firewall (such as by using the iptables scripts provided in the `scripts` directory of Core). It is considered that the advantages of this change, which close multiple known exploitable attack vectors, are worth the perceived reduced anonymity although the reality is that they were never anonymous to begin with.

It is also worth mentioning that the consensus mechanism of Core is inherently flawed and while these changes go some way to improving some of its weaknesses, it is not a solution for block finality. For that, another PR will be published in due course.

_Although this PR has been tested in private, it is considered experimental and unstable until further public testing has taken place on the Solar Development Network, therefore it may be subject to future changes or it could be reverted entirely pending the outcome of those tests which can only take place once this has been merged, released and widely tested._