### PR TITLE
feat(crypto): add vendorfield to ipfs transaction type

### DIFF
--- a/packages/crypto/src/transactions/builders/transactions/ipfs.ts
+++ b/packages/crypto/src/transactions/builders/transactions/ipfs.ts
@@ -10,6 +10,7 @@ export class IPFSBuilder extends TransactionBuilder<IPFSBuilder> {
         this.data.type = Two.IpfsTransaction.type;
         this.data.typeGroup = Two.IpfsTransaction.typeGroup;
         this.data.fee = Two.IpfsTransaction.staticFee();
+        this.data.vendorField = undefined;
         this.data.amount = BigNumber.ZERO;
         this.data.asset = {};
     }
@@ -24,6 +25,7 @@ export class IPFSBuilder extends TransactionBuilder<IPFSBuilder> {
 
     public getStruct(): ITransactionData {
         const struct: ITransactionData = super.getStruct();
+        struct.vendorField = this.data.vendorField;
         struct.amount = this.data.amount;
         struct.asset = this.data.asset;
         return struct;

--- a/packages/crypto/src/transactions/types/schemas.ts
+++ b/packages/crypto/src/transactions/types/schemas.ts
@@ -249,6 +249,7 @@ export const ipfs = extend(transactionBaseSchema, {
         type: { transactionType: TransactionType.Core.Ipfs },
         amount: { bignumber: { minimum: 0, maximum: 0 } },
         fee: { bignumber: { minimum: 1 } },
+        vendorField: { anyOf: [{ type: "null" }, { type: "string", format: "vendorField" }] },
         asset: {
             type: "object",
             required: ["ipfs"],

--- a/packages/crypto/src/transactions/types/two/ipfs.ts
+++ b/packages/crypto/src/transactions/types/two/ipfs.ts
@@ -23,6 +23,10 @@ export abstract class IpfsTransaction extends Transaction {
         return configManager.getMilestone().aip11 && super.verify();
     }
 
+    public hasVendorField(): boolean {
+        return true;
+    }
+
     public serialize(options?: ISerializeOptions): ByteBuffer | undefined {
         const { data } = this;
 


### PR DESCRIPTION
Solar Core's development team is actively engaged with the community in Discord and Telegram, and we listen to our valued members. We recently received a request from a community member to add vendorfield support to the IPFS transaction type so that users can optionally store up to 255 characters of free-form additional data with the hash, such as basic metadata or a description of what the IPFS hash is, or indeed, another IPFS hash associated with the transaction. There are multiple use cases where additional data is required alongside the hash, so this PR implements that request.