### PR TITLE
chore: sxp-swap maintenance

### DIFF
--- a/packages/core/bin/config/testnet/app.json
+++ b/packages/core/bin/config/testnet/app.json
@@ -17,12 +17,6 @@
                 "package": "@solar-network/core-transaction-pool"
             },
             {
-                "package": "@solar-network/sxp-swap",
-                "options": {
-                    "swapWalletPublicKey": "02f1e870a5404676a6f9058f871fc01f538252acbe269e3a3a33822d49905a0659"
-                }
-            },
-            {
                 "package": "@solar-network/core-p2p"
             },
             {
@@ -55,12 +49,6 @@
             },
             {
                 "package": "@solar-network/core-transaction-pool"
-            },
-            {
-                "package": "@solar-network/sxp-swap",
-                "options": {
-                    "swapWalletPublicKey": "02f1e870a5404676a6f9058f871fc01f538252acbe269e3a3a33822d49905a0659"
-                }
             },
             {
                 "package": "@solar-network/core-p2p"

--- a/plugins/sxp-swap/src/defaults.ts
+++ b/plugins/sxp-swap/src/defaults.ts
@@ -1,7 +1,7 @@
 export const defaults = {
     chainId: {
-        bsc: "0x61",
-        eth: "0x2a",
+        bsc: "0x38",
+        eth: "0x01",
     },
     contractAbis: {
         bsc: `
@@ -86,26 +86,6 @@ export const defaults = {
                 },
                 {
                     "inputs": [],
-                    "name": "isLocked",
-                    "outputs": [
-                        {
-                            "internalType": "bool",
-                            "name": "",
-                            "type": "bool"
-                        }
-                    ],
-                    "stateMutability": "view",
-                    "type": "function"
-                },
-                {
-                    "inputs": [],
-                    "name": "lockSwap",
-                    "outputs": [],
-                    "stateMutability": "nonpayable",
-                    "type": "function"
-                },
-                {
-                    "inputs": [],
                     "name": "owner",
                     "outputs": [
                         {
@@ -151,13 +131,6 @@ export const defaults = {
                         }
                     ],
                     "name": "transferOwnership",
-                    "outputs": [],
-                    "stateMutability": "nonpayable",
-                    "type": "function"
-                },
-                {
-                    "inputs": [],
-                    "name": "unlockSwap",
                     "outputs": [],
                     "stateMutability": "nonpayable",
                     "type": "function"
@@ -246,26 +219,6 @@ export const defaults = {
                 },
                 {
                     "inputs": [],
-                    "name": "isLocked",
-                    "outputs": [
-                        {
-                            "internalType": "bool",
-                            "name": "",
-                            "type": "bool"
-                        }
-                    ],
-                    "stateMutability": "view",
-                    "type": "function"
-                },
-                {
-                    "inputs": [],
-                    "name": "lockSwap",
-                    "outputs": [],
-                    "stateMutability": "nonpayable",
-                    "type": "function"
-                },
-                {
-                    "inputs": [],
                     "name": "owner",
                     "outputs": [
                         {
@@ -314,13 +267,6 @@ export const defaults = {
                     "outputs": [],
                     "stateMutability": "nonpayable",
                     "type": "function"
-                },
-                {
-                    "inputs": [],
-                    "name": "unlockSwap",
-                    "outputs": [],
-                    "stateMutability": "nonpayable",
-                    "type": "function"
                 }
             ]
         `,
@@ -335,16 +281,16 @@ export const defaults = {
         eth: 35,
     },
     peers: {
-        bsc: ["https://bsc1.testnet.sh", "https://bsc2.testnet.sh", "https://bsc3.testnet.sh"],
-        eth: ["https://eth1.testnet.sh", "https://eth2.testnet.sh", "https://eth3.testnet.sh"]
+        bsc: ["https://bsc1.mainnet.sh", "https://bsc2.mainnet.sh", "https://bsc3.mainnet.sh"],
+        eth: ["https://eth1.mainnet.sh", "https://eth2.mainnet.sh", "https://eth3.mainnet.sh"]
     },
     sxpTokenContracts: {
-        bsc: "0x8B06059234080FcB3e5f32598bf256d6d911FC26",
-        eth: "0x3DD5CfbC967593E8D7C7f391F131E44c0A8a6892",
+        bsc: "0x47bead2563dcbf3bf2c9407fea4dc236faba485a",
+        eth: "0x8ce9137d39326ad0cd6491fb5cc0cba0e089b6a9",
     },
     swapContractAddresses: {
-        bsc: "0x80a531752F7686435a1Eb15c8e41D9465daf2178",
-        eth: "0x4436fc5feF736FD6f7E0F537521a5246F0e29a66",
+        bsc: "0x66b44A53b55d2e4d69976cCF196D6beD2861D5a6",
+        eth: "0x3996E6837D7F43b046a95517436D1aAFc3BcC135",
     },
     swapWalletPublicKey: "",
 };

--- a/plugins/sxp-swap/src/sxp-swap.ts
+++ b/plugins/sxp-swap/src/sxp-swap.ts
@@ -239,9 +239,9 @@ export class SXPSwap {
                     const requests = peers[network].map((peer: Web3) =>
                         Promise.all([
                             peer.eth.currentProvider ? (peer.eth.currentProvider as HttpProvider).host : undefined,
-                            peer.eth.getBlockNumber(),
-                            peer.eth.getTransaction(transactionId),
-                            peer.eth.getTransactionReceipt(transactionId),
+                            self.getBlockNumber(peer),
+                            self.getTransaction(transactionId, peer),
+                            self.getReceipt(transactionId, peer)
                         ]),
                     );
 
@@ -432,5 +432,47 @@ export class SXPSwap {
         this.app
             .get<Services.Triggers.Triggers>(Container.Identifiers.TriggerService)
             .bind("applyTransaction", new ApplyTransactionAction());
+    }
+
+    private async getBlockNumber(peer) {
+        return new Promise(async (resolve, reject) => {
+            try {
+                const blockNumber = await peer.eth.getBlockNumber();
+                if (!blockNumber) {
+                    reject();
+                }
+                resolve(blockNumber);
+            } catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    private async getTransaction(transactionId, peer) {
+        return new Promise(async (resolve, reject) => {
+            try {
+                const transaction = await peer.eth.getTransaction(transactionId);
+                if (!transaction) {
+                    reject();
+                }
+                resolve(transaction);
+            } catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    private async getReceipt(transactionId, peer) {
+        return new Promise(async (resolve, reject) => {
+            try {
+                const receipt = await peer.eth.getTransactionReceipt(transactionId);
+                if (!receipt) {
+                    reject();
+                }
+                resolve(receipt);
+            } catch (err) {
+                reject(err);
+            }
+        });
     }
 }


### PR DESCRIPTION
Previous version of the swap plugin would not validate a swap in case one of the api nodes was not in sync and they would be the first to reply. This PR fixes this issue by not considering non valid responses from api.

This PR also includes changes of the plugin defaults in preparation for mainnet and the removal of the plugin from testnet.