### PR TITLE
fix(core-cli): stop repeating messages and change verbosity

### DIFF
--- a/packages/core-cli/src/commands/command.ts
+++ b/packages/core-cli/src/commands/command.ts
@@ -1,4 +1,3 @@
-import envPaths from "env-paths";
 import { PackageJson } from "type-fest";
 
 import { ActionFactory } from "../action-factory";
@@ -12,7 +11,6 @@ import { Output } from "../output";
 import { Config, Environment } from "../services";
 import { CommandHelp } from "./command-help";
 import { DiscoverConfig } from "./discover-config";
-import { DiscoverNetwork } from "./discover-network";
 
 /**
  * @export
@@ -207,7 +205,9 @@ export abstract class Command {
 
             await this.execute();
         } catch (error) {
-            this.components.fatal(error.message);
+            if (error.name !== "FatalException") {
+                this.components.fatal(error.message);
+            }
         }
     }
 
@@ -307,17 +307,8 @@ export abstract class Command {
      * @memberof Command
      */
     private async detectNetwork(): Promise<void> {
-        const requiresNetwork: boolean = Object.keys(this.definition.getFlags()).includes("network");
-
-        if (requiresNetwork && !this.input.hasFlag("network")) {
-            this.input.setFlag(
-                "network",
-                await this.app.resolve(DiscoverNetwork).discover(
-                    envPaths(this.input.getFlag("token"), {
-                        suffix: "core",
-                    }).config,
-                ),
-            );
+        if (!this.input.hasFlag("network")) {
+            throw new Error("You'll need to confirm the network to continue");
         }
     }
 

--- a/packages/core-cli/src/commands/command.ts
+++ b/packages/core-cli/src/commands/command.ts
@@ -146,9 +146,19 @@ export abstract class Command {
             this.input.bind();
             this.input.validate();
 
-            this.input.hasFlag("quiet")
-                ? this.output.setVerbosity(0)
-                : this.output.setVerbosity(this.input.getFlag("v") || 1);
+            if (this.input.hasFlag("quiet")) {
+                this.output.setVerbosity(0);
+            } else {
+                if (this.input.hasFlag("v")) {
+                    if (this.input.getFlag("v") === true) {
+                        this.output.setVerbosity(2);
+                    } else {
+                        this.output.setVerbosity(3);
+                    }
+                } else {
+                    this.output.setVerbosity(1);
+                }
+            }
         } catch (error) {
             this.components.fatal(error.message);
         }

--- a/packages/core-cli/src/input/parser.ts
+++ b/packages/core-cli/src/input/parser.ts
@@ -12,7 +12,7 @@ export class InputParser {
      * @memberof InputParser
      */
     public static parseArgv(args: string[]) {
-        const parsed: yargs.Arguments = yargs(args, { count: ["v"] });
+        const parsed: yargs.Arguments = yargs(args, { count: [] });
 
         const argv: string[] = parsed._;
 

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -141,6 +141,7 @@ export class CommandLineInterface {
                     suffix: "core",
                 }).config,
             );
+            this.argv.push(`--network=${tempFlags.network}`);
         } catch {}
 
         return tempFlags;

--- a/packages/core/src/commands/help.ts
+++ b/packages/core/src/commands/help.ts
@@ -79,11 +79,11 @@ ${blue().bold("Usage")}
   command [arguments] [flags]
 
 ${blue().bold("Flags")}
-  --help              Display the corresponding help message
-  --quiet             Do not output any message
+  --help                   Display the corresponding help message
+  --quiet                  Do not output any message
 
 ${blue().bold("Arguments")}
-  -v|vv|vvv          Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
+  -v|vv                    Increase verbosity of messages: 1 for verbose output and 2 for debug
 
 ${blue().bold("Available Commands")}
 ${commandsAsString.join("\n")}`,


### PR DESCRIPTION
For some inexplicable reason, setting the verbose flag `-v` in the CLI does nothing, and keeps logging at a normal level. To enable verbose mode, it requires `-vv`, and for debug logging, `-vvv`. This makes `-v` entirely redundant, so we change this so `-v` enables verbose mode and `-vv` enables debug mode.

In addition, in the case of certain errors and prompts, the CLI prints the same error or asks the same prompt twice. This annoying behaviour has been refactored away to remove this repetition.