### PR TITLE
refactor(core-p2p): delegate peering improvements

### DIFF
--- a/packages/core-p2p/src/defaults.ts
+++ b/packages/core-p2p/src/defaults.ts
@@ -28,7 +28,7 @@ export const defaults = {
     /**
      * The maximum authorized number of peers sharing same ip /24 subnet
      */
-    maxSameSubnetPeers: process.env.CORE_P2P_MAX_PEERS_SAME_SUBNET || 5,
+    maxSameSubnetPeers: process.env.CORE_P2P_MAX_PEERS_SAME_SUBNET || 256,
     /**
      * The maximum peer consecutive errors before peer is forget from peer store.
      */

--- a/packages/core-p2p/src/peer-communicator.ts
+++ b/packages/core-p2p/src/peer-communicator.ts
@@ -177,27 +177,28 @@ export class PeerCommunicator implements Contracts.P2P.PeerCommunicator {
                             (wallet: Contracts.State.Wallet) => wallet.getPublicKey(),
                         );
                         if (
-                            delegates.includes(publicKey) &&
-                            Crypto.Hash.verifySchnorr(stateBuffer, signature, publicKey)
+                            !delegates.includes(publicKey) ||
+                            !Crypto.Hash.verifySchnorr(stateBuffer, signature, publicKey)
                         ) {
-                            if (!delegatePeer) {
-                                peer.publicKeys.push(publicKey);
-                            } else if (!peer.isForked()) {
-                                if (
-                                    delegatePeer.isForked() ||
-                                    (peer.state.header.height === lastBlock.data.height &&
-                                        peer.state.header.id === lastBlock.data.id) ||
-                                    (peer.state.header.height >= delegatePeer.state.header.height &&
-                                        delegatePeer.state.header.id !== lastBlock.data.id)
-                                ) {
-                                    peer.publicKeys.push(publicKey);
-                                    delegatePeer.publicKeys = delegatePeer.publicKeys.filter(
-                                        (peerPublicKey) => peerPublicKey !== publicKey,
-                                    );
-                                }
-                            }
-                            alreadyCheckedSignatures.push(publicKey + signature);
+                            break;
                         }
+                        if (!delegatePeer) {
+                            peer.publicKeys.push(publicKey);
+                        } else if (!peer.isForked()) {
+                            if (
+                                delegatePeer.isForked() ||
+                                (peer.state.header.height === lastBlock.data.height &&
+                                    peer.state.header.id === lastBlock.data.id) ||
+                                (peer.state.header.height >= delegatePeer.state.header.height &&
+                                    delegatePeer.state.header.id !== lastBlock.data.id)
+                            ) {
+                                peer.publicKeys.push(publicKey);
+                                delegatePeer.publicKeys = delegatePeer.publicKeys.filter(
+                                    (peerPublicKey) => peerPublicKey !== publicKey,
+                                );
+                            }
+                        }
+                        alreadyCheckedSignatures.push(publicKey + signature);
                     }
                 }
             }


### PR DESCRIPTION
This PR comprises of two parts, both of which improve the responsiveness of peering with other delegates, which is now essential for calculating quorum to forge.

Firstly, we stop verifying signatures from the signed `p2p.peer.getStatus` endpoint as soon as we hit an invalid one, as it means a malicious actor is trying to do something nasty. By cutting the cord immediately, we don't waste processor time trying to verify more signatures from a peer that is obviously bad. An invalid signature is one that is either cryptographically incorrect, or from a public key that does not correspond to a currently active forging delegate.

Secondly, we disable the /24 subnet limit by default. This was originally set in the upstream code to prevent too many malicious relays overwhelming the network from the same hosting location to skew quorum, but is no longer necessary since we now only consider delegates in quorum calculations. Indeed, it is counterproductive to impose a subnet limit now, as we need to peer with as much of the network as possible to connect to all the delegates.