### PR TITLE
refactor(core-cli): print outcome of plugin manager action

### DIFF
--- a/packages/core-cli/src/services/plugin-manager.ts
+++ b/packages/core-cli/src/services/plugin-manager.ts
@@ -42,7 +42,10 @@ export class PluginManager implements Contracts.PluginManager {
             });
 
             if (await source.exists(pkg, version)) {
-                return source.install(pkg, version);
+                console.log(`Installing ${pkg} from ${source.constructor.name.toLowerCase()}...`)
+                await source.install(pkg, version);
+                console.log("Installation complete!");
+                return;
             }
         }
 
@@ -61,10 +64,13 @@ export class PluginManager implements Contracts.PluginManager {
         }
 
         if (existsSync(`${directory}/.git`)) {
-            return new Git(paths).update(pkg);
+            console.log(`Updating ${pkg} from git...`)
+            await new Git(paths).update(pkg);
+        } else {
+            console.log(`Updating ${pkg} from npm...`)
+            await new NPM(paths).update(pkg);
         }
-
-        return new NPM(paths).update(pkg);
+        console.log("Update complete!");
     }
 
     public async remove(token: string, network: string, pkg): Promise<void> {
@@ -74,7 +80,9 @@ export class PluginManager implements Contracts.PluginManager {
             throw new Error(`The package [${pkg}] does not exist`);
         }
 
+        console.log(`Removing ${pkg}...`)
         removeSync(directory);
+        console.log("Removal complete!");
     }
 
     private getPluginsPath(token: string, network: string): string {

--- a/packages/core-cli/src/services/source-providers/abstract-source.ts
+++ b/packages/core-cli/src/services/source-providers/abstract-source.ts
@@ -34,7 +34,12 @@ export abstract class AbstractSource implements Source {
     }
 
     protected async installDependencies(packageName: string): Promise<void> {
-        execa.sync(`yarn`, ["install", "--production"], { cwd: this.getDestPath(packageName) });
+        const subprocess = execa(`yarn`, ["install", "--production"], { cwd: this.getDestPath(packageName) });
+        if (process.argv.includes("-v") || process.argv.includes("-vv")) {
+            subprocess.stdout!.pipe(process.stdout);
+            subprocess.stderr!.pipe(process.stderr);
+        }
+        await subprocess;
     }
 
     protected getOriginPath(): string {

--- a/packages/core-cli/src/services/source-providers/git.ts
+++ b/packages/core-cli/src/services/source-providers/git.ts
@@ -35,13 +35,29 @@ export class Git extends AbstractSource {
     public async update(value: string): Promise<void> {
         const dest = this.getDestPath(value);
 
-        execa.sync(`git`, ["reset", "--hard"], { cwd: dest });
-        execa.sync(`git`, ["pull"], { cwd: dest });
+        let subprocess = execa(`git`, ["reset", "--hard"], { cwd: dest });
+        if (process.argv.includes("-v") || process.argv.includes("-vv")) {
+            subprocess.stdout!.pipe(process.stdout);
+            subprocess.stderr!.pipe(process.stderr);
+        }
+        await subprocess;
+
+        subprocess = execa(`git`, ["pull"], { cwd: dest });
+        if (process.argv.includes("-v") || process.argv.includes("-vv")) {
+            subprocess.stdout!.pipe(process.stdout);
+            subprocess.stderr!.pipe(process.stderr);
+        }
+        await subprocess;
 
         await this.installDependencies(value);
     }
 
     protected async preparePackage(value: string): Promise<void> {
-        execa.sync(`git`, ["clone", value, this.getOriginPath()]);
+        const subprocess = execa(`git`, ["clone", value, this.getOriginPath()]);
+        if (process.argv.includes("-v") || process.argv.includes("-vv")) {
+            subprocess.stdout!.pipe(process.stdout);
+            subprocess.stderr!.pipe(process.stderr);
+        }
+        await subprocess;
     }
 }


### PR DESCRIPTION
The CLI does not output anything during a `plugin:install`, `plugin:update` or `plugin:remove` operation unless it throws an error.

This has been a source of confusion for several users when installing plugins, so this PR adds basic output to at least tell the user that an operation is in progress, and also prints a message when it has finished.

It now also prints the raw logs from `yarn` and `git` if the command is executed in verbose mode.