### PR TITLE
feat(core-p2p): peer banning mechanism

### DIFF
--- a/packages/core-p2p/src/defaults.ts
+++ b/packages/core-p2p/src/defaults.ts
@@ -1,5 +1,6 @@
 export const defaults = {
     server: {
+        banSeconds: process.env.CORE_P2P_BAN_SECONDS || 60,
         hostname: process.env.CORE_P2P_HOST || "0.0.0.0",
         port: process.env.CORE_P2P_PORT || 4002,
         logLevel: process.env.CORE_NETWORK_NAME === "testnet" ? 1 : 0,

--- a/packages/core-p2p/src/hapi-nes/plugin.ts
+++ b/packages/core-p2p/src/hapi-nes/plugin.ts
@@ -22,6 +22,7 @@ const internals: any = {
 };
 
 internals.schema = Joi.object({
+    banHammerPlugin: Joi.object(),
     onConnection: Joi.function(), // async function (socket) {}
     onDisconnection: Joi.function(), // function (socket) {}
     onMessage: Joi.function(), // async function (socket, message) { return data; }    // Or throw errors

--- a/packages/core-p2p/src/hapi-nes/socket.ts
+++ b/packages/core-p2p/src/hapi-nes/socket.ts
@@ -53,8 +53,19 @@ export class Socket {
         };
 
         this._ws.on("message", (message) => this._onMessage(message));
-        this._ws.on("ping", () => this.terminate());
-        this._ws.on("pong", () => this.terminate());
+        this._ws.on("error", (error) => {
+            if (error instanceof RangeError) {
+                this.terminate(true, error.message.replaceAll("WebSocket", "websocket").replaceAll(":", " -"));
+            }
+        });
+        this._ws.on("ping", () => this.terminate(true, "Malicious ping frame received"));
+        this._ws.on("pong", () => this.terminate(true, "Malicious pong frame received"));
+    }
+
+    public getWebSocket() {
+        if (this._ws && this._ws._socket) {
+            return this._ws._socket;
+        }
     }
 
     public disconnect(): void {
@@ -62,7 +73,10 @@ export class Socket {
         return this._removed;
     }
 
-    public terminate(): void {
+    public terminate(ban: boolean, reason?: string): void {
+        if (ban && this._ws && this._ws._socket) {
+            this._ws._socket.ban = reason;
+        }
         this._ws.terminate();
         return this._removed;
     }
@@ -98,7 +112,7 @@ export class Socket {
 
             /* istanbul ignore else */
             if (message.id) {
-                return this._error(Boom.internal("Failed serializing message"), message);
+                return this._error(Boom.internal("Failed serialising message"), message);
             }
 
             /* istanbul ignore next */
@@ -188,7 +202,7 @@ export class Socket {
 
             return this._send(message);
         } else {
-            this.terminate();
+            this.terminate(true, err.output.payload.message);
             return Promise.resolve();
         }
     }
@@ -197,11 +211,11 @@ export class Socket {
         let request;
         try {
             if (!(message instanceof Buffer)) {
-                return this.terminate();
+                return this.terminate(true, "Invalid message received");
             }
             request = parseNesMessage(message);
         } catch (err) {
-            return this.terminate();
+            return this.terminate(true, "Invaild payload received");
         }
 
         this._pinged = true;
@@ -225,7 +239,7 @@ export class Socket {
             }
         } catch (err) {
             Bounce.rethrow(err, "system");
-            this.terminate();
+            this.terminate(false);
         }
 
         --this._processingCount;
@@ -256,7 +270,7 @@ export class Socket {
         }
 
         if (!this._helloed) {
-            throw Boom.badRequest("Connection is not initialized");
+            throw Boom.badRequest("Connection is not initialised");
         }
 
         // Endpoint request
@@ -274,7 +288,7 @@ export class Socket {
     private async _processHello(request) {
         /* istanbul ignore next */
         if (this._helloed) {
-            throw Boom.badRequest("Connection already initialized");
+            throw Boom.badRequest("Connection already initialised");
         }
 
         if (request.version !== internals.version) {

--- a/packages/core-p2p/src/service-provider.ts
+++ b/packages/core-p2p/src/service-provider.ts
@@ -55,6 +55,7 @@ export class ServiceProvider extends Providers.ServiceProvider {
     public configSchema(): object {
         return Joi.object({
             server: Joi.object({
+                banSeconds: Joi.number().integer().min(0).required(),
                 hostname: Joi.string()
                     .ip({ version: ["ipv4", "ipv6"] })
                     .required(),
@@ -114,7 +115,8 @@ export class ServiceProvider extends Providers.ServiceProvider {
 
     private async buildServer(): Promise<void> {
         const server: Server = this.app.get<Server>(Container.Identifiers.P2PServer);
-        const serverConfig = this.config().getRequired<{ hostname: string; port: number }>("server");
+        const serverConfig =
+            this.config().getRequired<{ banSeconds: number; hostname: string; port: number }>("server");
         Utils.assert.defined<Types.JsonObject>(serverConfig);
 
         await server.initialize("P2P Server", serverConfig);

--- a/packages/core-p2p/src/socket-server/plugins/ban-hammer.ts
+++ b/packages/core-p2p/src/socket-server/plugins/ban-hammer.ts
@@ -1,0 +1,173 @@
+import { isBoom } from "@hapi/boom";
+import { Container, Contracts, Enums, Utils } from "@solar-network/core-kernel";
+import { Server } from "http";
+import { createServer } from "http";
+import { Socket } from "net";
+
+import { getPeerIp } from "../../utils/get-peer-ip";
+import { BlocksRoute } from "../routes/blocks";
+import { PeerRoute } from "../routes/peer";
+import { TransactionsRoute } from "../routes/transactions";
+
+@Container.injectable()
+export class BanHammerPlugin {
+    @Container.inject(Container.Identifiers.Application)
+    protected readonly app!: Contracts.Kernel.Application;
+
+    @Container.inject(Container.Identifiers.EventDispatcherService)
+    private readonly events!: Contracts.Kernel.EventDispatcher;
+
+    @Container.inject(Container.Identifiers.LogService)
+    private readonly logger!: Contracts.Kernel.Logger;
+
+    @Container.inject(Container.Identifiers.PeerProcessor)
+    private readonly peerProcessor!: Contracts.P2P.PeerProcessor;
+
+    private banList: Map<string, number> = new Map();
+    private sockets: Map<string, Map<Socket, boolean>> = new Map();
+
+    private banSeconds!: number;
+
+    private stateGenerated: boolean = false;
+
+    public ban(ip: string, reason: string) {
+        if (this.banSeconds === 0 || this.banSeconds === undefined) {
+            return;
+        }
+
+        const isWhitelisted: boolean = this.peerProcessor.isWhitelisted({ ip } as Contracts.P2P.Peer);
+
+        if (!isWhitelisted) {
+            if (!this.banList.has(ip)) {
+                this.logger.debug(
+                    `Banning ${ip} for ${Utils.formatSeconds(
+                        this.banSeconds,
+                    )}. Reason: ${reason} :oncoming_police_car:`,
+                );
+            }
+            const timeNow: number = new Date().getTime() / 1000;
+            this.banList.set(ip, timeNow);
+        }
+    }
+
+    public createServer(): Server {
+        const listener = createServer();
+
+        listener.on("connection", (socket: Socket) => {
+            const ip = socket.remoteAddress;
+            if (ip) {
+                if (this.banList.has(ip)) {
+                    const bannedUntil: number = this.banList.get(ip)!;
+                    const timeNow: number = new Date().getTime() / 1000;
+                    if (timeNow - bannedUntil >= this.banSeconds) {
+                        this.banList.delete(ip);
+                    } else {
+                        socket.destroy();
+                        return;
+                    }
+                }
+
+                if (this.sockets.has(ip)) {
+                    const foundSockets = this.sockets.get(ip)!;
+                    for (const [foundSocket] of foundSockets) {
+                        if (foundSocket !== socket) {
+                            foundSocket.destroy();
+                        }
+                    }
+                }
+
+                let sockets = this.sockets.get(ip)!;
+                if (!sockets) {
+                    sockets = new Map<Socket, boolean>();
+                    this.sockets.set(ip, sockets);
+                }
+
+                sockets.set(socket, false);
+
+                socket.on("close", () => {
+                    if (this.sockets.has(ip)) {
+                        const foundSockets = this.sockets.get(ip);
+                        if (foundSockets && foundSockets.has(socket)) {
+                            const established = foundSockets.get(socket);
+                            if (!this.banList.has(ip)) {
+                                const nesBanReason: string = (socket as any).ban;
+                                if (nesBanReason) {
+                                    this.ban(ip, nesBanReason);
+                                } else if (!established && this.stateGenerated) {
+                                    this.ban(ip, "Failed to complete websocket handshake");
+                                }
+                            }
+                            foundSockets.delete(socket);
+                            if (foundSockets.size === 0) {
+                                this.sockets.delete(ip);
+                            }
+                        }
+                    }
+                });
+            }
+        });
+
+        listener.timeout = 8000;
+
+        return listener;
+    }
+
+    public register(server, banSeconds: number): void {
+        this.banSeconds = banSeconds;
+
+        this.events.listen(Enums.StateEvent.BuilderFinished, {
+            handle: async () => {
+                this.stateGenerated = true;
+            },
+        });
+
+        const routesConfigByPath = {
+            ...this.app.resolve(PeerRoute).getRoutesConfigByPath(),
+            ...this.app.resolve(BlocksRoute).getRoutesConfigByPath(),
+            ...this.app.resolve(TransactionsRoute).getRoutesConfigByPath(),
+        };
+
+        server.ext({
+            type: "onPostAuth",
+            method: async (request, h) => {
+                if (routesConfigByPath[request.path]) {
+                    const peerIp = request.socket ? getPeerIp(request.socket) : request.info.remoteAddress;
+                    if (request.socket) {
+                        this.setEstablished(peerIp, request.socket.getWebSocket());
+                    }
+                }
+                return h.continue;
+            },
+        });
+
+        server.ext({
+            type: "onPreResponse",
+            method: async (request, h) => {
+                const ip: string = request.info.remoteAddress;
+
+                if (isBoom(request.response)) {
+                    if (ip && request.response.output.statusCode < 499) {
+                        this.ban(
+                            ip,
+                            request.response.output.statusCode == 404
+                                ? "Failed to complete websocket handshake"
+                                : request.response.message,
+                        );
+                    }
+                }
+                return h.continue;
+            },
+        });
+    }
+
+    private setEstablished(ip: string, socket: Socket): void {
+        let sockets: Map<Socket, boolean>;
+        if (this.sockets.has(ip)) {
+            sockets = this.sockets.get(ip)!;
+        } else {
+            sockets = new Map<Socket, boolean>();
+            this.sockets.set(ip, sockets);
+        }
+        sockets.set(socket, true);
+    }
+}


### PR DESCRIPTION
The upstream codebase relies on kernel-based iptables firewall rules to implement IP banning for denial of service mitigation. This is not portable as it requires superuser privileges and is tied to Linux kernels that include the netfilter module. Also, it is optional and requires manual activation at the end, their rules have been known to conflict with existing firewall rules and [there was recently a security vulnerability discovered inside the very tool the upstream Core uses to protect itself](https://www.zdnet.com/article/nasty-linux-netfilter-firewall-security-hole-found/). There have also already been several denial of service security exploits that were not prevented by iptables rules, rendering it not fit for this particular purpose.

With all these facts combined, it was decided that upstream's solution is not a suitable strategy for Solar Core. Therefore, this PR presents an alternative mechanism by introducing its own protection from denial of service attacks without any need for operating system-level reconfiguration. It also has the added benefit that, if debug-level logging is enabled, ban details are printed in the logs for audit purposes. By default, misbehaving peers are banned for one minute which is sufficient to quell any denial of service attack, but this duration can be changed using the `CORE_P2P_BAN_SECONDS` environment variable using `solar env:set`.

As this mitigation mechanism is now built in to Core directly, there are no operating system prerequisites or any need for superuser access or additional firewall configuration at the end which most people probably forget or don't realise they need to do. Ultimately, no matter your operating system or its configuration, Core is now protected right out of the box.