### PR TITLE
refactor(core-api): wallet compatibility

### DIFF
--- a/packages/core-p2p/src/peer-communicator.ts
+++ b/packages/core-p2p/src/peer-communicator.ts
@@ -219,6 +219,10 @@ export class PeerCommunicator implements Contracts.P2P.PeerCommunicator {
             }
         }
 
+        if (peer.plugins["@solar-network/core-api"]) {
+            peer.plugins["@arkecosystem/core-api"] = peer.plugins["@solar-network/core-api"];
+        }
+
         return pingResponse.state;
     }
 


### PR DESCRIPTION
Peer discovery in the upstream wallet relies on the Public API port being exposed via `@arkecosystem/core-api`. Until now, we have been exposing our Public API exclusively as `@solar-network/core-api`. While this works with our own wallet, it breaks compatibility with the peer discovery mechanism in the upstream wallet.

Since some people may prefer to continue using the wallet provided by the upstream maintainers instead, this PR now exposes the Public API port via both `@arkecosystem/core-api` and `@solar-network/core-api`.