### PR TITLE
feat(core-p2p): ignore persistently disruptive peers

### DIFF
--- a/packages/core-forger/src/forger-service.ts
+++ b/packages/core-forger/src/forger-service.ts
@@ -275,7 +275,7 @@ export class ForgerService {
             let errored = false;
             const minimumMs = 2000;
             try {
-                let networkState: Contracts.P2P.NetworkState = await this.client.getNetworkState(firstAttempt);
+                const networkState: Contracts.P2P.NetworkState = await this.client.getNetworkState(firstAttempt);
                 const networkStateHeight = networkState.getNodeHeight();
 
                 AppUtils.assert.defined<number>(networkStateHeight);
@@ -305,7 +305,6 @@ export class ForgerService {
 
                 const prettyName = this.usernames[delegate.publicKey];
 
-                networkState = await this.client.getNetworkState(false);
                 const { state } = await this.client.getStatus();
                 const currentSlot = await this.client.getSlotNumber();
                 const lastBlockSlot = await this.client.getSlotNumber(state.header.timestamp);

--- a/packages/core-kernel/src/contracts/p2p/peer.ts
+++ b/packages/core-kernel/src/contracts/p2p/peer.ts
@@ -18,6 +18,8 @@ export interface Peer {
     version: string | undefined;
     latency: number | undefined;
 
+    infractions: Set<number>;
+
     lastPinged: Dayjs | undefined;
     plugins: PeerPlugins;
     publicKeys: string[];
@@ -26,7 +28,9 @@ export interface Peer {
     state: PeerState;
     verificationResult: PeerVerificationResult | undefined;
 
+    addInfraction(): void;
     isActiveDelegate(): boolean;
+    isIgnored(): boolean;
     isVerified(): boolean;
     isForked(): boolean;
     recentlyPinged(): boolean;

--- a/packages/core-p2p/src/peer-communicator.ts
+++ b/packages/core-p2p/src/peer-communicator.ts
@@ -115,7 +115,7 @@ export class PeerCommunicator implements Contracts.P2P.PeerCommunicator {
     ): Promise<any> {
         const deadline = new Date().getTime() + timeoutMsec;
 
-        if (!peer.stale && peer.recentlyPinged() && !force) {
+        if (peer.isIgnored() || (!peer.stale && peer.recentlyPinged() && !force)) {
             return undefined;
         }
 

--- a/packages/core-p2p/src/peer.ts
+++ b/packages/core-p2p/src/peer.ts
@@ -153,7 +153,7 @@ export class Peer implements Contracts.P2P.Peer {
     public isIgnored(): boolean {
         const timeNow: number = new Date().getTime() / 1000;
         for (const infraction of this.infractions) {
-            if (timeNow - infraction > 60) {
+            if (timeNow - infraction > 600) {
                 this.infractions.delete(infraction);
             }
         }

--- a/packages/core-p2p/src/peer.ts
+++ b/packages/core-p2p/src/peer.ts
@@ -22,6 +22,12 @@ export class Peer implements Contracts.P2P.Peer {
     public version: string | undefined;
 
     /**
+     * @type {(Set<number>)}
+     * @memberof Peer
+     */
+    public infractions: Set<number> = new Set();
+
+    /**
      * @type {(number | undefined)}
      * @memberof Peer
      */
@@ -137,5 +143,20 @@ export class Peer implements Contracts.P2P.Peer {
             ip: this.ip,
             port: this.port,
         };
+    }
+
+    public addInfraction(): void {
+        const timeNow: number = new Date().getTime() / 1000;
+        this.infractions.add(timeNow);
+    }
+
+    public isIgnored(): boolean {
+        const timeNow: number = new Date().getTime() / 1000;
+        for (const infraction of this.infractions) {
+            if (timeNow - infraction > 60) {
+                this.infractions.delete(infraction);
+            }
+        }
+        return this.infractions.size >= 3;
     }
 }


### PR DESCRIPTION
Prior to forging, delegates ping all peers on the network to ascertain their network state. If peers do not reply on time, this can delay the forging process. While this ordinarily should not stop delegates from forging, it does mean that if they are unable to forge initially, there is less time remaining in the slot to attempt to forge again which can increase the chance of ultimate failure.

We now therefore operate a three strikes policy; if a peer does not reply within the allocated time, it gains a strike which expires after 10 minutes. If a peer accumulates three strikes, it is ignored from network state calculations until the earliest active strike expires.