### PR TITLE
feat(core-cli): add --all flag to update all installed plugins

### DIFF
--- a/packages/core-cli/src/contracts.ts
+++ b/packages/core-cli/src/contracts.ts
@@ -66,7 +66,7 @@ export interface PluginManager {
 
     install(token: string, network: string, pkg: string, version?: string): Promise<void>;
 
-    update(token: string, network: string, pkg: string): Promise<void>;
+    update(all: boolean, token: string, network: string, pkg: string): Promise<void>;
 
     remove(token: string, network: string, pkg: string): Promise<void>;
 }

--- a/packages/core/src/commands/plugin-update.ts
+++ b/packages/core/src/commands/plugin-update.ts
@@ -36,9 +36,10 @@ export class Command extends Commands.Command {
      */
     public configure(): void {
         this.definition
+            .setFlag("all", "Whether to update all packages", Joi.boolean())
             .setFlag("token", "The name of the token", Joi.string().default("ark"))
             .setFlag("network", "The name of the network", Joi.string().valid(...Object.keys(Networks)))
-            .setArgument("package", "The name of the package", Joi.string().required());
+            .setArgument("package", "The name of the package", Joi.string());
     }
 
     /**
@@ -49,6 +50,7 @@ export class Command extends Commands.Command {
      */
     public async execute(): Promise<void> {
         return await this.pluginManager.update(
+            this.getFlag("all"),
             this.getFlag("token"),
             this.getFlag("network"),
             this.getArgument("package"),


### PR DESCRIPTION
If we have multiple plugins installed, it can get a bit tedious to manually update them. So now we can run `plugin:update --all` to update all of them at once.

This PR also prettifies the logging of plugin manager actions by using the spinner component.