### PR TITLE
chore(core): remove jemalloc

### DIFF
--- a/packages/core/bin/run
+++ b/packages/core/bin/run
@@ -1,36 +1,7 @@
 #!/usr/bin/env node
 
-const child_process = require("child_process");
 const { existsSync, readdirSync, readJSONSync, statSync } = require("fs-extra");
-const glob = require("glob");
 const { dirname, join } = require("path");
-
-const jemallocPath = child_process
-    .spawnSync(
-        `ls -d1H $(gcc -print-search-dirs | grep libraries: | awk '{print $2}' | sed -e 's/:/* /g' -e 's/$/*/' -e 's/^.//') | grep libjemalloc.so`,
-        { shell: true },
-    )
-    .stdout.toString()
-    .split("\n")
-    .shift()
-    .trim();
-
-if (jemallocPath) {
-    if (process.env.LD_PRELOAD !== jemallocPath) {
-        process.env.LD_PRELOAD = jemallocPath;
-        let exitCode = 0;
-        try {
-            child_process.execFileSync(process.argv0, process.argv.slice(1), { stdio: [0, 1, 2] });
-        } catch (error) {
-            exitCode = error.status;
-        }
-        process.exit(exitCode);
-    }
-} else {
-    console.error(
-        "The jemalloc library was not found on your system. It is recommended to install it for better memory management. Falling back to the system default...",
-    );
-}
 
 const main = async () => {
     try {


### PR DESCRIPTION
[I originally implemented jemalloc as the memory allocator in the upstream Core back in 2020](https://github.com/ArkEcosystem/core/pull/3541) as a result of problems with memory fragmentation. In the end, it was [traced to a memory leak caused by the use of compression in the p2p middleware](https://github.com/ArkEcosystem/core/issues/2803).

[Since I fixed that memory leak](https://github.com/ArkEcosystem/core/pull/3518), and the entire p2p middleware was subsequently replaced in Core 3.x, there is no major need for jemalloc anymore, so we no longer ship it.