### PR TITLE
fix(core-api): create block and transaction sorting schemas

### DIFF
--- a/packages/core-api/src/resources-new/block.ts
+++ b/packages/core-api/src/resources-new/block.ts
@@ -1,5 +1,7 @@
 import Joi from "joi";
 
+import * as Schemas from "../schemas";
+
 const blockHeightSchema = Joi.number().integer().min(1);
 const blockIdSchema = Joi.alternatives(
     Joi.string()
@@ -30,3 +32,4 @@ export const blockCriteriaSchemaObject = {
 };
 
 export const blockParamSchema = Joi.alternatives(blockIdSchema, blockHeightSchema);
+export const blockSortingSchema = Schemas.createSortingSchema(Schemas.blockCriteriaSchemas, [], false);

--- a/packages/core-api/src/resources-new/transaction.ts
+++ b/packages/core-api/src/resources-new/transaction.ts
@@ -1,5 +1,6 @@
 import Joi from "joi";
 
+import * as Schemas from "../schemas";
 import { walletCriteriaSchemaObject } from "./wallet";
 
 export const transactionIdSchema = Joi.string().hex().length(64);
@@ -17,3 +18,4 @@ export const transactionCriteriaSchemaObject = {
 };
 
 export const transactionParamSchema = transactionIdSchema;
+export const transactionSortingSchema = Schemas.createSortingSchema(Schemas.transactionCriteriaSchemas, [], false);

--- a/packages/core-api/src/routes/blocks.ts
+++ b/packages/core-api/src/routes/blocks.ts
@@ -2,6 +2,7 @@ import Hapi from "@hapi/hapi";
 import Joi from "joi";
 
 import { BlocksController } from "../controllers/blocks";
+import { blockSortingSchema, transactionSortingSchema } from "../resources-new";
 import * as Schemas from "../schemas";
 
 export const register = (server: Hapi.Server): void => {
@@ -18,7 +19,9 @@ export const register = (server: Hapi.Server): void => {
                     ...server.app.schemas.blockCriteriaSchemas,
                     orderBy: server.app.schemas.blocksOrderBy,
                     transform: Joi.bool().default(true),
-                }).concat(Schemas.pagination),
+                })
+                    .concat(blockSortingSchema)
+                    .concat(Schemas.pagination),
             },
             plugins: {
                 pagination: {
@@ -83,7 +86,9 @@ export const register = (server: Hapi.Server): void => {
                     ...server.app.schemas.transactionCriteriaSchemas,
                     orderBy: server.app.schemas.transactionsOrderBy,
                     transform: Joi.bool().default(true),
-                }).concat(Schemas.pagination),
+                })
+                    .concat(transactionSortingSchema)
+                    .concat(Schemas.pagination),
             },
             plugins: {
                 pagination: {

--- a/packages/core-api/src/routes/delegates.ts
+++ b/packages/core-api/src/routes/delegates.ts
@@ -3,6 +3,7 @@ import Joi from "joi";
 
 import { DelegatesController } from "../controllers/delegates";
 import {
+    blockSortingSchema,
     delegateCriteriaSchema,
     delegateSortingSchema,
     walletCriteriaSchema,
@@ -75,7 +76,9 @@ export const register = (server: Hapi.Server): void => {
                     ...server.app.schemas.blockCriteriaSchemas,
                     orderBy: server.app.schemas.blocksOrderBy,
                     transform: Joi.bool().default(true),
-                }).concat(Schemas.pagination),
+                })
+                    .concat(blockSortingSchema)
+                    .concat(Schemas.pagination),
             },
             plugins: {
                 pagination: {

--- a/packages/core-api/src/routes/transactions.ts
+++ b/packages/core-api/src/routes/transactions.ts
@@ -3,6 +3,7 @@ import { Container, Providers } from "@solar-network/core-kernel";
 import Joi from "joi";
 
 import { TransactionsController } from "../controllers/transactions";
+import { transactionSortingSchema } from "../resources-new";
 import * as Schemas from "../schemas";
 
 export const register = (server: Hapi.Server): void => {
@@ -19,7 +20,9 @@ export const register = (server: Hapi.Server): void => {
                     ...server.app.schemas.transactionCriteriaSchemas,
                     orderBy: server.app.schemas.transactionsOrderBy,
                     transform: Joi.bool().default(true),
-                }).concat(Schemas.pagination),
+                })
+                    .concat(transactionSortingSchema)
+                    .concat(Schemas.pagination),
             },
             plugins: {
                 pagination: {

--- a/packages/core-api/src/routes/votes.ts
+++ b/packages/core-api/src/routes/votes.ts
@@ -2,6 +2,7 @@ import Hapi from "@hapi/hapi";
 import Joi from "joi";
 
 import { VotesController } from "../controllers/votes";
+import { transactionSortingSchema } from "../resources-new";
 import * as Schemas from "../schemas";
 
 export const register = (server: Hapi.Server): void => {
@@ -18,7 +19,9 @@ export const register = (server: Hapi.Server): void => {
                     ...server.app.schemas.transactionCriteriaSchemas,
                     orderBy: server.app.schemas.transactionsOrderBy,
                     transform: Joi.bool().default(true),
-                }).concat(Schemas.pagination),
+                })
+                    .concat(transactionSortingSchema)
+                    .concat(Schemas.pagination),
             },
             plugins: {
                 pagination: {

--- a/packages/core-api/src/routes/wallets.ts
+++ b/packages/core-api/src/routes/wallets.ts
@@ -5,6 +5,7 @@ import { WalletsController } from "../controllers/wallets";
 import {
     lockCriteriaSchema,
     lockSortingSchema,
+    transactionSortingSchema,
     walletCriteriaSchema,
     walletParamSchema,
     walletSortingSchema,
@@ -86,7 +87,9 @@ export const register = (server: Hapi.Server): void => {
                     ...server.app.schemas.transactionCriteriaSchemas,
                     orderBy: server.app.schemas.transactionsOrderBy,
                     transform: Joi.bool().default(true),
-                }).concat(Schemas.pagination),
+                })
+                    .concat(transactionSortingSchema)
+                    .concat(Schemas.pagination),
             },
             plugins: {
                 pagination: {
@@ -109,7 +112,9 @@ export const register = (server: Hapi.Server): void => {
                     ...server.app.schemas.transactionCriteriaSchemas,
                     orderBy: server.app.schemas.transactionsOrderBy,
                     transform: Joi.bool().default(true),
-                }).concat(Schemas.pagination),
+                })
+                    .concat(transactionSortingSchema)
+                    .concat(Schemas.pagination),
             },
             plugins: {
                 pagination: {
@@ -132,7 +137,9 @@ export const register = (server: Hapi.Server): void => {
                     ...server.app.schemas.transactionCriteriaSchemas,
                     orderBy: server.app.schemas.transactionsOrderBy,
                     transform: Joi.bool().default(true),
-                }).concat(Schemas.pagination),
+                })
+                    .concat(transactionSortingSchema)
+                    .concat(Schemas.pagination),
             },
             plugins: {
                 pagination: {
@@ -155,7 +162,9 @@ export const register = (server: Hapi.Server): void => {
                     ...server.app.schemas.transactionCriteriaSchemas,
                     orderBy: server.app.schemas.transactionsOrderBy,
                     transform: Joi.bool().default(true),
-                }).concat(Schemas.pagination),
+                })
+                    .concat(transactionSortingSchema)
+                    .concat(Schemas.pagination),
             },
             plugins: {
                 pagination: {

--- a/packages/core-api/src/schemas.ts
+++ b/packages/core-api/src/schemas.ts
@@ -44,7 +44,11 @@ export const createRangeCriteriaSchema = (item: Joi.Schema): Joi.Schema => {
 
 // Sorting
 
-export const createSortingSchema = (schemaObject: SchemaObject, wildcardPaths: string[] = []): Joi.ObjectSchema => {
+export const createSortingSchema = (
+    schemaObject: SchemaObject,
+    wildcardPaths: string[] = [],
+    transform: boolean = true,
+): Joi.ObjectSchema => {
     const getObjectPaths = (object: SchemaObject): string[] => {
         return Object.entries(object)
             .map(([key, value]) => {
@@ -80,7 +84,11 @@ export const createSortingSchema = (schemaObject: SchemaObject, wildcardPaths: s
                     });
                 }
 
-                sorting.push({ property, direction: direction as "asc" | "desc" });
+                if (transform) {
+                    sorting.push({ property, direction: direction as "asc" | "desc" });
+                } else {
+                    sorting.push(value);
+                }
             }
 
             return sorting;


### PR DESCRIPTION
This resolves [an issue in the upstream code](https://github.com/ArkEcosystem/core/issues/4621) which remains open and unfixed at the time of this PR.

The bug causes a HTTP 500 Internal Server Error on the Public API and node log spam whenever somebody tries to access any of the following endpoints with an invalid `orderBy` query parameter:

`/api/blocks`

`/api/blocks/{id}/transactions`

`/api/delegates/{id}/blocks`

`/api/transactions`

`/api/votes`

`/api/wallets/{id}/transactions`

`/api/wallets/{id}/transactions/sent`

`/api/wallets/{id}/transactions/received`

`/api/wallets/{id}/votes`

Since a lengthy stack trace is printed in the node logs each time, we have taken the decision to fix it in our own codebase rather than waiting for upstream to resolve it as we have decided that this could cause service degradation if bots or crawlers were to start hitting these endpoints, since the log files will fill up, taking disk space and preventing operators from seeing log entries that are actually important.

Upstream may ultimately choose a different method of resolution, and that's fine, since our respective codebases have already diverged and will continue to do so as time goes on.