### PR TITLE
feat(core-kernel): add format seconds function

### DIFF
--- a/packages/core-blockchain/src/state-machine/actions/check-later.ts
+++ b/packages/core-blockchain/src/state-machine/actions/check-later.ts
@@ -48,22 +48,14 @@ export class CheckLater implements Action {
 
                 const days = Math.floor(seconds / (3600 * 24));
                 const hours = Math.floor((seconds % (3600 * 24)) / 3600);
-                const mins = Math.floor((seconds % 3600) / 60);
-                const secs = Math.floor(seconds % 60);
 
                 let emoji = emojiSet.normal;
                 if (days === 0 && hours === 0) {
                     emoji = emojiSet.soon;
                 }
 
-                const daysToGo = days > 0 ? days + (days == 1 ? " day, " : " days, ") : "";
-                const hoursToGo = hours > 0 ? hours + (hours == 1 ? " hour, " : " hours, ") : "";
-                const minsToGo = mins > 0 ? mins + (mins == 1 ? " minute, " : " minutes, ") : "";
-                const secsToGo = secs > 0 ? secs + (secs == 1 ? " second" : " seconds") : "";
+                const countdown = AppUtils.formatSeconds(seconds);
 
-                const countdown = (daysToGo + hoursToGo + minsToGo + secsToGo)
-                    .replace(/,\s*$/, "")
-                    .replace(/,([^,]*)$/, " and$1");
                 this.logger.info(`The network launches in ${countdown} ${emoji[seconds % 5]}`);
             } else {
                 this.logger.info(

--- a/packages/core-kernel/src/utils/format-seconds.ts
+++ b/packages/core-kernel/src/utils/format-seconds.ts
@@ -1,0 +1,15 @@
+export const formatSeconds = (seconds: number): string => {
+    const days = Math.floor(seconds / (3600 * 24));
+    const hours = Math.floor((seconds % (3600 * 24)) / 3600);
+    const mins = Math.floor((seconds % 3600) / 60);
+    const secs = Math.floor(seconds % 60);
+
+    const secondsInDays = days > 0 ? days + (days == 1 ? " day, " : " days, ") : "";
+    const secondsInHours = hours > 0 ? hours + (hours == 1 ? " hour, " : " hours, ") : "";
+    const secondsInMinutes = mins > 0 ? mins + (mins == 1 ? " minute, " : " minutes, ") : "";
+    const secondsRemaining = secs > 0 ? secs + (secs == 1 ? " second" : " seconds") : "";
+
+    return (secondsInDays + secondsInHours + secondsInMinutes + secondsRemaining)
+        .replace(/,\s*$/, "")
+        .replace(/,([^,]*)$/, " and$1");
+};

--- a/packages/core-kernel/src/utils/index.ts
+++ b/packages/core-kernel/src/utils/index.ts
@@ -1,6 +1,7 @@
 import { calculateForgingInfo } from "./calculate-forging-info";
 import { calculateApproval, calculateForgedTotal } from "./delegate-calculator";
 import { calculateLockExpirationStatus, calculateTransactionExpiration } from "./expiration-calculator";
+import { formatSeconds } from "./format-seconds";
 import { formatTimestamp } from "./format-timestamp";
 import { getBlockTimeLookup } from "./get-blocktime-lookup";
 import { getForgerDelegates, sendForgerSignal } from "./get-forger-delegates";
@@ -27,6 +28,7 @@ export const supplyCalculator = { calculate };
 export const forgingInfoCalculator = { calculateForgingInfo, getBlockTimeLookup };
 
 export {
+    formatSeconds,
     formatTimestamp,
     isBlockChained,
     getBlockNotChainedErrorMessage,


### PR DESCRIPTION
This extracts the code to convert seconds to a pretty textual representation of days, hours, minutes and seconds into its own utility function, so it can be reused elsewhere in Core too.