### PR TITLE
feat: fees by consensus

### DIFF
--- a/packages/core-kernel/src/contracts/shared/dynamic-fee.ts
+++ b/packages/core-kernel/src/contracts/shared/dynamic-fee.ts
@@ -4,5 +4,4 @@ export interface DynamicFeeContext {
     transaction: Interfaces.ITransaction;
     addonBytes: number;
     satoshiPerByte: number;
-    height: number;
 }

--- a/packages/core-transaction-pool/src/dynamic-fee-matcher.ts
+++ b/packages/core-transaction-pool/src/dynamic-fee-matcher.ts
@@ -14,9 +14,6 @@ export class DynamicFeeMatcher implements Contracts.TransactionPool.DynamicFeeMa
     @Container.tagged("state", "blockchain")
     private readonly handlerRegistry!: Handlers.Registry;
 
-    @Container.inject(Container.Identifiers.StateStore)
-    private readonly stateStore!: Contracts.State.StateStore;
-
     @Container.inject(Container.Identifiers.LogService)
     private readonly logger!: Contracts.Kernel.Logger;
 
@@ -28,14 +25,12 @@ export class DynamicFeeMatcher implements Contracts.TransactionPool.DynamicFeeMa
 
         if (dynamicFeesConfiguration.enabled) {
             const addonBytes: number = dynamicFeesConfiguration.addonBytes[transaction.key];
-            const height: number = this.stateStore.getLastHeight();
             const handler = await this.handlerRegistry.getActivatedHandlerForData(transaction.data);
 
             const minFeePool: Utils.BigNumber = handler.dynamicFee({
                 transaction,
                 addonBytes,
                 satoshiPerByte: dynamicFeesConfiguration.minFeePool,
-                height,
             });
             const minFeeStr = Utils.formatSatoshi(minFeePool);
 
@@ -71,14 +66,12 @@ export class DynamicFeeMatcher implements Contracts.TransactionPool.DynamicFeeMa
 
         if (dynamicFeesConfiguration.enabled) {
             const addonBytes: number = dynamicFeesConfiguration.addonBytes[transaction.key];
-            const height: number = this.stateStore.getLastHeight();
             const handler = await this.handlerRegistry.getActivatedHandlerForData(transaction.data);
 
             const minFeeBroadcast: Utils.BigNumber = handler.dynamicFee({
                 transaction,
                 addonBytes,
                 satoshiPerByte: dynamicFeesConfiguration.minFeeBroadcast,
-                height,
             });
             const minFeeStr = Utils.formatSatoshi(minFeeBroadcast);
 

--- a/packages/core-transaction-pool/src/dynamic-fee-matcher.ts
+++ b/packages/core-transaction-pool/src/dynamic-fee-matcher.ts
@@ -1,6 +1,6 @@
 import { Container, Contracts, Providers } from "@arkecosystem/core-kernel";
 import { Handlers } from "@arkecosystem/core-transactions";
-import { Interfaces, Utils } from "@arkecosystem/crypto";
+import { Interfaces, Managers, Utils } from "@arkecosystem/crypto";
 
 import { TransactionFeeTooHighError, TransactionFeeTooLowError } from "./errors";
 
@@ -18,24 +18,29 @@ export class DynamicFeeMatcher implements Contracts.TransactionPool.DynamicFeeMa
     private readonly logger!: Contracts.Kernel.Logger;
 
     public async throwIfCannotEnterPool(transaction: Interfaces.ITransaction): Promise<void> {
-        const dynamicFeesConfiguration: Record<string, any> = this.configuration.getRequired<Record<string, any>>(
-            "dynamicFees",
-        );
+        const milestone = Managers.configManager.getMilestone();
+
+        let dynamicFeesConfiguration;
         const feeStr = Utils.formatSatoshi(transaction.data.fee);
 
+        if (milestone.dynamicFees && milestone.dynamicFees.enabled) {
+            dynamicFeesConfiguration = milestone.dynamicFees;
+        } else {
+            dynamicFeesConfiguration = this.configuration.getRequired<Record<string, any>>("dynamicFees");
+            dynamicFeesConfiguration.minFee = dynamicFeesConfiguration.minFeePool;
+        }
+
         if (dynamicFeesConfiguration.enabled) {
-            const addonBytes: number = dynamicFeesConfiguration.addonBytes[transaction.key];
             const handler = await this.handlerRegistry.getActivatedHandlerForData(transaction.data);
 
-            const minFeePool: Utils.BigNumber = handler.dynamicFee({
-                transaction,
-                addonBytes,
-                satoshiPerByte: dynamicFeesConfiguration.minFeePool,
-            });
+            const minFeePool: Utils.BigNumber = handler.getMinimumFee(transaction, dynamicFeesConfiguration);
+
             const minFeeStr = Utils.formatSatoshi(minFeePool);
 
             if (transaction.data.fee.isGreaterThanEqual(minFeePool)) {
-                this.logger.debug(`${transaction} eligible to enter pool (fee ${feeStr} >= ${minFeeStr}) :money_with_wings:`);
+                this.logger.debug(
+                    `${transaction} eligible to enter pool (fee ${feeStr} >= ${minFeeStr}) :money_with_wings:`,
+                );
                 return;
             }
 
@@ -45,7 +50,9 @@ export class DynamicFeeMatcher implements Contracts.TransactionPool.DynamicFeeMa
             const staticFeeStr = Utils.formatSatoshi(transaction.staticFee);
 
             if (transaction.data.fee.isEqualTo(transaction.staticFee)) {
-                this.logger.debug(`${transaction} eligible to enter pool (fee ${feeStr} = ${staticFeeStr}) :money_with_wings:`);
+                this.logger.debug(
+                    `${transaction} eligible to enter pool (fee ${feeStr} = ${staticFeeStr}) :money_with_wings:`,
+                );
                 return;
             }
             if (transaction.data.fee.isLessThan(transaction.staticFee)) {
@@ -59,28 +66,36 @@ export class DynamicFeeMatcher implements Contracts.TransactionPool.DynamicFeeMa
     }
 
     public async throwIfCannotBroadcast(transaction: Interfaces.ITransaction): Promise<void> {
-        const dynamicFeesConfiguration: Record<string, any> = this.configuration.getRequired<Record<string, any>>(
-            "dynamicFees",
-        );
+        const milestone = Managers.configManager.getMilestone();
+
+        let dynamicFeesConfiguration;
         const feeStr = Utils.formatSatoshi(transaction.data.fee);
 
+        if (milestone.dynamicFees && milestone.dynamicFees.enabled) {
+            dynamicFeesConfiguration = milestone.dynamicFees;
+        } else {
+            dynamicFeesConfiguration = this.configuration.getRequired<Record<string, any>>("dynamicFees");
+            dynamicFeesConfiguration.minFee = dynamicFeesConfiguration.minFeeBroadcast;
+        }
+
         if (dynamicFeesConfiguration.enabled) {
-            const addonBytes: number = dynamicFeesConfiguration.addonBytes[transaction.key];
             const handler = await this.handlerRegistry.getActivatedHandlerForData(transaction.data);
 
-            const minFeeBroadcast: Utils.BigNumber = handler.dynamicFee({
-                transaction,
-                addonBytes,
-                satoshiPerByte: dynamicFeesConfiguration.minFeeBroadcast,
-            });
+            const minFeeBroadcast: Utils.BigNumber = handler.getMinimumFee(transaction, dynamicFeesConfiguration);
+
             const minFeeStr = Utils.formatSatoshi(minFeeBroadcast);
 
             if (transaction.data.fee.isGreaterThanEqual(minFeeBroadcast)) {
-                this.logger.debug(`${transaction} eligible for broadcast (fee ${feeStr} >= ${minFeeStr}) :earth_africa:`);
+                if (!milestone.dynamicFees || !milestone.dynamicFees.enabled) {
+                    this.logger.debug(
+                        `${transaction} eligible for broadcast (fee ${feeStr} >= ${minFeeStr}) :earth_africa:`,
+                    );
+                }
                 return;
             }
-
-            this.logger.notice(`${transaction} not eligible for broadcast (fee ${feeStr} < ${minFeeStr}) :zap:`);
+            if (!milestone.dynamicFees || !milestone.dynamicFees.enabled) {
+                this.logger.notice(`${transaction} not eligible for broadcast (fee ${feeStr} < ${minFeeStr}) :zap:`);
+            }
             throw new TransactionFeeTooLowError(transaction);
         } else {
             const staticFeeStr = Utils.formatSatoshi(transaction.staticFee);

--- a/packages/core-transactions/src/errors.ts
+++ b/packages/core-transactions/src/errors.ts
@@ -19,6 +19,12 @@ export class TransactionError extends Error {
     }
 }
 
+export class TransactionFeeTooLowError extends TransactionError {
+    public constructor(fee: Utils.BigNumber, expectedFee: Utils.BigNumber) {
+        super(`Transaction fee is too low (fee ${Utils.formatSatoshi(fee)} < ${Utils.formatSatoshi(expectedFee)})`);
+    }
+}
+
 export class InvalidTransactionTypeError extends TransactionError {
     public constructor(type: Transactions.InternalTransactionType) {
         super(`Transaction type ${type.toString()} does not exist`);

--- a/packages/core-transactions/src/handlers/two/delegate-resignation.ts
+++ b/packages/core-transactions/src/handlers/two/delegate-resignation.ts
@@ -1,5 +1,5 @@
 import { Container, Contracts, Enums as AppEnums, Utils as AppUtils } from "@arkecosystem/core-kernel";
-import { Interfaces, Managers, Transactions } from "@arkecosystem/crypto";
+import { Interfaces, Managers, Transactions, Utils } from "@arkecosystem/crypto";
 
 import { NotEnoughDelegatesError, WalletAlreadyResignedError, WalletNotADelegateError } from "../../errors";
 import { TransactionHandler, TransactionHandlerConstructor } from "../transaction";
@@ -43,6 +43,11 @@ export class DelegateResignationTransactionHandler extends TransactionHandler {
     }
     public async isActivated(): Promise<boolean> {
         return Managers.configManager.getMilestone().aip11 === true;
+    }
+
+    public dynamicFee(context: Contracts.Shared.DynamicFeeContext): Utils.BigNumber {
+        // override dynamicFee calculation as this is a zero-fee transaction
+        return Utils.BigNumber.ZERO;
     }
 
     public async throwIfCannotBeApplied(

--- a/packages/core-transactions/src/handlers/two/delegate-resignation.ts
+++ b/packages/core-transactions/src/handlers/two/delegate-resignation.ts
@@ -46,7 +46,6 @@ export class DelegateResignationTransactionHandler extends TransactionHandler {
     }
 
     public dynamicFee(context: Contracts.Shared.DynamicFeeContext): Utils.BigNumber {
-        // override dynamicFee calculation as this is a zero-fee transaction
         return Utils.BigNumber.ZERO;
     }
 

--- a/packages/core-transactions/src/handlers/two/htlc-refund.ts
+++ b/packages/core-transactions/src/handlers/two/htlc-refund.ts
@@ -39,7 +39,6 @@ export class HtlcRefundTransactionHandler extends TransactionHandler {
     }
 
     public dynamicFee(context: Contracts.Shared.DynamicFeeContext): Utils.BigNumber {
-        // override dynamicFee calculation as this is a zero-fee transaction
         return Utils.BigNumber.ZERO;
     }
 

--- a/packages/crypto/src/transactions/types/schemas.ts
+++ b/packages/crypto/src/transactions/types/schemas.ts
@@ -299,7 +299,7 @@ export const htlcClaim = extend(transactionBaseSchema, {
     properties: {
         type: { transactionType: TransactionType.HtlcClaim },
         amount: { bignumber: { minimum: 0, maximum: 0 } },
-        fee: { bignumber: { minimum: 0, maximum: 0 } },
+        fee: { bignumber: { minimum: 0 } },
         asset: {
             type: "object",
             required: ["claim"],
@@ -322,7 +322,7 @@ export const htlcRefund = extend(transactionBaseSchema, {
     properties: {
         type: { transactionType: TransactionType.HtlcRefund },
         amount: { bignumber: { minimum: 0, maximum: 0 } },
-        fee: { bignumber: { minimum: 0, maximum: 0 } },
+        fee: { bignumber: { minimum: 0 } },
         asset: {
             type: "object",
             required: ["refund"],

--- a/packages/crypto/src/transactions/types/schemas.ts
+++ b/packages/crypto/src/transactions/types/schemas.ts
@@ -374,7 +374,7 @@ export const delegateResignation = extend(transactionBaseSchema, {
     properties: {
         type: { transactionType: TransactionType.DelegateResignation },
         amount: { bignumber: { minimum: 0, maximum: 0 } },
-        fee: { bignumber: { minimum: 1 } },
+        fee: { bignumber: { minimum: 0 } },
     },
 });
 

--- a/plugins/sxp-swap/src/sxp-swap.ts
+++ b/plugins/sxp-swap/src/sxp-swap.ts
@@ -3,7 +3,7 @@ import { Container, Contracts, Providers, Services, Utils as AppUtils } from "@a
 import { TransactionValidator } from "@arkecosystem/core-state/dist/transaction-validator";
 import { Handlers } from "@arkecosystem/core-transactions";
 import { ColdWalletError } from "@arkecosystem/core-transactions/dist/errors";
-import { Interfaces, Transactions, Utils } from "@arkecosystem/crypto";
+import { Interfaces, Managers, Transactions, Utils } from "@arkecosystem/crypto";
 import * as EthereumTx from '@ethereumjs/tx';
 import assert from "assert";
 import delay from "delay";
@@ -172,6 +172,9 @@ export class SXPSwap {
             if (!(this as any).walletRepository.hasByPublicKey(sender.getPublicKey()!) && senderWallet.getBalance().isZero()) {
                 throw new ColdWalletError();
             }
+
+            const milestone = Managers.configManager.getMilestone();
+            (this as any).enforceMinimumFee(transaction, milestone.dynamicFees);
 
             return (this as any).performGenericWalletChecks(transaction, sender);
         };


### PR DESCRIPTION
In the previous implementation, dynamic fees were not enforced by consensus and a single delegate could lower the fees as far as 0.00000001 and the network would have accepted it. 

This PR incorporates fees into consensus. More specifically, fees cannot be lowered under a certain threshold calculated with the same formula used for dynamic fees.

This was introduced to avoid delegates lowering fees for themselves or others to avoid/reduce the amount of burned fees.