### PR TITLE
refactor(core-blockchain): keep downloading until new block received

### DIFF
--- a/packages/core-blockchain/src/state-machine/actions/check-later.ts
+++ b/packages/core-blockchain/src/state-machine/actions/check-later.ts
@@ -1,4 +1,5 @@
-import { Container, Contracts } from "@arkecosystem/core-kernel";
+import { Container, Contracts, Enums, Utils as AppUtils } from "@arkecosystem/core-kernel";
+import { Utils } from "@arkecosystem/crypto";
 
 import { Action } from "../contracts";
 
@@ -10,11 +11,90 @@ export class CheckLater implements Action {
     @Container.inject(Container.Identifiers.BlockchainService)
     private readonly blockchain!: Contracts.Blockchain.Blockchain;
 
+    @Container.inject(Container.Identifiers.EventDispatcherService)
+    private readonly events!: Contracts.Kernel.EventDispatcher;
+
+    @Container.inject(Container.Identifiers.LogService)
+    private readonly logger!: Contracts.Kernel.Logger;
+
+    @Container.inject(Container.Identifiers.PeerNetworkMonitor)
+    private readonly peerNetworkMonitor!: Contracts.P2P.NetworkMonitor;
+
     @Container.inject(Container.Identifiers.StateStore)
     private readonly stateStore!: Contracts.State.StateStore;
 
+    @Container.inject(Container.Identifiers.WalletRepository)
+    @Container.tagged("state", "blockchain")
+    private readonly walletRepository!: Contracts.State.WalletRepository;
+
     public async handle(): Promise<void> {
         if (!this.blockchain.isStopped() && !this.stateStore.isWakeUpTimeoutSet()) {
+            const downloadInterval = setInterval(async () => {
+                try {
+                    let lastBlock = this.app
+                        .get<Contracts.State.StateStore>(Container.Identifiers.StateStore)
+                        .getLastBlock();
+                    let blocks = await this.peerNetworkMonitor.downloadBlocksFromHeight(
+                        lastBlock.data.height,
+                        undefined,
+                        true,
+                        2000,
+                    );
+                    lastBlock = this.app
+                        .get<Contracts.State.StateStore>(Container.Identifiers.StateStore)
+                        .getLastBlock();
+                    blocks = blocks.filter((block) => block.height > lastBlock.data.height);
+                    if (blocks.length) {
+                        if (blocks.length === 1) {
+                            const generatorWallet: Contracts.State.Wallet = this.walletRepository.findByPublicKey(
+                                blocks[0].generatorPublicKey,
+                            );
+
+                            let generator: string;
+                            try {
+                                generator = `delegate ${generatorWallet.getAttribute(
+                                    "delegate.username",
+                                )} (#${generatorWallet.getAttribute("delegate.rank")})`;
+                            } catch {
+                                generator = "an unknown delegate";
+                            }
+
+                            this.logger.info(
+                                `Downloaded new block forged by ${generator} at height ${blocks[0].height.toLocaleString()} with ${Utils.formatSatoshi(
+                                    blocks[0].reward,
+                                )} reward :package:`,
+                            );
+
+                            this.logger.debug(`The id of the new block is ${blocks[0].id}`);
+
+                            this.logger.debug(
+                                `It contains ${AppUtils.pluralize(
+                                    "transaction",
+                                    blocks[0].numberOfTransactions,
+                                    true,
+                                )} and was downloaded from ${blocks[0].ip}`,
+                            );
+
+                            this.blockchain.handleIncomingBlock(blocks[0], false, false);
+                        } else {
+                            this.blockchain.enqueueBlocks(blocks);
+                            this.blockchain.dispatch("DOWNLOADED");
+                        }
+                    }
+                } catch {
+                    //
+                }
+            }, 500);
+
+            const stopDownloading = {
+                handle: () => {
+                    this.events.forget(Enums.BlockEvent.Received, stopDownloading);
+                    clearInterval(downloadInterval);
+                },
+            };
+
+            this.events.listen(Enums.BlockEvent.Received, stopDownloading);
+
             this.blockchain.setWakeUp();
         }
     }

--- a/packages/core-kernel/src/contracts/blockchain/blockchain.ts
+++ b/packages/core-kernel/src/contracts/blockchain/blockchain.ts
@@ -49,7 +49,7 @@ export interface Blockchain {
     /**
      * Push a block to the process queue.
      */
-    handleIncomingBlock(block: Interfaces.IBlockData, fromForger): void;
+    handleIncomingBlock(block: Interfaces.IBlockData, fromForger: boolean, fireBlockReceivedEvent?: boolean): void;
 
     enqueueBlocks(blocks: Interfaces.IBlockData[]);
 

--- a/packages/core-kernel/src/contracts/p2p/network-monitor.ts
+++ b/packages/core-kernel/src/contracts/p2p/network-monitor.ts
@@ -31,7 +31,12 @@ export interface NetworkMonitor {
     getNetworkState(log?: boolean): Promise<NetworkState>;
     refreshPeersAfterFork(): Promise<void>;
     checkNetworkHealth(): Promise<NetworkStatus>;
-    downloadBlocksFromHeight(fromBlockHeight: number, maxParallelDownloads?: number): Promise<Interfaces.IBlockData[]>;
+    downloadBlocksFromHeight(
+        fromBlockHeight: number,
+        maxParallelDownloads?: number,
+        silent?: boolean,
+        timeout?: number,
+    ): Promise<Interfaces.IBlockData[]>;
     broadcastBlock(block: Interfaces.IBlock): Promise<void>;
     isColdStart(): boolean;
     completeColdStart(): void;

--- a/packages/crypto/src/interfaces/block.ts
+++ b/packages/crypto/src/interfaces/block.ts
@@ -42,6 +42,7 @@ export interface IBlockData {
     blockSignature?: string;
     serialized?: string;
     transactions?: ITransactionData[];
+    ip?: string;
 }
 
 export interface IBlockJson {


### PR DESCRIPTION
Core has an issue where we might not receive blocks in real time for one minute after starting. This happens because although our node syncs on startup by downloading blocks to catch up, another block is sent after that period which we don't catch. And since we don't have that block, we can't receive the subsequent ones either because they are not chained. This means we end up waiting 60 seconds for the wakeup routine to download those blocks before we finally start receiving blocks properly.

Now we automatically keep polling peers for the blocks that we don't have after syncing, so we should start receiving blocks in real time straight away. The polling stops when we eventually receive a block by the normal method.