### PR TITLE
refactor: keep deps and env vars inside .solar dir

### DIFF
--- a/packages/core-cli/src/services/installer.ts
+++ b/packages/core-cli/src/services/installer.ts
@@ -76,12 +76,18 @@ export class Installer {
         const pnpmFlags = "--reporter=" + (this.output.isNormal() ? "ndjson" : "default");
 
         const shell = spawn(
-            "sh",
+            "/bin/bash",
             [
                 "-c",
-                `( git tag -l | xargs git tag -d && git fetch --all --tags -f && git reset --hard && git checkout tags/${gitTag} && pnpm install ${pnpmFlags} && pnpm build ${pnpmFlags} && exit 0 ) || exit $?`,
+                `(git tag -l | xargs git tag -d &&
+                git fetch --all --tags -f &&
+                git reset --hard &&
+                git checkout tags/${gitTag} &&
+                CFLAGS="$CFLAGS" CPATH="$CPATH" LDFLAGS="$LDFLAGS" LD_LIBRARY_PATH="$LD_LIBRARY_PATH" pnpm install ${pnpmFlags} &&
+                pnpm build ${pnpmFlags} &&
+                exit 0) || exit $?`,
             ],
-            { cols: process.stdout.columns, cwd: corePath },
+            { cols: process.stdout.columns, cwd: corePath, env: process.env as { [key: string]: string } },
         );
 
         let errorLevel = 0;

--- a/packages/core-kernel/src/services/config/drivers/local.ts
+++ b/packages/core-kernel/src/services/config/drivers/local.ts
@@ -2,6 +2,7 @@ import { dotenv, get, set } from "@solar-network/utils";
 import { existsSync, readFileSync } from "fs";
 import importFresh from "import-fresh";
 import Joi from "joi";
+import { homedir } from "os";
 import { extname } from "path";
 
 import { Application } from "../../../contracts/kernel";
@@ -66,13 +67,20 @@ export class LocalConfigLoader implements ConfigLoader {
      */
     public async loadEnvironmentVariables(): Promise<void> {
         try {
-            const config: Record<string, Primitive> = dotenv.parseFile(this.app.environmentFile());
+            const home: string = homedir();
 
-            for (const [key, value] of Object.entries(config)) {
-                if (process.env[key] === undefined) {
-                    set(process.env, key, value);
+            const config: Record<string, Primitive>[] = [
+                dotenv.parseFile(this.app.environmentFile()),
+                dotenv.parseFile(`${home}/.${process.env.CORE_TOKEN}/.env`),
+            ];
+
+            config.forEach((configuration, index) => {
+                for (const [key, value] of Object.entries(configuration)) {
+                    if (+index === 1 || process.env[key] === undefined) {
+                        set(process.env, key, value);
+                    }
                 }
-            }
+            });
         } catch (error) {
             throw new EnvironmentConfigurationCannotBeLoaded(error.message);
         }

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -1,7 +1,9 @@
 import { ApplicationFactory, Commands, Container, Contracts, InputParser, Plugins } from "@solar-network/core-cli";
+import { dotenv, set } from "@solar-network/utils";
 import envPaths from "env-paths";
+import { homedir } from "os";
 import { resolve } from "path";
-import { PackageJson } from "type-fest";
+import { PackageJson, Primitive } from "type-fest";
 
 type Flags = {
     [args: string]: any;
@@ -57,6 +59,14 @@ export class CommandLineInterface {
 
         const args = parsedArgv.args;
         const flags = await this.detectNetworkAndToken(parsedArgv.flags);
+
+        const home: string = homedir();
+
+        const config: Record<string, Primitive> = dotenv.parseFile(`${home}/.${flags.token}/.env`);
+
+        for (const [key, value] of Object.entries(config)) {
+            set(process.env, key, value);
+        }
 
         // Discover commands and commands from plugins
         const commands: Contracts.CommandList = await this.discoverCommands(dirname, flags);


### PR DESCRIPTION
This PR revises the architecture of the Core installation to fix some issues.

The installer no longer relies on identifying English language strings in the logs so it should now work with non-English locales, and we no longer export any environment variables to the shell. Before, we were modifying things like `CPATH`, `CFLAGS`, `LDFLAGS` and so on which may have had adverse consequences if anyone tried building unrelated tools using a compiler under the user account running Core. Now, we only set up aliases for `solar` and `pm2` in the shell and leave the rest untouched. Those previously exported flags are instead located in a separate `.env` file inside `.solar/` and are used internally by the installer and by Core without affecting the shell.

This means Solar Core only modifies the following files and directories (and subdirectories):
`.{bash|ksh|zsh}rc`
`.solar/`
`.solarrc`
`config/@solar-network/`
`config/solar-core/`
`local/share/solar-core/`
`local/state/solar-core/`
`solar-core/`
`/tmp/{USER}/solar-core/`

It also uses its own version of `node` throughout so it will not conflict or clash if a different version of nodejs is installed elsewhere. Everything is now fully localised, making it possible to implement the `uninstall` command which until now has been left unimplemented by the upstream maintainers. This comes in another PR.

It no longer installs `libjemalloc-dev` as this is going to be removed from Core in another PR since it is no longer necessary. It also installs `python3` instead of `python`.