### PR TITLE
refactor(crypto): use milestone height for transaction fee burn

### DIFF
--- a/packages/core-database/src/model-converter.ts
+++ b/packages/core-database/src/model-converter.ts
@@ -45,6 +45,8 @@ export class ModelConverter implements Contracts.Database.ModelConverter {
             // set_row_nonce trigger
             data.nonce = model.nonce;
 
+            data.burnedFee = model.burnedFee;
+
             // block constructor
             data.blockId = model.blockId;
             data.blockHeight = model.blockHeight;

--- a/packages/core-kernel/src/contracts/state/block-state.ts
+++ b/packages/core-kernel/src/contracts/state/block-state.ts
@@ -8,9 +8,9 @@ export interface BlockState {
 
     revertBlock(block: Interfaces.IBlock): Promise<void>;
 
-    applyTransaction(transaction: Interfaces.ITransaction): Promise<void>;
+    applyTransaction(height: number, transaction: Interfaces.ITransaction): Promise<void>;
 
-    revertTransaction(transaction: Interfaces.ITransaction): Promise<void>;
+    revertTransaction(height: number, transaction: Interfaces.ITransaction): Promise<void>;
 
     increaseWalletDelegateVoteBalance(wallet: Wallet, amount: BigNumber): void;
 

--- a/packages/crypto/src/blocks/block.ts
+++ b/packages/crypto/src/blocks/block.ts
@@ -112,6 +112,7 @@ export class Block implements IBlock {
     public getBurnedFees(): BigNumber {
         let fees = BigNumber.ZERO;
         for (const transaction of this.transactions) {
+            transaction.setBurnedFee(this.data.height);
             fees = fees.plus(transaction.data.burnedFee!);
         }
         return fees;

--- a/packages/crypto/src/interfaces/transactions.ts
+++ b/packages/crypto/src/interfaces/transactions.ts
@@ -17,6 +17,8 @@ export interface ITransaction {
     serialized: Buffer;
     timestamp: number;
 
+    setBurnedFee(height: number): void;
+
     serialize(options?: ISerializeOptions): ByteBuffer | undefined;
     deserialize(buf: ByteBuffer): void;
 

--- a/packages/crypto/src/transactions/deserializer.ts
+++ b/packages/crypto/src/transactions/deserializer.ts
@@ -6,7 +6,6 @@ import {
 } from "../errors";
 import { Address } from "../identities";
 import { IDeserializeOptions, ITransaction, ITransactionData } from "../interfaces";
-import { configManager } from "../managers";
 import { BigNumber, ByteBuffer, isSupportedTransactionVersion } from "../utils";
 import { TransactionTypeFactory } from "./types";
 
@@ -34,8 +33,6 @@ export class Deserializer {
 
         const buff: ByteBuffer = this.getByteBuffer(serialized);
         this.deserializeCommon(data, buff);
-
-        this.burnFee(data);
 
         const instance: ITransaction = TransactionTypeFactory.create(data);
         this.deserializeVendorField(instance, buff);
@@ -141,16 +138,5 @@ export class Deserializer {
         }
 
         return new ByteBuffer(serialized);
-    }
-
-    private static burnFee(data: ITransactionData): void {
-        const milestone = configManager.getMilestone();
-        data.burnedFee = BigNumber.ZERO;
-        if (milestone.burnPercentage !== undefined) {
-            const burnPercentage = parseInt(milestone.burnPercentage);
-            if (burnPercentage >= 0 && burnPercentage <= 100) {
-                data.burnedFee = data.fee.minus(data.fee.times(100 - burnPercentage).dividedBy(100));
-            }
-        }
     }
 }

--- a/packages/crypto/src/transactions/types/transaction.ts
+++ b/packages/crypto/src/transactions/types/transaction.ts
@@ -70,6 +70,18 @@ export abstract class Transaction implements ITransaction {
         return this.defaultStaticFee;
     }
 
+    public setBurnedFee(height: number): void {
+        const milestone = configManager.getMilestone(height);
+
+        this.data.burnedFee = BigNumber.ZERO;
+        if (milestone.burnPercentage !== undefined) {
+            const burnPercentage = parseInt(milestone.burnPercentage);
+            if (burnPercentage >= 0 && burnPercentage <= 100) {
+                this.data.burnedFee = this.data.fee.times(burnPercentage).dividedBy(100);
+            }
+        }
+    }
+
     public verify(options?: ISerializeOptions): boolean {
         return Verifier.verify(this.data, options);
     }


### PR DESCRIPTION
This PR moves the fee burn calculation logic out of the deserialiser so that it has better compatibility with milestones.

The formula for calculating the fee burn has also been simplified. It is mostly functionally equivalent, with the exception that any  _de minimis_ decimal truncation is now favourable for the delegate that forged the transaction which previously was not the case. In other words, assuming we burn 90% of a 1.00000123 SXP fee, this would mathematically be 0.900001107, but the coin is limited to 8 decimal places so the final decimal is truncated. Previously 0.90000111 SXP would have been burned with the delegate keeping 0.10000012 SXP but with the revised formula, 0.90000110 SXP is burned so the delegate keeps 0.10000013. The difference is so negligible that it is irrelevant, and cleaner code and simplified logic is considered better.