### PR TITLE
feat: delegate name in vote asset

### DIFF
--- a/packages/core-state/src/block-state.ts
+++ b/packages/core-state/src/block-state.ts
@@ -243,7 +243,14 @@ export class BlockState implements Contracts.State.BlockState {
 
             for (let i = 0; i < transaction.asset.votes.length; i++) {
                 const vote: string = transaction.asset.votes[i];
-                const delegate: Contracts.State.Wallet = this.walletRepository.findByPublicKey(vote.substr(1));
+                let delegate: Contracts.State.Wallet;
+
+                const delegateVote: string = vote.slice(1);
+                if (delegateVote.length === 66) {
+                    delegate = this.walletRepository.findByPublicKey(delegateVote);
+                } else {
+                    delegate = this.walletRepository.findByUsername(delegateVote);
+                }
 
                 // first unvote also changes vote balance by fee
                 const senderVoteDelegatedAmount =

--- a/packages/core-transactions/src/handlers/two/vote.ts
+++ b/packages/core-transactions/src/handlers/two/vote.ts
@@ -34,16 +34,22 @@ export class VoteTransactionHandler extends One.VoteTransactionHandler {
             for (const vote of transaction.asset.votes) {
                 const hasVoted: boolean = wallet.hasAttribute("vote");
 
+                let delegateVote: string = vote.slice(1);
+                if (delegateVote.length !== 66) {
+                    const delegateWallet: Contracts.State.Wallet = this.walletRepository.findByUsername(delegateVote);
+                    delegateVote = delegateWallet.getPublicKey()!;
+                }
+
                 if (vote.startsWith("+")) {
                     if (hasVoted) {
                         throw new AlreadyVotedError();
                     }
 
-                    wallet.setAttribute("vote", vote.slice(1));
+                    wallet.setAttribute("vote", delegateVote);
                 } else {
                     if (!hasVoted) {
                         throw new NoVoteError();
-                    } else if (wallet.getAttribute("vote") !== vote.slice(1)) {
+                    } else if (wallet.getAttribute("vote") !== delegateVote) {
                         throw new UnvoteMismatchError();
                     }
 

--- a/packages/crypto/src/transactions/types/one/vote.ts
+++ b/packages/crypto/src/transactions/types/one/vote.ts
@@ -18,11 +18,21 @@ export class VoteTransaction extends Transaction {
 
     public serialize(options?: ISerializeOptions): ByteBuffer | undefined {
         const { data } = this;
-        const buff: ByteBuffer = new ByteBuffer(Buffer.alloc(100));
+        const buff: ByteBuffer = new ByteBuffer(Buffer.alloc(69));
 
         if (data.asset && data.asset.votes) {
             const voteBytes = data.asset.votes
-                .map((vote) => (vote.startsWith("+") ? "01" : "00") + vote.slice(1))
+                .map((vote) => {
+                    const prefix = vote.startsWith("+") ? "01" : "00";
+                    const sliced = vote.slice(1);
+                    if (sliced.length === 66) {
+                        return prefix + sliced;
+                    }
+
+                    return (
+                        "ff" + vote.length.toString(16).padStart(2, "0") + prefix + Buffer.from(sliced).toString("hex")
+                    );
+                })
                 .join("");
             buff.writeUInt8(data.asset.votes.length);
             buff.writeBuffer(Buffer.from(voteBytes, "hex"));
@@ -33,12 +43,22 @@ export class VoteTransaction extends Transaction {
 
     public deserialize(buf: ByteBuffer): void {
         const { data } = this;
-        const votelength: number = buf.readUInt8();
+        const voteLength: number = buf.readUInt8();
         data.asset = { votes: [] };
 
-        for (let i = 0; i < votelength; i++) {
-            let vote: string = buf.readBuffer(34).toString("hex");
-            vote = (vote[1] === "1" ? "+" : "-") + vote.slice(2);
+        for (let i = 0; i < voteLength; i++) {
+            const firstByte: number = buf.readUInt8();
+            let vote: string;
+            if (firstByte !== 0xff) {
+                buf.jump(-1);
+                vote = buf.readBuffer(34).toString("hex");
+                vote = (vote[1] === "1" ? "+" : "-") + vote.slice(2);
+            } else {
+                const length: number = buf.readUInt8();
+                const voteBuffer: Buffer = buf.readBuffer(length);
+                const prefix: number = voteBuffer.readUInt8();
+                vote = (prefix === 1 ? "+" : "-") + voteBuffer.slice(1).toString();
+            }
 
             if (data.asset && data.asset.votes) {
                 data.asset.votes.push(vote);

--- a/packages/crypto/src/validation/schemas.ts
+++ b/packages/crypto/src/validation/schemas.ts
@@ -39,7 +39,15 @@ export const schemas = {
 
     walletVote: {
         $id: "walletVote",
-        allOf: [{ type: "string", pattern: "^[+|-][a-zA-Z0-9]{66}$" }, { transform: ["toLowerCase"] }],
+        allOf: [
+            {
+                oneOf: [
+                    { type: "string", pattern: "^[+|-][a-zA-Z0-9]{66}$" },
+                    { type: "string", pattern: "^[+|-][a-z0-9!@$&_.]+$", minLength: 2, maxLength: 21 },
+                ],
+            },
+            { transform: ["toLowerCase"] },
+        ],
     },
 
     username: {


### PR DESCRIPTION
This PR updates the asset of the vote transaction type to accept a delegate name in place of the public key, e.g. `+gym` for a vote or `-gym` for an unvote. For backwards compatibility, the public key is still accepted.

This means the Ledger app can display the name of the delegate a user is about to vote or unvote, rather than only their public key, which significantly improves the user experience. The delegate name is short enough for a user to easily check and confirm it is correct on the Ledger screen, unlike the public key which is not usually displayed in the wallet anyway when voting and is 66 characters long, therefore making a user susceptible to skipping it and not actually verifying it properly.