### PR TITLE
feat(core-cli): more informative update and reinstall

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -43,6 +43,7 @@
         "@typescript-eslint/unbound-method": "off",
         "jest/no-standalone-expect": "off",
         "no-async-promise-executor": "off",
+        "no-control-regex": "off",
         "no-empty": "off",
         "no-inferrable-types": "off",
         "no-prototype-builtins": "off",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "description": "The packages that make up the Solar Core",
     "scripts": {
         "lerna": "node ./node_modules/lerna/cli.js",
+        "lerna:verbose": "node ./node_modules/lerna/cli.js --loglevel=3 --concurrency=1",
         "setup": "yarn --force && yarn bootstrap && yarn build",
         "setup:clean": "yarn --force && yarn clean && yarn bootstrap && yarn build",
         "bootstrap": "yarn lerna bootstrap",

--- a/packages/core-cli/package.json
+++ b/packages/core-cli/package.json
@@ -38,6 +38,7 @@
         "kleur": "4.0.0",
         "latest-version": "5.1.0",
         "listr": "0.14.3",
+        "node-pty": "0.10.1",
         "nodejs-tail": "1.1.1",
         "ora": "4.1.1",
         "prompts": "2.4.0",

--- a/packages/core-cli/src/components/spinner.ts
+++ b/packages/core-cli/src/components/spinner.ts
@@ -14,7 +14,13 @@ export class Spinner {
      * @returns {Ora}
      * @memberof Spinner
      */
+
+    private ora!: Ora;
+    public get(): Ora {
+        return this.ora;
+    }
     public render(options?: string | Options | undefined): Ora {
-        return ora(options);
+        this.ora = ora(options);
+        return this.ora;
     }
 }

--- a/packages/core-cli/src/services/installer.ts
+++ b/packages/core-cli/src/services/installer.ts
@@ -1,6 +1,11 @@
+import Listr, { ListrTaskWrapper } from "listr";
 import { sync } from "execa";
+import { spawn } from "node-pty";
 
-import { injectable } from "../ioc";
+import { Application } from "../application";
+import { Spinner, TaskList } from "../components";
+import { Identifiers, inject, injectable } from "../ioc";
+import { Output } from "../output";
 
 /**
  * @export
@@ -8,26 +13,240 @@ import { injectable } from "../ioc";
  */
 @injectable()
 export class Installer {
+    @inject(Identifiers.Application)
+    private readonly app!: Application;
+
+    @inject(Identifiers.Output)
+    private readonly output!: Output;
+
     /**
      * @param {string} pkg
      * @memberof Installer
      */
-    public install(pkg: string, tag: string = "latest"): void {
+    public async install(pkg: string, tag: string = "latest"): Promise<void> {
         const coreDirectory = __dirname + "/../../../../";
 
-        const getLastTag = (regex) => `\`git tag --sort=committerdate | grep -Px ${regex} | tail -1\``;
-        let gitTag = tag;
+        const getLastTag = (regex) => `git tag --sort=committerdate | grep -Px ${regex} | tail -1`;
+        let gitTag: string = tag;
+        let tagFromRegex!: string;
+
+        let version:string = tag;
+
         if (tag === "latest") {
-            gitTag = getLastTag('"^\\d+.\\d+.\\d+"');
+            tagFromRegex = getLastTag('"^\\d+.\\d+.\\d+"');
+            gitTag = "`" + tagFromRegex + "`";
         } else if (tag === "next") {
-            gitTag = getLastTag('"^\\d+.\\d+.\\d+-next.\\d+"');
+            tagFromRegex = getLastTag('"^\\d+.\\d+.\\d+-next.\\d+"');
+            gitTag = "`" + tagFromRegex + "`";
         }
 
-        const command = `cd ${coreDirectory} && git tag -l | xargs git tag -d && git fetch --all --tags -f && rm -f node_modules/better-sqlite3/build/Release/better_sqlite3.node && git reset --hard && git checkout tags/${gitTag} && yarn cache clean && yarn setup`;
-        const { stderr, exitCode } = sync(command, { shell: true });
+        if (tagFromRegex) {
+            version = sync(tagFromRegex, { cwd: coreDirectory, shell: true }).stdout;
+        }
 
-        if (exitCode !== 0) {
-            throw new Error(`"${command}" exited with code ${exitCode}\n${stderr}`);
+        let currentTask: ListrTaskWrapper;
+        let errorMessage!: string;
+        let log = "";
+        const packages = { building: 0, total: 0 };
+        let phase = 0;
+        const phaseComplete: {
+            promise: Promise<void>;
+            reject: (value: void) => void;
+            resolve: (value: void) => void;
+        }[] = [];
+
+        const nextPhase = () => {
+            phaseComplete[phase].resolve();
+            phase++;
+        };
+
+        for (let i = 0; i < 5; i++) {
+            let rejecter!: (value: void) => void;
+            let resolver!: (value: void) => void;
+            phaseComplete.push({
+                promise: new Promise<void>((resolve, reject) => {
+                    (rejecter = reject), (resolver = resolve);
+                }).catch(() => {}),
+                reject: rejecter,
+                resolve: resolver,
+            });
+        }
+
+        const shell = spawn(
+            "sh",
+            [
+                "-c",
+                `( git tag -l | xargs git tag -d && git fetch --all --tags -f && rm -f node_modules/better-sqlite3/build/Release/better_sqlite3.node && git reset --hard && git checkout tags/${gitTag} && yarn --force && yarn lerna:verbose run build && cd node_modules/better-sqlite3 && npm rebuild && exit 0 ) || exit $?`,
+            ],
+            { cwd: coreDirectory },
+        );
+        const shellExit = new Promise<void>((resolve, reject) => {
+            shell.onExit(({ exitCode }) => {
+                if (exitCode === 0) {
+                    if (phase === 4) {
+                        nextPhase();
+                    }
+                    resolve();
+                } else {
+                    reject(`Process failed with error code ${exitCode}`);
+                }
+            });
+        }).catch((error) => {
+            if (this.output.isNormal()) {
+                errorMessage = `The process did not complete successfully:\n${log}\n${error}`;
+            } else {
+                errorMessage = error;
+            }
+            for (const phase of phaseComplete) {
+                phase.reject();
+            }
+        });
+
+        shell.onData((data) => {
+            if (this.output.isNormal()) {
+                log += data;
+                const output = data
+                    .replace(/[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g, "")
+                    .trim()
+                    .split("\n");
+                for (const line of output) {
+                    switch (phase) {
+                        case 0: {
+                            if (line.includes("yarn install")) {
+                                nextPhase();
+                            }
+                            break;
+                        }
+                        case 1: {
+                            if (line.includes("]")) {
+                                const progress = line
+                                    .substring(line.indexOf("]") + 1)
+                                    .trim()
+                                    .split("/");
+                                if (!isNaN(+progress[0]) && !isNaN(+progress[1])) {
+                                    currentTask.title = `Fetching dependencies (${progress[0]} of ${progress[1]})`;
+                                }
+                            }
+                            if (line.includes("Linking dependencies...")) {
+                                currentTask.title = "Fetching dependencies";
+                                nextPhase();
+                            }
+                            break;
+                        }
+                        case 2: {
+                            if (line.includes("]")) {
+                                const progress = line
+                                    .substring(line.indexOf("]") + 1)
+                                    .trim()
+                                    .split("/");
+                                if (!isNaN(+progress[0]) && !isNaN(+progress[1])) {
+                                    currentTask.title = `Linking dependencies (${progress[0]} of ${progress[1]})`;
+                                }
+                            }
+                            if (
+                                line.includes("Rebuilding all packages...") ||
+                                line.includes("Building fresh packages...")
+                            ) {
+                                currentTask.title = "Linking dependencies";
+                                nextPhase();
+                            }
+                            break;
+                        }
+                        case 3: {
+                            if (line.includes("]")) {
+                                const dependencyName = line.substring(line.lastIndexOf(" ") + 1);
+                                const progress = line.substring(1, line.indexOf("]")).trim().split("/");
+                                if (!isNaN(+progress[0]) && !isNaN(+progress[1])) {
+                                    currentTask.title = `Building dependencies (${progress[0]} of ${progress[1]}: ${dependencyName})`;
+                                }
+                            }
+                            if (line.includes("Done in")) {
+                                currentTask.title = "Building dependencies";
+                                nextPhase();
+                            }
+                            break;
+                        }
+                        case 4: {
+                            if (line.includes("Executing command in")) {
+                                packages.total = +line
+                                    .substring(line.indexOf("Executing command in") + 21)
+                                    .split(" ")[0];
+                            }
+                            if (line.includes("build []")) {
+                                const packageName = line.substring(line.lastIndexOf(" ") + 1).trim();
+                                packages.building++;
+                                currentTask.title = `Installing Core packages (${packages.building} of ${packages.total}: ${packageName})`;
+                            }
+                        }
+                    }
+                }
+            } else {
+                process.stdout.write(data);
+            }
+        });
+        const tasks = [
+            {
+                title: `Downloading Core ${version}`,
+                task: async (ctx, task) => {
+                    currentTask = task;
+                    await phaseComplete[0].promise;
+                },
+            },
+            {
+                title: `Preparing to build Core ${version}`,
+                task: () => {
+                    return new Listr([
+                        {
+                            title: "Fetching dependencies",
+                            task: async (ctx, task) => {
+                                currentTask = task;
+                                await phaseComplete[1].promise;
+                            },
+                        },
+                        {
+                            title: "Linking dependencies",
+                            task: async (ctx, task) => {
+                                currentTask = task;
+                                await phaseComplete[2].promise;
+                            },
+                        },
+                        {
+                            title: "Building dependencies",
+                            task: async (ctx, task) => {
+                                currentTask = task;
+                                await phaseComplete[3].promise;
+                            },
+                        },
+                    ]);
+                },
+            },
+            {
+                title: `Building Core ${version}`,
+                task: async () => {
+                    return new Listr([
+                        {
+                            title: `Installing Core packages`,
+                            task: async (ctx, task) => {
+                                currentTask = task;
+                                await phaseComplete[4].promise;
+                                task.title = "Installing Core packages";
+                            },
+                        },
+                    ]);
+                },
+            },
+        ];
+
+        this.app.get<Spinner>(Identifiers.Spinner).get().stop();
+
+        if (this.output.isNormal()) {
+            await this.app.get<TaskList>(Identifiers.TaskList).render(tasks);
+        }
+
+        await shellExit;
+
+        if (errorMessage) {
+            throw new Error(errorMessage);
         }
     }
 }

--- a/packages/core-cli/src/services/updater.ts
+++ b/packages/core-cli/src/services/updater.ts
@@ -118,7 +118,7 @@ export class Updater implements Contracts.Updater {
         spinner.start();
 
         try {
-            this.installer.install(this.packageName, this.packageChannel);
+            await this.installer.install(this.packageName, this.packageChannel);
 
             if (updateProcessManager) {
                 this.processManager.update();

--- a/packages/core/src/commands/config-cli.ts
+++ b/packages/core/src/commands/config-cli.ts
@@ -82,7 +82,7 @@ export class Command extends Commands.Command {
             spinner.start();
 
             try {
-                this.installer.install(this.pkg.name!, newChannel);
+                await this.installer.install(this.pkg.name!, newChannel);
 
                 spinner.succeed();
 

--- a/packages/core/src/commands/reinstall.ts
+++ b/packages/core/src/commands/reinstall.ts
@@ -83,7 +83,7 @@ export class Command extends Commands.Command {
         spinner.start();
 
         try {
-            this.installer.install(this.pkg.name!, this.pkg.version!);
+            await this.installer.install(this.pkg.name!, this.pkg.version!);
 
             this.processManager.update();
 


### PR DESCRIPTION
This PR gives users more information during the reinstallation and update process of Core.

Previously, there would be one message printed at the start of the process, then nothing until the end. This meant the user was not aware of its progress and could think it had crashed.

This PR adds extra logging to keep the user informed throughout the process. Here is an example of how the logging looks during an update now:

```
✔ Update available 3.1.1-next.3  →  3.1.1-next.4. Would you like to update? … yes
  ✔ Downloading Core 3.1.1-next.4
  ❯ Preparing to build Core 3.1.1-next.4
    ✔ Fetching dependencies
    ✔ Linking dependencies
    ⠦ Building dependencies (3 of 18: bcrypto)
    Building Core 3.1.1-next.4
```

This PR also introduces an alternative logging method when running in verbose mode. In that mode, instead of the above, the user sees the output from the various `git` and `yarn` commands in real time, as they execute.