### PR TITLE
feat(core-cli): translate plugin package scope

### DIFF
--- a/packages/core-cli/src/services/source-providers/git.ts
+++ b/packages/core-cli/src/services/source-providers/git.ts
@@ -49,6 +49,8 @@ export class Git extends AbstractSource {
         }
         await subprocess;
 
+        this.translate(dest);
+
         await this.installDependencies(value);
     }
 


### PR DESCRIPTION
Now that we have moved all the packages to our own scope, any existing third party plugins that depend on the upstream scope will no longer work.

Since we cannot, and should not, expect existing plugins for the upstream Core to be rewritten to target our own scope, this PR introduces a translation routine to automatically modify the plugin's source code to rewrite references to the upstream scope so that they are changed to use our scope whenever a plugin is installed or updated.