### PR TITLE
refactor: try not to give users epilepsy

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -92,7 +92,7 @@ global-bin-dir=""$SOLAR_DATA_PATH""/.pnpm/bin
 store-dir=""$SOLAR_DATA_PATH""/.pnpm/store" > "$SOLAR_DATA_PATH"/lib/node_modules/npm/npmrc
 ln -sf "$SOLAR_DATA_PATH"/lib/node_modules/npm/npmrc "$SOLAR_DATA_PATH"/etc/npmrc
 
-npm install -g delay@5.0.0 env-paths@2.2.1 kleur@4.1.4 listr@0.14.3 pnpm prompts@2.4.2 >/dev/null 2>/dev/null
+npm install -g delay@5.0.0 env-paths@2.2.1 kleur@4.1.4 @alessiodf/listr pnpm prompts@2.4.2 >/dev/null 2>/dev/null
 
 cat << 'EOF' > "$SOLAR_TEMP_PATH"/install.js
 const { spawn, spawnSync } = require("child_process");
@@ -101,7 +101,8 @@ const envPaths = require("env-paths");
 const { appendFileSync, existsSync, readdirSync, readFileSync, statSync, writeFileSync, unlinkSync } = require("fs");
 const { homedir } = require("os");
 const { white } = require("kleur");
-const Listr = require("listr");
+const Listr = require("@alessiodf/listr");
+
 const prompts = require("prompts");
 
 const envLines = readFileSync(`${process.env.SOLAR_DATA_PATH}/.env`).toString().split("\n");
@@ -163,11 +164,10 @@ function consume(data, stderr) {
         }
         return;
     }
-    if (data.endsWith("]") && currentTask.title.startsWith("Downloading operating system dependencies")) {
+    if (data.endsWith("]") && currentTask.title === "Downloading operating system dependencies") {
         const split = data.split(" ");
         if (!split[4].includes("[") && !split[4].includes("]") && !split[6].includes("[") && !split[6].includes("]")) {
             totalPackages++;
-            currentTask.title = `Downloading operating system dependencies (${split[4]}-${split[6]})`;
         }
     } else if (data.startsWith("{") && data.endsWith("}")) {
         const parsed = JSON.parse(data);
@@ -476,16 +476,12 @@ async function installOSDependencies() {
         for (const pkg of packages) {
             currentPackage++;
             const name = unescape(pkg.substring(0, pkg.length - 4).substring(pkg.lastIndexOf("/") + 1));
-            if (currentTask.title) {
-                currentTask.title = `Installing operating system dependencies (${currentPackage} of ${totalPackages}: ${name})`;
-            }
             try {
                 await installOSDependency(pkg);
             } catch (error) {
                 reject(error);
             }
         }
-        currentTask.title = "Installing operating system dependencies";
         resolve();
     });
 }
@@ -665,7 +661,6 @@ async function start() {
             {
                 title: "Installing operating system dependencies",
                 task: async (_, task) => {
-                    currentTask.title = currentTask.title.substring(0, currentTask.title.lastIndexOf("("));
                     currentTask = task;
                     return await installOSDependencies();
                 },

--- a/packages/core-cli/package.json
+++ b/packages/core-cli/package.json
@@ -19,6 +19,7 @@
         "compile": "node ../../node_modules/typescript/bin/tsc"
     },
     "dependencies": {
+        "@alessiodf/listr": "^0.0.1",
         "@solar-network/core-kernel": "workspace:*",
         "@solar-network/crypto": "workspace:*",
         "@solar-network/utils": "workspace:*",
@@ -37,7 +38,6 @@
         "joi": "17.6.0",
         "kleur": "4.1.4",
         "latest-version": "5.1.0",
-        "listr": "0.14.3",
         "node-pty": "0.10.1",
         "nodejs-tail": "1.1.1",
         "ora": "4.1.1",

--- a/packages/core-cli/package.json
+++ b/packages/core-cli/package.json
@@ -19,7 +19,7 @@
         "compile": "node ../../node_modules/typescript/bin/tsc"
     },
     "dependencies": {
-        "@alessiodf/listr": "^0.0.1",
+        "@alessiodf/listr": "^0.0.2",
         "@alessiodf/ora": "^0.0.1",
         "@solar-network/core-kernel": "workspace:*",
         "@solar-network/crypto": "workspace:*",

--- a/packages/core-cli/package.json
+++ b/packages/core-cli/package.json
@@ -20,6 +20,7 @@
     },
     "dependencies": {
         "@alessiodf/listr": "^0.0.1",
+        "@alessiodf/ora": "^0.0.1",
         "@solar-network/core-kernel": "workspace:*",
         "@solar-network/crypto": "workspace:*",
         "@solar-network/utils": "workspace:*",
@@ -40,7 +41,6 @@
         "latest-version": "5.1.0",
         "node-pty": "0.10.1",
         "nodejs-tail": "1.1.1",
-        "ora": "4.1.1",
         "prompts": "2.4.2",
         "read-last-lines": "1.8.0",
         "reflect-metadata": "0.1.13",

--- a/packages/core-cli/src/component-factory.ts
+++ b/packages/core-cli/src/component-factory.ts
@@ -1,4 +1,4 @@
-import { Options, Ora } from "ora";
+import { Options, Ora } from "@alessiodf/ora";
 import { JsonObject } from "type-fest";
 
 import {

--- a/packages/core-cli/src/components/spinner.ts
+++ b/packages/core-cli/src/components/spinner.ts
@@ -1,4 +1,4 @@
-import ora, { Options, Ora } from "ora";
+import ora, { Options, Ora } from "@alessiodf/ora";
 
 import { injectable } from "../ioc";
 

--- a/packages/core-cli/src/components/task-list.ts
+++ b/packages/core-cli/src/components/task-list.ts
@@ -1,4 +1,4 @@
-import Listr from "listr";
+import Listr from "@alessiodf/listr";
 
 import { injectable } from "../ioc";
 

--- a/packages/core-cli/src/services/installer.ts
+++ b/packages/core-cli/src/services/installer.ts
@@ -1,7 +1,7 @@
 import delay from "delay";
 import { sync } from "execa";
 import { white } from "kleur";
-import Listr from "listr";
+import Listr from "@alessiodf/listr";
 import { spawn } from "node-pty";
 
 import { Application } from "../application";

--- a/packages/core-snapshots/package.json
+++ b/packages/core-snapshots/package.json
@@ -19,6 +19,7 @@
         "compile": "node ../../node_modules/typescript/bin/tsc"
     },
     "dependencies": {
+        "@alessiodf/ora": "^0.0.1",
         "@solar-network/core-database": "workspace:*",
         "@solar-network/core-kernel": "workspace:*",
         "@solar-network/crypto": "workspace:*",
@@ -26,7 +27,6 @@
         "fs-extra": "8.1.0",
         "joi": "17.6.0",
         "msgpack-lite": "0.1.26",
-        "ora": "4.1.1",
         "pg": "8.7.1",
         "pg-query-stream": "3.4.2",
         "pluralize": "8.0.0",

--- a/packages/core-snapshots/src/progress-renderer.ts
+++ b/packages/core-snapshots/src/progress-renderer.ts
@@ -1,5 +1,5 @@
 import { Container, Contracts } from "@solar-network/core-kernel";
-import { Ora } from "ora";
+import { Ora } from "@alessiodf/ora";
 
 import { SnapshotApplicationEvents } from "./events";
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -241,7 +241,7 @@ importers:
 
   packages/core-cli:
     specifiers:
-      '@alessiodf/listr': ^0.0.1
+      '@alessiodf/listr': ^0.0.2
       '@alessiodf/ora': ^0.0.1
       '@solar-network/core-kernel': workspace:*
       '@solar-network/crypto': workspace:*
@@ -277,7 +277,7 @@ importers:
       type-fest: 0.21.3
       yargs-parser: 20.2.9
     dependencies:
-      '@alessiodf/listr': 0.0.1
+      '@alessiodf/listr': 0.0.2
       '@alessiodf/ora': 0.0.1
       '@solar-network/core-kernel': link:../core-kernel
       '@solar-network/crypto': link:../crypto
@@ -758,8 +758,8 @@ importers:
 
 packages:
 
-  /@alessiodf/listr/0.0.1:
-    resolution: {integrity: sha512-9qkXEcnLwtxVI41ZcQr4ll34Bk2AajAtcup7h7Tf4VKz5R9OSXVK2c2klXUyMbZnvdGm99krsVMJf3oZQ5NmEg==}
+  /@alessiodf/listr/0.0.2:
+    resolution: {integrity: sha512-OgLJ0vFkDcp8PovtbuGp1RVI7eND89H9GCP9/byuFkfwE+ISsu6V3N/AlSthKjHdCsfNR/d5LUCk9Lye1ZKIjw==}
     dependencies:
       '@samverschueren/stream-to-observable': 0.3.1_rxjs@7.5.5
       chalk: 4.1.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -241,6 +241,8 @@ importers:
 
   packages/core-cli:
     specifiers:
+      '@alessiodf/listr': ^0.0.1
+      '@alessiodf/ora': ^0.0.1
       '@solar-network/core-kernel': workspace:*
       '@solar-network/crypto': workspace:*
       '@solar-network/utils': workspace:*
@@ -265,10 +267,8 @@ importers:
       joi: 17.6.0
       kleur: 4.1.4
       latest-version: 5.1.0
-      listr: 0.14.3
       node-pty: 0.10.1
       nodejs-tail: 1.1.1
-      ora: 4.1.1
       prompts: 2.4.2
       read-last-lines: 1.8.0
       reflect-metadata: 0.1.13
@@ -277,6 +277,8 @@ importers:
       type-fest: 0.21.3
       yargs-parser: 20.2.9
     dependencies:
+      '@alessiodf/listr': 0.0.1
+      '@alessiodf/ora': 0.0.1
       '@solar-network/core-kernel': link:../core-kernel
       '@solar-network/crypto': link:../crypto
       '@solar-network/utils': link:../utils
@@ -295,10 +297,8 @@ importers:
       joi: 17.6.0
       kleur: 4.1.4
       latest-version: 5.1.0
-      listr: 0.14.3
       node-pty: 0.10.1
       nodejs-tail: 1.1.1
-      ora: 4.1.1
       prompts: 2.4.2
       read-last-lines: 1.8.0
       reflect-metadata: 0.1.13
@@ -516,6 +516,7 @@ importers:
 
   packages/core-snapshots:
     specifiers:
+      '@alessiodf/ora': ^0.0.1
       '@solar-network/core-database': workspace:*
       '@solar-network/core-kernel': workspace:*
       '@solar-network/crypto': workspace:*
@@ -524,13 +525,13 @@ importers:
       fs-extra: 8.1.0
       joi: 17.6.0
       msgpack-lite: 0.1.26
-      ora: 4.1.1
       pg: 8.7.1
       pg-query-stream: 3.4.2
       pluralize: 8.0.0
       typeorm: 0.2.25
       xcase: 2.0.1
     dependencies:
+      '@alessiodf/ora': 0.0.1
       '@solar-network/core-database': link:../core-database
       '@solar-network/core-kernel': link:../core-kernel
       '@solar-network/crypto': link:../crypto
@@ -538,7 +539,6 @@ importers:
       fs-extra: 8.1.0
       joi: 17.6.0
       msgpack-lite: 0.1.26
-      ora: 4.1.1
       pg: 8.7.1
       pg-query-stream: 3.4.2_pg@8.7.1
       pluralize: 8.0.0
@@ -757,6 +757,39 @@ importers:
       '@solar-network/utils': link:../../packages/utils
 
 packages:
+
+  /@alessiodf/listr/0.0.1:
+    resolution: {integrity: sha512-9qkXEcnLwtxVI41ZcQr4ll34Bk2AajAtcup7h7Tf4VKz5R9OSXVK2c2klXUyMbZnvdGm99krsVMJf3oZQ5NmEg==}
+    dependencies:
+      '@samverschueren/stream-to-observable': 0.3.1_rxjs@7.5.5
+      chalk: 4.1.2
+      cli-truncate: 2.1.0
+      figures: 3.2.0
+      indent-string: 4.0.0
+      is-observable: 2.1.0
+      is-promise: 4.0.0
+      is-stream: 2.0.1
+      log-symbols: 4.1.0
+      log-update: 4.0.0
+      p-map: 4.0.0
+      rxjs: 7.5.5
+      strip-ansi: 6.0.1
+    transitivePeerDependencies:
+      - zen-observable
+    dev: false
+
+  /@alessiodf/ora/0.0.1:
+    resolution: {integrity: sha512-Ffe8Vht/MKd3h6ssjtSuuXe7LgM+ZgDmb34tJpKY01l+hPdEhcEWM5Yb3Or48glQHSuuTAkT/qJNq/bl45vZHw==}
+    dependencies:
+      chalk: 4.1.2
+      cli-cursor: 3.1.0
+      figures: 3.2.0
+      is-interactive: 1.0.0
+      log-symbols: 4.1.0
+      mute-stream: 0.0.8
+      strip-ansi: 6.0.1
+      wcwidth: 1.0.1
+    dev: false
 
   /@ampproject/remapping/2.1.2:
     resolution: {integrity: sha512-hoyByceqwKirw7w3Z7gnIIZC3Wx3J484Y3L/cMpXFbr7d9ZQj2mODrirNzcJa+SM3UlpWXYvKV4RlRpFXlWgXg==}
@@ -4074,7 +4107,7 @@ packages:
       picomatch: 2.3.1
     dev: true
 
-  /@samverschueren/stream-to-observable/0.3.1_rxjs@6.6.7:
+  /@samverschueren/stream-to-observable/0.3.1_rxjs@7.5.5:
     resolution: {integrity: sha512-c/qwwcHyafOQuVQJj0IlBjf5yYgBI7YPJ77k4fOJYesb41jio65eaJODRUmfYKhTOFBrIZ66kgvGPlNbjuoRdQ==}
     engines: {node: '>=6'}
     peerDependencies:
@@ -4087,7 +4120,7 @@ packages:
         optional: true
     dependencies:
       any-observable: 0.3.0
-      rxjs: 6.6.7
+      rxjs: 7.5.5
     dev: false
 
   /@sideway/address/4.1.3:
@@ -4920,7 +4953,6 @@ packages:
     dependencies:
       clean-stack: 2.2.0
       indent-string: 4.0.0
-    dev: true
 
   /ajv-keywords/3.4.1_ajv@6.12.6:
     resolution: {integrity: sha512-RO1ibKvd27e6FEShVFfPALuHI3WjSVNeK5FIsmme/LYRNxjKuNj+Dt7bucLa6NdSv3JcVTyMlm9kGR84z1XpaQ==}
@@ -4967,22 +4999,17 @@ packages:
   /ansi-escapes/3.2.0:
     resolution: {integrity: sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==}
     engines: {node: '>=4'}
+    dev: true
 
   /ansi-escapes/4.3.2:
     resolution: {integrity: sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==}
     engines: {node: '>=8'}
     dependencies:
       type-fest: 0.21.3
-    dev: true
 
   /ansi-regex/2.1.1:
     resolution: {integrity: sha1-w7M6te42DYbg5ijwRorn7yfWVN8=}
     engines: {node: '>=0.10.0'}
-
-  /ansi-regex/3.0.0:
-    resolution: {integrity: sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=}
-    engines: {node: '>=4'}
-    dev: false
 
   /ansi-regex/4.1.1:
     resolution: {integrity: sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==}
@@ -5198,7 +5225,6 @@ packages:
   /astral-regex/2.0.0:
     resolution: {integrity: sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==}
     engines: {node: '>=8'}
-    dev: true
 
   /async-limiter/1.0.1:
     resolution: {integrity: sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==}
@@ -5870,14 +5896,6 @@ packages:
       escape-string-regexp: 1.0.5
       supports-color: 5.5.0
 
-  /chalk/3.0.0:
-    resolution: {integrity: sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==}
-    engines: {node: '>=8'}
-    dependencies:
-      ansi-styles: 4.3.0
-      supports-color: 7.2.0
-    dev: false
-
   /chalk/4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
@@ -5973,7 +5991,6 @@ packages:
   /clean-stack/2.2.0:
     resolution: {integrity: sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==}
     engines: {node: '>=6'}
-    dev: true
 
   /clean-stack/3.0.1:
     resolution: {integrity: sha512-lR9wNiMRcVQjSB3a7xXGLuz4cr4wJuuXlaAEbRutGowQTmlp7R72/DOgN21e8jdwblMWl9UOJMJXarX94pzKdg==}
@@ -5985,13 +6002,6 @@ packages:
   /cli-boxes/2.2.1:
     resolution: {integrity: sha512-y4coMcylgSCdVinjiDBuR8PCC2bLjyGTwEmPb9NHR/QaNU6EUOXcTY/s6VjGMD6ENSEaeQYHCY0GNGS5jfMwPw==}
     engines: {node: '>=6'}
-
-  /cli-cursor/2.1.0:
-    resolution: {integrity: sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=}
-    engines: {node: '>=4'}
-    dependencies:
-      restore-cursor: 2.0.0
-    dev: false
 
   /cli-cursor/3.1.0:
     resolution: {integrity: sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==}
@@ -6022,6 +6032,7 @@ packages:
   /cli-spinners/2.6.1:
     resolution: {integrity: sha512-x/5fWmGMnbKQAaNwN+UZlV79qBLM9JFnJuJ03gIi5whrob0xV0ofNVHy9DhwGdsMJQc2OKv0oGmLzvaqvAVv+g==}
     engines: {node: '>=6'}
+    dev: true
 
   /cli-table/0.3.11:
     resolution: {integrity: sha512-IqLQi4lO0nIB4tcdTpN4LCB9FI3uqrJZK7RC515EnhZ6qBaglkIgICb1wjeAqpdoOabm1+SuQtkXIPdYC93jhQ==}
@@ -6040,21 +6051,12 @@ packages:
       colors: 1.4.0
     dev: false
 
-  /cli-truncate/0.2.1:
-    resolution: {integrity: sha1-nxXPuwcFAFNpIWxiasfQWrkN1XQ=}
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      slice-ansi: 0.0.4
-      string-width: 1.0.2
-    dev: false
-
   /cli-truncate/2.1.0:
     resolution: {integrity: sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==}
     engines: {node: '>=8'}
     dependencies:
       slice-ansi: 3.0.0
       string-width: 4.2.3
-    dev: true
 
   /cli-ux/5.6.7:
     resolution: {integrity: sha512-dsKAurMNyFDnO6X1TiiRNiVbL90XReLKcvIq4H777NMqXGBxBws23ag8ubCJE97vVZEgWG2eSUhsyLf63Jv8+g==}
@@ -6498,10 +6500,6 @@ packages:
     resolution: {integrity: sha512-vKQ9DTQPN1FLYiiEEOQ6IBGFqvjCa5rSK3cWMy/Nespm5d/x3dGFT9UBZnkLxCwua/IXBi2TYnwTEpsOvhC4UQ==}
     dev: false
 
-  /date-fns/1.30.1:
-    resolution: {integrity: sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==}
-    dev: false
-
   /dateformat/4.6.3:
     resolution: {integrity: sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==}
     dev: false
@@ -6869,11 +6867,6 @@ packages:
   /electron-to-chromium/1.4.82:
     resolution: {integrity: sha512-Ks+ANzLoIrFDUOJdjxYMH6CMKB8UQo5modAwvSZTxgF+vEs/U7G5IbWFUp6dS4klPkTDVdxbORuk8xAXXhMsWw==}
     dev: true
-
-  /elegant-spinner/1.0.1:
-    resolution: {integrity: sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4=}
-    engines: {node: '>=0.10.0'}
-    dev: false
 
   /elliptic/6.5.4:
     resolution: {integrity: sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==}
@@ -7625,17 +7618,9 @@ packages:
     engines: {node: '>= 0.4.0'}
     dev: false
 
-  /figures/1.7.0:
-    resolution: {integrity: sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=}
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      escape-string-regexp: 1.0.5
-      object-assign: 4.1.1
-    dev: false
-
-  /figures/2.0.0:
-    resolution: {integrity: sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=}
-    engines: {node: '>=4'}
+  /figures/3.2.0:
+    resolution: {integrity: sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==}
+    engines: {node: '>=8'}
     dependencies:
       escape-string-regexp: 1.0.5
     dev: false
@@ -8506,15 +8491,9 @@ packages:
     engines: {node: '>=0.8.19'}
     dev: true
 
-  /indent-string/3.2.0:
-    resolution: {integrity: sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=}
-    engines: {node: '>=4'}
-    dev: false
-
   /indent-string/4.0.0:
     resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
     engines: {node: '>=8'}
-    dev: true
 
   /indent-string/5.0.0:
     resolution: {integrity: sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==}
@@ -8796,11 +8775,9 @@ packages:
     resolution: {integrity: sha512-2rRIahhZr2UWb45fIOuvZGpFtz0TyOZLf32KxBbSoUCeZR495zCKlWUKKUByk3geS2eAs7ZAABt0Y/Rx0GiQGA==}
     dev: false
 
-  /is-observable/1.1.0:
-    resolution: {integrity: sha512-NqCa4Sa2d+u7BWc6CukaObG3Fh+CU9bvixbpcXYhy2VvYS7vVGIdAgnIS5Ks3A/cqk4rebLJ9s8zBstT2aKnIA==}
-    engines: {node: '>=4'}
-    dependencies:
-      symbol-observable: 1.2.0
+  /is-observable/2.1.0:
+    resolution: {integrity: sha512-DailKdLb0WU+xX8K5w7VsJhapwHLZ9jjmazqCJq4X12CTgqq73TKnbRcnSLuXYPOoLQgV5IrD7ePiX/h1vnkBw==}
+    engines: {node: '>=8'}
     dev: false
 
   /is-path-cwd/2.2.0:
@@ -8835,6 +8812,10 @@ packages:
 
   /is-promise/2.2.2:
     resolution: {integrity: sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==}
+    dev: false
+
+  /is-promise/4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
     dev: false
 
   /is-reference/1.2.1:
@@ -8905,7 +8886,6 @@ packages:
   /is-unicode-supported/0.1.0:
     resolution: {integrity: sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==}
     engines: {node: '>=10'}
-    dev: true
 
   /is-unicode-supported/1.1.0:
     resolution: {integrity: sha512-lDcxivp8TJpLG75/DpatAqNzOpDPSpED8XNtrpBHTdQ2InQ1PbW78jhwSxyxhhu+xbVSast2X38bwj8atwoUQA==}
@@ -9255,55 +9235,6 @@ packages:
       supports-color: 8.1.1
     dev: true
 
-  /listr-silent-renderer/1.1.1:
-    resolution: {integrity: sha1-kktaN1cVN3C/Go4/v3S4u/P5JC4=}
-    engines: {node: '>=4'}
-    dev: false
-
-  /listr-update-renderer/0.5.0_listr@0.14.3:
-    resolution: {integrity: sha512-tKRsZpKz8GSGqoI/+caPmfrypiaq+OQCbd+CovEC24uk1h952lVj5sC7SqyFUm+OaJ5HN/a1YLt5cit2FMNsFA==}
-    engines: {node: '>=6'}
-    peerDependencies:
-      listr: ^0.14.2
-    dependencies:
-      chalk: 1.1.3
-      cli-truncate: 0.2.1
-      elegant-spinner: 1.0.1
-      figures: 1.7.0
-      indent-string: 3.2.0
-      listr: 0.14.3
-      log-symbols: 1.0.2
-      log-update: 2.3.0
-      strip-ansi: 3.0.1
-    dev: false
-
-  /listr-verbose-renderer/0.5.0:
-    resolution: {integrity: sha512-04PDPqSlsqIOaaaGZ+41vq5FejI9auqTInicFRndCBgE3bXG8D6W1I+mWhk+1nqbHmyhla/6BUrd5OSiHwKRXw==}
-    engines: {node: '>=4'}
-    dependencies:
-      chalk: 2.4.2
-      cli-cursor: 2.1.0
-      date-fns: 1.30.1
-      figures: 2.0.0
-    dev: false
-
-  /listr/0.14.3:
-    resolution: {integrity: sha512-RmAl7su35BFd/xoMamRjpIE4j3v+L28o8CT5YhAXQJm1fD+1l9ngXY8JAQRJ+tFK2i5njvi0iRUKV09vPwA0iA==}
-    engines: {node: '>=6'}
-    dependencies:
-      '@samverschueren/stream-to-observable': 0.3.1_rxjs@6.6.7
-      is-observable: 1.1.0
-      is-promise: 2.2.2
-      is-stream: 1.1.0
-      listr-silent-renderer: 1.1.1
-      listr-update-renderer: 0.5.0_listr@0.14.3
-      listr-verbose-renderer: 0.5.0
-      p-map: 2.1.0
-      rxjs: 6.6.7
-    transitivePeerDependencies:
-      - zen-observable
-    dev: false
-
   /listr2/3.14.0_enquirer@2.3.6:
     resolution: {integrity: sha512-TyWI8G99GX9GjE54cJ+RrNMcIFBfwMPxc3XTFiAYGN4s10hWROGtOg7+O6u6LE3mNkyld7RSLE6nrKBvTfcs3g==}
     engines: {node: '>=10.0.0'}
@@ -9416,36 +9347,12 @@ packages:
       semver: 7.3.5
     dev: false
 
-  /log-symbols/1.0.2:
-    resolution: {integrity: sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=}
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      chalk: 1.1.3
-    dev: false
-
-  /log-symbols/3.0.0:
-    resolution: {integrity: sha512-dSkNGuI7iG3mfvDzUuYZyvk5dD9ocYCYzNU6CYDE6+Xqd+gwme6Z00NS3dUh8mq/73HaEtT7m6W+yUPtU6BZnQ==}
-    engines: {node: '>=8'}
-    dependencies:
-      chalk: 2.4.2
-    dev: false
-
   /log-symbols/4.1.0:
     resolution: {integrity: sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==}
     engines: {node: '>=10'}
     dependencies:
       chalk: 4.1.2
       is-unicode-supported: 0.1.0
-    dev: true
-
-  /log-update/2.3.0:
-    resolution: {integrity: sha1-iDKP19HOeTiykoN0bwsbwSayRwg=}
-    engines: {node: '>=4'}
-    dependencies:
-      ansi-escapes: 3.2.0
-      cli-cursor: 2.1.0
-      wrap-ansi: 3.0.1
-    dev: false
 
   /log-update/4.0.0:
     resolution: {integrity: sha512-9fkkDevMefjg0mmzWFBW8YkFP91OrizzkW3diF7CpG+S2EYdy4+TVfGwz1zeF8x7hCx1ovSPTOE9Ngib74qqUg==}
@@ -9455,7 +9362,6 @@ packages:
       cli-cursor: 3.1.0
       slice-ansi: 4.0.0
       wrap-ansi: 6.2.0
-    dev: true
 
   /long/3.2.0:
     resolution: {integrity: sha1-2CG3E4yhy1gcFymQ7xTbIAtcR0s=}
@@ -9715,11 +9621,6 @@ packages:
     resolution: {integrity: sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==}
     engines: {node: '>=4'}
     hasBin: true
-    dev: false
-
-  /mimic-fn/1.2.0:
-    resolution: {integrity: sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==}
-    engines: {node: '>=4'}
     dev: false
 
   /mimic-fn/2.1.0:
@@ -10451,13 +10352,6 @@ packages:
     dependencies:
       wrappy: 1.0.2
 
-  /onetime/2.0.1:
-    resolution: {integrity: sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=}
-    engines: {node: '>=4'}
-    dependencies:
-      mimic-fn: 1.2.0
-    dev: false
-
   /onetime/5.1.2:
     resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
     engines: {node: '>=6'}
@@ -10492,20 +10386,6 @@ packages:
       type-check: 0.4.0
       word-wrap: 1.2.3
     dev: true
-
-  /ora/4.1.1:
-    resolution: {integrity: sha512-sjYP8QyVWBpBZWD6Vr1M/KwknSw6kJOz41tvGMlwWeClHBtYKTbHMki1PsLZnxKpXMPbTKv9b3pjQu3REib96A==}
-    engines: {node: '>=8'}
-    dependencies:
-      chalk: 3.0.0
-      cli-cursor: 3.1.0
-      cli-spinners: 2.6.1
-      is-interactive: 1.0.0
-      log-symbols: 3.0.0
-      mute-stream: 0.0.8
-      strip-ansi: 6.0.1
-      wcwidth: 1.0.1
-    dev: false
 
   /ora/5.4.1:
     resolution: {integrity: sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==}
@@ -10600,6 +10480,7 @@ packages:
   /p-map/2.1.0:
     resolution: {integrity: sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==}
     engines: {node: '>=6'}
+    dev: true
 
   /p-map/3.0.0:
     resolution: {integrity: sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ==}
@@ -10613,7 +10494,6 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       aggregate-error: 3.1.0
-    dev: true
 
   /p-timeout/1.2.1:
     resolution: {integrity: sha1-XrOzU7f86Z8QGhA4iAuwVOu+o4Y=}
@@ -11684,14 +11564,6 @@ packages:
       lowercase-keys: 2.0.0
     dev: false
 
-  /restore-cursor/2.0.0:
-    resolution: {integrity: sha1-n37ih/gv0ybU/RYpI9YhKe7g368=}
-    engines: {node: '>=4'}
-    dependencies:
-      onetime: 2.0.1
-      signal-exit: 3.0.7
-    dev: false
-
   /restore-cursor/3.1.0:
     resolution: {integrity: sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==}
     engines: {node: '>=8'}
@@ -11799,12 +11671,12 @@ packages:
     engines: {npm: '>=2.0.0'}
     dependencies:
       tslib: 1.14.1
+    dev: true
 
   /rxjs/7.5.5:
     resolution: {integrity: sha512-sy+H0pQofO95VDmFLzyaw9xNJU4KTRSwQIGM6+iG3SypAtCiLDzpeG8sJrNCWn2Up9km+KhkvTdbkrdy+yzZdw==}
     dependencies:
       tslib: 2.3.1
-    dev: true
 
   /safe-buffer/5.1.2:
     resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
@@ -12060,11 +11932,6 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /slice-ansi/0.0.4:
-    resolution: {integrity: sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=}
-    engines: {node: '>=0.10.0'}
-    dev: false
-
   /slice-ansi/3.0.0:
     resolution: {integrity: sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==}
     engines: {node: '>=8'}
@@ -12072,7 +11939,6 @@ packages:
       ansi-styles: 4.3.0
       astral-regex: 2.0.0
       is-fullwidth-code-point: 3.0.0
-    dev: true
 
   /slice-ansi/4.0.0:
     resolution: {integrity: sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==}
@@ -12081,7 +11947,6 @@ packages:
       ansi-styles: 4.3.0
       astral-regex: 2.0.0
       is-fullwidth-code-point: 3.0.0
-    dev: true
 
   /smart-buffer/4.2.0:
     resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
@@ -12328,14 +12193,6 @@ packages:
       is-fullwidth-code-point: 1.0.0
       strip-ansi: 3.0.1
 
-  /string-width/2.1.1:
-    resolution: {integrity: sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==}
-    engines: {node: '>=4'}
-    dependencies:
-      is-fullwidth-code-point: 2.0.0
-      strip-ansi: 4.0.0
-    dev: false
-
   /string-width/3.1.0:
     resolution: {integrity: sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==}
     engines: {node: '>=6'}
@@ -12393,13 +12250,6 @@ packages:
     engines: {node: '>=0.10.0'}
     dependencies:
       ansi-regex: 2.1.1
-
-  /strip-ansi/4.0.0:
-    resolution: {integrity: sha1-qEeQIusaw2iocTibY1JixQXuNo8=}
-    engines: {node: '>=4'}
-    dependencies:
-      ansi-regex: 3.0.0
-    dev: false
 
   /strip-ansi/5.2.0:
     resolution: {integrity: sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==}
@@ -12506,11 +12356,6 @@ packages:
       setimmediate: 1.0.5
       tar: 4.4.19
       xhr-request: 1.1.0
-    dev: false
-
-  /symbol-observable/1.2.0:
-    resolution: {integrity: sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==}
-    engines: {node: '>=0.10.0'}
     dev: false
 
   /tar-fs/2.1.1:
@@ -13442,14 +13287,6 @@ packages:
     resolution: {integrity: sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==}
     engines: {node: '>=0.10.0'}
 
-  /wrap-ansi/3.0.1:
-    resolution: {integrity: sha1-KIoE2H7aXChuBg3+jxNc6NAH+Lo=}
-    engines: {node: '>=4'}
-    dependencies:
-      string-width: 2.1.1
-      strip-ansi: 4.0.0
-    dev: false
-
   /wrap-ansi/5.1.0:
     resolution: {integrity: sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==}
     engines: {node: '>=6'}
@@ -13466,7 +13303,6 @@ packages:
       ansi-styles: 4.3.0
       string-width: 4.2.3
       strip-ansi: 6.0.1
-    dev: true
 
   /wrap-ansi/7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}


### PR DESCRIPTION
We use Listr to render lists in the installer and command line interface, and Ora for progress indicators in the CLI too. However, they have redraw issues under heavy load (i.e. during an installation, reinstallation or update procedure) that seem to affect various remote terminals such as Termius, VSCode, iTerm2, SecureCRT and probably others, causing a strobing, flickering and flashing effect. Curiously, it doesn't seem to affect the built-in macOS Terminal which is what I personally use.

I have forked both Ora and Listr to change the redraw routines to reduce the unwanted redraw artefacts. It's still not perfect, sometimes there will still be some occasional flashes when the status of the currently executing task changes or new tasks are added (which will particularly affect the `Installing Core dependencies` phase of the installer).

Unfortunately that also means for now we don't have an animated spinner anymore but a static chevron. I know that's not ideal because the animation is useful to check that the process hasn't crashed or that you're still connected via SSH, so we will address this issue properly some time in the future after mainnet, but at least for now it won't be like watching an episode of [Battling Seizure Robots](https://simpsons.fandom.com/wiki/Battling_Seizure_Robots).