### PR TITLE
refactor(core-forger): catch more cases of accidental double forgery

### DIFF
--- a/packages/core-forger/src/client.ts
+++ b/packages/core-forger/src/client.ts
@@ -131,7 +131,7 @@ export class Client {
     }
 
     public async getNetworkState(log: boolean): Promise<Contracts.P2P.NetworkState> {
-        return NetworkState.parse(await this.emit<Contracts.P2P.NetworkState>("p2p.internal.getNetworkState", { log }, 4000));
+        return await NetworkState.parse(await this.emit<Contracts.P2P.NetworkState>("p2p.internal.getNetworkState", { log }, 4000));
     }
 
     /**

--- a/packages/core-kernel/src/contracts/p2p/network-state.ts
+++ b/packages/core-kernel/src/contracts/p2p/network-state.ts
@@ -1,14 +1,12 @@
 export interface NetworkState {
     readonly status: any;
 
-    // static analyze(monitor: NetworkMonitor, repository: PeerRepository): NetworkState;
-    // static parse(data: any): NetworkState;
-
     canForge();
 
     getNodeHeight(): number | undefined;
     getLastBlockId(): string | undefined;
-
+    getLastGenerator(): string | undefined;
+    getLastSlotNumber(): number | undefined;
     getQuorum();
     getOverHeightBlockHeaders();
     setOverHeightBlockHeaders(overHeightBlockHeaders: Array<any>): void;

--- a/packages/core-kernel/src/contracts/p2p/server.ts
+++ b/packages/core-kernel/src/contracts/p2p/server.ts
@@ -31,7 +31,8 @@ export interface ForgingTransactions {
 export interface Status {
     state: {
         header: {
-            timestamp: number
+            generatorPublicKey: string;
+            timestamp: number;
         }
     };
 }

--- a/packages/core-p2p/src/socket-server/controllers/internal.ts
+++ b/packages/core-p2p/src/socket-server/controllers/internal.ts
@@ -103,7 +103,7 @@ export class InternalController extends Controller {
 
 
     public async getNetworkState(request: Hapi.Request, h: Hapi.ResponseToolkit): Promise<Contracts.P2P.NetworkState> {
-        return this.peerNetworkMonitor.getNetworkState(!!request.payload.log);
+        return await this.peerNetworkMonitor.getNetworkState(!!request.payload.log);
     }
 
     public syncBlockchain(request: Hapi.Request, h: Hapi.ResponseToolkit): boolean {


### PR DESCRIPTION
We know that the quorum-based consensus algorithm has flaws regarding double forgery. Sometimes it happens by accident, e.g. leaving a backup node forging after performing maintenance on their main node.

This PR improves the detection mechanism to catch more instances of accidental double forgery. However, it will not catch all cases - that is impossible - but, since we know the consequences, anything that improves the chance of reducing accidental double forgery on the network is worthwhile.

This issue will be resolved once and for all when we implement the new replacement consensus which does not use quorum.