### PR TITLE
refactor(core-forger): remove core-database dependency

### DIFF
--- a/packages/core-forger/src/client.ts
+++ b/packages/core-forger/src/client.ts
@@ -1,5 +1,5 @@
 import { Container, Contracts, Utils } from "@solar-network/core-kernel";
-import { Codecs, Nes, NetworkState, NetworkStateStatus } from "@solar-network/core-p2p";
+import { Codecs, Nes, NetworkState } from "@solar-network/core-p2p";
 import { Blocks, Interfaces } from "@solar-network/crypto";
 
 import { HostNoResponseError, RelayCommunicationError } from "./errors";
@@ -124,14 +124,14 @@ export class Client {
         return this.emit<Contracts.P2P.CurrentRound>("p2p.internal.getCurrentRound");
     }
 
+    public async getSlotNumber(timestamp?: number): Promise<number> {
+        await this.selectHost();
+
+        return this.emit<number>("p2p.internal.getSlotNumber", { timestamp });
+    }
+
     public async getNetworkState(log: boolean): Promise<Contracts.P2P.NetworkState> {
-        try {
-            return NetworkState.parse(
-                await this.emit<Contracts.P2P.NetworkState>("p2p.internal.getNetworkState", { log }, 4000),
-            );
-        } catch (err) {
-            return new NetworkState(NetworkStateStatus.Unknown);
-        }
+        return NetworkState.parse(await this.emit<Contracts.P2P.NetworkState>("p2p.internal.getNetworkState", { log }, 4000));
     }
 
     /**
@@ -241,6 +241,7 @@ export class Client {
             "p2p.internal.getUnconfirmedTransactions": Codecs.getUnconfirmedTransactions,
             "p2p.internal.getCurrentRound": Codecs.getCurrentRound,
             "p2p.internal.getNetworkState": Codecs.getNetworkState,
+            "p2p.internal.getSlotNumber": Codecs.getSlotNumber,
             "p2p.internal.syncBlockchain": Codecs.syncBlockchain,
             "p2p.blocks.postBlock": Codecs.postBlock,
             "p2p.peer.getStatus": Codecs.getStatus,

--- a/packages/core-p2p/src/socket-server/codecs/internal.ts
+++ b/packages/core-p2p/src/socket-server/codecs/internal.ts
@@ -42,6 +42,17 @@ export const getNetworkState = {
     },
 };
 
+export const getSlotNumber = {
+    request: {
+        serialize: (obj): Buffer => Buffer.from(JSON.stringify(obj)),
+        deserialize: (payload: Buffer) => JSON.parse(payload.toString()),
+    },
+    response: {
+        serialize: (obj): Buffer => Buffer.from(JSON.stringify(obj)),
+        deserialize: (payload: Buffer) => JSON.parse(payload.toString()),
+    },
+};
+
 export const syncBlockchain = {
     request: {
         serialize: (obj): Buffer => Buffer.from(JSON.stringify(obj)),

--- a/packages/core-p2p/src/socket-server/controllers/internal.ts
+++ b/packages/core-p2p/src/socket-server/controllers/internal.ts
@@ -93,6 +93,15 @@ export class InternalController extends Controller {
         };
     }
 
+    public async getSlotNumber(request: Hapi.Request, h: Hapi.ResponseToolkit): Promise<number> {
+        const lastBlock = this.blockchain.getLastBlock();
+
+        const height = lastBlock.data.height + 1;
+        const blockTimeLookup = await Utils.forgingInfoCalculator.getBlockTimeLookup(this.app, height);
+        return Crypto.Slots.getSlotNumber(blockTimeLookup, request.payload.timestamp);
+    }
+
+
     public async getNetworkState(request: Hapi.Request, h: Hapi.ResponseToolkit): Promise<Contracts.P2P.NetworkState> {
         return this.peerNetworkMonitor.getNetworkState(!!request.payload.log);
     }

--- a/packages/core-p2p/src/socket-server/routes/internal.ts
+++ b/packages/core-p2p/src/socket-server/routes/internal.ts
@@ -1,4 +1,4 @@
-import { emitEvent, getCurrentRound, getNetworkState, getUnconfirmedTransactions, syncBlockchain } from "../codecs/internal";
+import { emitEvent, getCurrentRound, getNetworkState, getSlotNumber, getUnconfirmedTransactions, syncBlockchain } from "../codecs/internal";
 import { InternalController } from "../controllers/internal";
 import { internalSchemas } from "../schemas/internal";
 import { Route, RouteConfig } from "./route";
@@ -22,6 +22,11 @@ export class InternalRoute extends Route {
                 id: "p2p.internal.getCurrentRound",
                 handler: controller.getCurrentRound,
                 codec: getCurrentRound,
+            },
+            "/p2p/internal/getSlotNumber": {
+                id: "p2p.internal.getSlotNumber",
+                handler: controller.getSlotNumber,
+                codec: getSlotNumber,
             },
             "/p2p/internal/getNetworkState": {
                 id: "p2p.internal.getNetworkState",

--- a/packages/core/bin/config/devnet/app.json
+++ b/packages/core/bin/config/devnet/app.json
@@ -88,9 +88,6 @@
                 "package": "@solar-network/core-logger-pino"
             },
             {
-                "package": "@solar-network/core-database"
-            },
-            {
                 "package": "@solar-network/core-transactions"
             },
             {

--- a/packages/core/bin/config/mainnet/app.json
+++ b/packages/core/bin/config/mainnet/app.json
@@ -70,9 +70,6 @@
                 "package": "@solar-network/core-logger-pino"
             },
             {
-                "package": "@solar-network/core-database"
-            },
-            {
                 "package": "@solar-network/core-transactions"
             },
             {

--- a/packages/core/bin/config/testnet/app.json
+++ b/packages/core/bin/config/testnet/app.json
@@ -76,9 +76,6 @@
                 "package": "@solar-network/core-logger-pino"
             },
             {
-                "package": "@solar-network/core-database"
-            },
-            {
                 "package": "@solar-network/core-transactions"
             },
             {


### PR DESCRIPTION
Recent PR #11 temporarily reintroduced `core-database` as a dependency for the forger process due to the database requirement of `getBlockTimeLookup` which is used to get the current slot number.

It was always the intention that this would be temporary and this PR now refactors it to delegate the `getBlockTimeLookup` call to the connected relay, accessed via a new private `p2p.internal.getCurrentSlot` endpoint. This means the forger process is once again decoupled from the database, potentially allowing a forger to operate via a remote connection to a relay without the need for a local blockchain database on the same node as the forger.