### PR TITLE
fix(core-cli): correctly implement flags

### DIFF
--- a/packages/core/src/commands/pool-clear.ts
+++ b/packages/core/src/commands/pool-clear.ts
@@ -34,6 +34,7 @@ export class Command extends Commands.Command {
      */
     public configure(): void {
         this.definition
+            .setFlag("force", "Force the pool to be cleared", Joi.boolean())
             .setFlag("token", "The name of the token", Joi.string().default("solar"))
             .setFlag("network", "The name of the network", Joi.string().valid(...Object.keys(Networks)));
     }
@@ -49,7 +50,7 @@ export class Command extends Commands.Command {
         this.actions.abortRunningProcess(`${this.getFlag("token")}-forger`);
         this.actions.abortRunningProcess(`${this.getFlag("token")}-relay`);
 
-        if (this.getFlag("false")) {
+        if (this.getFlag("force")) {
             return this.removeFiles();
         }
 

--- a/packages/core/src/commands/reinstall.ts
+++ b/packages/core/src/commands/reinstall.ts
@@ -50,7 +50,9 @@ export class Command extends Commands.Command {
      * @memberof Command
      */
     public configure(): void {
-        this.definition.setFlag("force", "Force a reinstall", Joi.boolean());
+        this.definition
+            .setFlag("force", "Force a reinstall", Joi.boolean())
+            .setFlag("token", "The name of the token", Joi.string().default("solar"));
     }
 
     /**
@@ -65,7 +67,6 @@ export class Command extends Commands.Command {
         }
 
         if (await this.components.confirm("Are you sure you want to reinstall?")) {
-            //Come back to this
             return this.performInstall();
         }
 


### PR DESCRIPTION
The `pool:clear` command was missing a `force` flag and the code was instead looking for a `false` flag which I presume was a typo.

The `reinstall` command checked the value of the `token` flag but it was not set in the command definition, so it was undefined by default unless explicitly set. This meant the command would fail unless a value for `token` was passed as a command line argument.

Both issues are present in the upstream Core and were not a result of any modifications by Solar.