### PR TITLE
fix(core-transaction-pool): set storage to correct directory

### DIFF
--- a/packages/core-transaction-pool/src/defaults.ts
+++ b/packages/core-transaction-pool/src/defaults.ts
@@ -1,6 +1,6 @@
 export const defaults = {
     enabled: !process.env.CORE_TRANSACTION_POOL_DISABLED,
-    storage: `${process.env.CORE_PATH_DATA}/transaction-pool.sqlite`,
+    storage: `${process.env.CORE_PATH_DATA}/transaction-pool/transaction-pool.sqlite`,
     // When the pool contains that many transactions, then a new transaction is
     // only accepted if its fee is higher than the transaction with the lowest
     // fee in the pool. In this case the transaction with the lowest fee is removed


### PR DESCRIPTION
There is a bug in the upstream implementation of the transaction pool as it places its sqlite storage files in the wrong location. This prevents the `pool:clear` CLI option from ever working.

This PR moves the storage files to the correct location, so now `solar pool:clear` works as expected.