### PR TITLE
feat(core): new command to create database

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -541,15 +541,9 @@ async function setUpDatabase() {
         const { data } = envPaths(process.env.SOLAR_CORE_TOKEN, { suffix: "core" });
         const psql = spawn(
             `
-                . "${process.env.SOLAR_DATA_PATH}"/.env &&
-                mkdir -p ${data}/${network}/database &&
-                LD_LIBRARY_PATH="$LD_LIBRARY_PATH" "$POSTGRES_DIR"/bin/initdb -D ${data}/${network}/database &&
-                echo "\n# "$SOLAR_CORE_TOKEN"\nlisten_addresses = ''\nunix_socket_directories = '${data}/${network}/database'\nunix_socket_permissions = 0700" >> ${data}/${network}/database/postgresql.conf &&
-                "$POSTGRES_DIR"/bin/pg_ctl -D ${data}/${network}/database start >"$SOLAR_TEMP_PATH"/pg_ctl.log &&
-                cat "$SOLAR_TEMP_PATH"/pg_ctl.log &&
-                rm "$SOLAR_TEMP_PATH"/pg_ctl.log &&
                 sed -i "s@"/usr/lib/postgresql/"@""$SOLAR_DATA_PATH"/usr/lib/postgresql/"@g" "$SOLAR_DATA_PATH"/usr/share/perl5/PgCommon.pm &&
-                LD_LIBRARY_PATH="$LD_LIBRARY_PATH" PERL5LIB="$PERL5LIB" createdb -h ${data}/${network}/database "$SOLAR_CORE_TOKEN"_${network}
+                cd "$SOLAR_CORE_PATH" &&
+                "$SOLAR_DATA_PATH"/bin/node packages/core/bin/run database:create --network=${network}
             `,
             { shell: true },
         );

--- a/packages/core/src/commands/database-create.ts
+++ b/packages/core/src/commands/database-create.ts
@@ -68,7 +68,6 @@ export class Command extends Commands.Command {
                         //
                     }
                 }
-                await remove(databaseDir);
                 return this.createDatabase(databaseDir);
             }
 
@@ -91,6 +90,7 @@ export class Command extends Commands.Command {
         const spinner = this.components.spinner("Creating database");
         spinner.start();
         try {
+            await remove(databaseDir);
             mkdirSync(databaseDir, { recursive: true });
 
             let shellResult = await this.shell(`${process.env.POSTGRES_DIR}/bin/initdb -D ${databaseDir}`);

--- a/packages/core/src/commands/database-create.ts
+++ b/packages/core/src/commands/database-create.ts
@@ -95,7 +95,7 @@ export class Command extends Commands.Command {
 
             let shellResult = await this.shell(`${process.env.POSTGRES_DIR}/bin/initdb -D ${databaseDir}`);
             if (shellResult.exitCode !== 0) {
-                throw new Error(shellResult.stdout.toString());
+                throw new Error(shellResult.stderr.toString());
             }
 
             let config: string = readFileSync(`${databaseDir}/postgresql.conf`).toString();
@@ -108,14 +108,14 @@ export class Command extends Commands.Command {
 
             shellResult = await this.shell(`${process.env.POSTGRES_DIR}/bin/pg_ctl -D ${databaseDir} start >/dev/null`);
             if (shellResult.exitCode !== 0) {
-                throw new Error(shellResult.stdout.toString());
+                throw new Error(shellResult.stderr.toString());
             }
 
             shellResult = await this.shell(
                 `createdb -h ${databaseDir} ${this.getFlag("token")}_${this.getFlag("network")}`,
             );
             if (shellResult.exitCode !== 0) {
-                throw new Error(shellResult.stdout.toString());
+                throw new Error(shellResult.stderr.toString());
             }
 
             spinner.succeed();

--- a/packages/core/src/commands/database-create.ts
+++ b/packages/core/src/commands/database-create.ts
@@ -1,0 +1,127 @@
+import { Commands, Container } from "@solar-network/core-cli";
+import { Networks } from "@solar-network/crypto";
+import envPaths from "env-paths";
+import execa, { ExecaReturnValue } from "execa";
+import { existsSync, mkdirSync, readFileSync, remove, statSync, writeFileSync } from "fs-extra";
+import Joi from "joi";
+
+/**
+ * @export
+ * @class Command
+ * @extends {Commands.Command}
+ */
+@Container.injectable()
+export class Command extends Commands.Command {
+    /**
+     * The console command signature.
+     *
+     * @type {string}
+     * @memberof Command
+     */
+    public signature: string = "database:create";
+
+    /**
+     * The console command description.
+     *
+     * @type {string}
+     * @memberof Command
+     */
+    public description: string = "Create a new database to store the blockchain";
+
+    /**
+     * Configure the console command.
+     *
+     * @returns {void}
+     * @memberof Command
+     */
+    public configure(): void {
+        this.definition
+            .setFlag("force", "Force the database creation", Joi.boolean())
+            .setFlag("token", "The name of the token", Joi.string().default("solar"))
+            .setFlag("network", "The name of the network", Joi.string().valid(...Object.keys(Networks)));
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @returns {Promise<void>}
+     * @memberof Command
+     */
+    public async execute(): Promise<void> {
+        const { data } = envPaths(this.getFlag("token"), { suffix: "core" });
+        const databaseDir: string = `${data}/${this.getFlag("network")}/database`;
+        const pidFile: string = databaseDir + "/postmaster.pid";
+        if (existsSync(databaseDir)) {
+            if (
+                this.getFlag("force") ||
+                (await this.components.confirm(
+                    `The ${this.getFlag(
+                        "network",
+                    )} database already exists. Do you want to destroy it and create a new one?`,
+                ))
+            ) {
+                if (existsSync(pidFile) && statSync(pidFile).isFile()) {
+                    try {
+                        const pid: string = readFileSync(pidFile).toString().split("\n")[0];
+                        process.kill(+pid);
+                    } catch {
+                        //
+                    }
+                }
+                await remove(databaseDir);
+                return this.createDatabase(databaseDir);
+            }
+
+            return;
+        }
+
+        return this.createDatabase(databaseDir);
+    }
+
+    private async shell(command: string): Promise<ExecaReturnValue> {
+        return execa(command, { shell: true });
+    }
+
+    /**
+     * @private
+     * @returns {Promise<void>}
+     * @memberof Command
+     */
+    private async createDatabase(databaseDir: string): Promise<void> {
+        const spinner = this.components.spinner("Creating database");
+        spinner.start();
+        try {
+            mkdirSync(databaseDir, { recursive: true });
+
+            let shellResult = await this.shell(`${process.env.POSTGRES_DIR}/bin/initdb -D ${databaseDir}`);
+            if (shellResult.exitCode !== 0) {
+                throw new Error(shellResult.stdout.toString());
+            }
+
+            let config: string = readFileSync(`${databaseDir}/postgresql.conf`).toString();
+            config +=
+                `\n# ${this.getFlag("token")}\n` +
+                `listen_addresses = ''\n` +
+                `unix_socket_directories = '${databaseDir}'\n` +
+                `unix_socket_permissions = 0700`;
+            writeFileSync(`${databaseDir}/postgresql.conf`, config);
+
+            shellResult = await this.shell(`${process.env.POSTGRES_DIR}/bin/pg_ctl -D ${databaseDir} start >/dev/null`);
+            if (shellResult.exitCode !== 0) {
+                throw new Error(shellResult.stdout.toString());
+            }
+
+            shellResult = await this.shell(
+                `createdb -h ${databaseDir} ${this.getFlag("token")}_${this.getFlag("network")}`,
+            );
+            if (shellResult.exitCode !== 0) {
+                throw new Error(shellResult.stdout.toString());
+            }
+
+            spinner.succeed();
+        } catch (error) {
+            spinner.fail();
+            this.components.error(error);
+        }
+    }
+}


### PR DESCRIPTION
This adds a new `database:create` command to the CLI to (re)create the necessary structure for a new PostgreSQL database for the specified network in our local architecture.

Accordingly, the install script has also been refactored to use this command as part of the setup routine.