### PR TITLE
release: mainnet 3.2.2

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -327,7 +327,7 @@ async function core() {
                 pm2 set pm2-logrotate:retain 7 &&
                 ln -sf "$SOLAR_DATA_PATH"/bin/node "$SOLAR_DATA_PATH"/.pnpm/bin/node &&
                 rm -rf /tmp/pm2-logrotate &&
-                (crontab -l; echo "@reboot /bin/bash -lc \\"source "$SOLAR_DATA_PATH"/.env; "$SOLAR_DATA_PATH"/.pnpm/bin/pm2 resurrect\\"") | sort -u - | crontab - 2>/dev/null &&
+                ((crontab -l; echo "@reboot /bin/bash -lc \\"source "$SOLAR_DATA_PATH"/.env; "$SOLAR_DATA_PATH"/.pnpm/bin/pm2 resurrect\\"") | sort -u - | crontab - 2>/dev/null) || true &&
                 cd "$SOLAR_CORE_PATH" &&
                 CFLAGS="$CFLAGS" CPATH="$CPATH" LDFLAGS="$LDFLAGS" LD_LIBRARY_PATH="$LD_LIBRARY_PATH" pnpm install ${pnpmFlags} &&
                 pnpm build ${pnpmFlags} &&

--- a/install.sh
+++ b/install.sh
@@ -753,7 +753,7 @@ async function start() {
 
         const rc =
             `alias ${process.env.SOLAR_CORE_TOKEN}="${process.env.SOLAR_DATA_PATH}/bin/node ${process.env.SOLAR_CORE_PATH}/packages/core/bin/run $@ --token=${process.env.SOLAR_CORE_TOKEN}"\n` +
-            `alias pm2="${process.env.SOLAR_DATA_PATH}/.pnpm/bin/pm2"`;
+            `alias pm2="/bin/bash --rcfile "${process.env.SOLAR_DATA_PATH}"/.env -i ${process.env.SOLAR_DATA_PATH}/.pnpm/bin/pm2 $@"`;
         writeFileSync(`${home}/.${process.env.SOLAR_CORE_TOKEN}rc`, rc);
 
         for (const file of [".bashrc", ".kshrc", ".zshrc"]) {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
         "husky": "7.0.4",
         "js-yaml": "4.1.0",
         "lint-staged": "11.2.6",
-        "moment": "2.29.1",
+        "moment": "2.29.2",
         "moment-timezone": "0.5.33",
         "npm-check-updates": "11.8.5",
         "prettier": "2.4.1",

--- a/packages/core-api/package.json
+++ b/packages/core-api/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-api",
-    "version": "3.2.2-next.0",
+    "version": "3.2.2-next.1",
     "description": "Public API for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-api/package.json
+++ b/packages/core-api/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-api",
-    "version": "3.2.2-next.1",
+    "version": "3.2.2",
     "description": "Public API for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-api/package.json
+++ b/packages/core-api/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-api",
-    "version": "3.2.1",
+    "version": "3.2.2-next.0",
     "description": "Public API for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-api/src/controllers/controller.ts
+++ b/packages/core-api/src/controllers/controller.ts
@@ -58,10 +58,12 @@ export class Controller {
 
         const orderBy = Array.isArray(request.query.orderBy) ? request.query.orderBy : request.query.orderBy.split(",");
 
-        return orderBy.map((s: string) => ({
-            property: s.split(":")[0],
-            direction: s.split(":")[1] === "desc" ? "desc" : "asc",
-        }));
+        return orderBy
+            .flatMap((o: object) => o)
+            .map((s: string) => ({
+                property: s.split(":")[0],
+                direction: s.split(":")[1] === "desc" ? "desc" : "asc",
+            }));
     }
 
     protected getListingOptions(): Contracts.Search.Options {

--- a/packages/core-api/src/plugins/pagination/ext.ts
+++ b/packages/core-api/src/plugins/pagination/ext.ts
@@ -54,7 +54,8 @@ export class Ext {
 
         // strip prefix in baseUri, we want a "clean" relative path
         const baseUri = request.url.pathname.slice(this.routePathPrefix.length) + "?";
-        const { query } = request;
+        const query = { ...request.query };
+        delete query.orderBy;
         const currentPage = query.page;
         const currentLimit = query.limit;
 

--- a/packages/core-api/src/schemas.ts
+++ b/packages/core-api/src/schemas.ts
@@ -74,27 +74,31 @@ export const createSortingSchema = (
 
         const sorting: Contracts.Search.Sorting = [];
 
-        for (const item of value.split(",")) {
-            const pair = item.split(":");
-            const property = String(pair[0]);
-            const direction = pair.length === 1 ? "asc" : pair[1];
+        const sortingCriteria: string[] = Array.isArray(value) ? value : [value];
 
-            if (!exactPaths.includes(property) && !wildcardPaths.find((wp) => property.startsWith(`${wp}.`))) {
-                return helpers.message({
-                    custom: `Unknown orderBy property '${property}'`,
-                });
-            }
+        for (const criteria of sortingCriteria) {
+            for (const item of criteria.split(",")) {
+                const pair = item.split(":");
+                const property = String(pair[0]);
+                const direction = pair.length === 1 ? "asc" : pair[1];
 
-            if (direction !== "asc" && direction !== "desc") {
-                return helpers.message({
-                    custom: `Unexpected orderBy direction '${direction}' for property '${property}'`,
-                });
-            }
+                if (!exactPaths.includes(property) && !wildcardPaths.find((wp) => property.startsWith(`${wp}.`))) {
+                    return helpers.message({
+                        custom: `Unknown orderBy property '${property}'`,
+                    });
+                }
 
-            if (transform) {
-                sorting.push({ property, direction: direction as "asc" | "desc" });
-            } else {
-                sorting.push(value);
+                if (direction !== "asc" && direction !== "desc") {
+                    return helpers.message({
+                        custom: `Unexpected orderBy direction '${direction}' for property '${property}'`,
+                    });
+                }
+
+                if (transform) {
+                    sorting.push({ property, direction: direction as "asc" | "desc" });
+                } else {
+                    sorting.push(value);
+                }
             }
         }
 

--- a/packages/core-blockchain/package.json
+++ b/packages/core-blockchain/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-blockchain",
-    "version": "3.2.1",
+    "version": "3.2.2-next.0",
     "description": "Blockchain Manager for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-blockchain/package.json
+++ b/packages/core-blockchain/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-blockchain",
-    "version": "3.2.2-next.0",
+    "version": "3.2.2-next.1",
     "description": "Blockchain Manager for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-blockchain/package.json
+++ b/packages/core-blockchain/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-blockchain",
-    "version": "3.2.2-next.1",
+    "version": "3.2.2",
     "description": "Blockchain Manager for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-cli/package.json
+++ b/packages/core-cli/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-cli",
-    "version": "3.2.1",
+    "version": "3.2.2-next.0",
     "description": "Command Line Interface to manage the Core of the Solar Network Blockchain",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-cli/package.json
+++ b/packages/core-cli/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-cli",
-    "version": "3.2.2-next.0",
+    "version": "3.2.2-next.1",
     "description": "Command Line Interface to manage the Core of the Solar Network Blockchain",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-cli/package.json
+++ b/packages/core-cli/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-cli",
-    "version": "3.2.2-next.1",
+    "version": "3.2.2",
     "description": "Command Line Interface to manage the Core of the Solar Network Blockchain",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-cli/src/components/warning.ts
+++ b/packages/core-cli/src/components/warning.ts
@@ -23,6 +23,6 @@ export class Warning {
      * @memberof Warning
      */
     public render(message: string): void {
-        this.logger.warning(white().bgYellow(`[WARNING] ${message}`));
+        this.logger.warning(white().bgRed(`[WARNING] ${message}`));
     }
 }

--- a/packages/core-database/package.json
+++ b/packages/core-database/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-database",
-    "version": "3.2.2-next.0",
+    "version": "3.2.2-next.1",
     "description": "Database Interface for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-database/package.json
+++ b/packages/core-database/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-database",
-    "version": "3.2.1",
+    "version": "3.2.2-next.0",
     "description": "Database Interface for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-database/package.json
+++ b/packages/core-database/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-database",
-    "version": "3.2.2-next.1",
+    "version": "3.2.2",
     "description": "Database Interface for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-database/src/service-provider.ts
+++ b/packages/core-database/src/service-provider.ts
@@ -1,6 +1,6 @@
 import { Container, Contracts, Enums, Providers } from "@solar-network/core-kernel";
 import { sync } from "execa";
-import { existsSync, readFileSync, unlinkSync } from "fs";
+import { chmodSync, existsSync, readFileSync, unlinkSync } from "fs";
 import Joi from "joi";
 import { Connection, createConnection, getCustomRepository } from "typeorm";
 
@@ -79,6 +79,7 @@ export class ServiceProvider extends Providers.ServiceProvider {
             }
 
             if (startPostgres) {
+                chmodSync(connection.extra.host, "700");
                 sync(`${process.env.POSTGRES_DIR}/bin/pg_ctl -D ${connection.extra.host} start >/dev/null`, {
                     shell: true,
                 });

--- a/packages/core-forger/package.json
+++ b/packages/core-forger/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-forger",
-    "version": "3.2.2-next.0",
+    "version": "3.2.2-next.1",
     "description": "Forger for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-forger/package.json
+++ b/packages/core-forger/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-forger",
-    "version": "3.2.1",
+    "version": "3.2.2-next.0",
     "description": "Forger for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-forger/package.json
+++ b/packages/core-forger/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-forger",
-    "version": "3.2.2-next.1",
+    "version": "3.2.2",
     "description": "Forger for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-kernel/package.json
+++ b/packages/core-kernel/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-kernel",
-    "version": "3.2.2-next.0",
+    "version": "3.2.2-next.1",
     "description": "Kernel of Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-kernel/package.json
+++ b/packages/core-kernel/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-kernel",
-    "version": "3.2.2-next.1",
+    "version": "3.2.2",
     "description": "Kernel of Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-kernel/package.json
+++ b/packages/core-kernel/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-kernel",
-    "version": "3.2.1",
+    "version": "3.2.2-next.0",
     "description": "Kernel of Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-logger-pino/package.json
+++ b/packages/core-logger-pino/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-logger-pino",
-    "version": "3.2.1",
+    "version": "3.2.2-next.0",
     "description": "Webhooks for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-logger-pino/package.json
+++ b/packages/core-logger-pino/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-logger-pino",
-    "version": "3.2.2-next.1",
+    "version": "3.2.2",
     "description": "Webhooks for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-logger-pino/package.json
+++ b/packages/core-logger-pino/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-logger-pino",
-    "version": "3.2.2-next.0",
+    "version": "3.2.2-next.1",
     "description": "Webhooks for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-p2p/package.json
+++ b/packages/core-p2p/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-p2p",
-    "version": "3.2.1",
+    "version": "3.2.2-next.0",
     "description": "P2P API for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-p2p/package.json
+++ b/packages/core-p2p/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-p2p",
-    "version": "3.2.2-next.1",
+    "version": "3.2.2",
     "description": "P2P API for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-p2p/package.json
+++ b/packages/core-p2p/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-p2p",
-    "version": "3.2.2-next.0",
+    "version": "3.2.2-next.1",
     "description": "P2P API for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-snapshots/package.json
+++ b/packages/core-snapshots/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-snapshots",
-    "version": "3.2.2-next.1",
+    "version": "3.2.2",
     "description": "Provides live local streamed snapshots functionality for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-snapshots/package.json
+++ b/packages/core-snapshots/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-snapshots",
-    "version": "3.2.2-next.0",
+    "version": "3.2.2-next.1",
     "description": "Provides live local streamed snapshots functionality for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-snapshots/package.json
+++ b/packages/core-snapshots/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-snapshots",
-    "version": "3.2.1",
+    "version": "3.2.2-next.0",
     "description": "Provides live local streamed snapshots functionality for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-state/package.json
+++ b/packages/core-state/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-state",
-    "version": "3.2.1",
+    "version": "3.2.2-next.0",
     "description": "State Management for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-state/package.json
+++ b/packages/core-state/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-state",
-    "version": "3.2.2-next.1",
+    "version": "3.2.2",
     "description": "State Management for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-state/package.json
+++ b/packages/core-state/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-state",
-    "version": "3.2.2-next.0",
+    "version": "3.2.2-next.1",
     "description": "State Management for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-transaction-pool/package.json
+++ b/packages/core-transaction-pool/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-transaction-pool",
-    "version": "3.2.2-next.0",
+    "version": "3.2.2-next.1",
     "description": "Transaction Pool Manager for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-transaction-pool/package.json
+++ b/packages/core-transaction-pool/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-transaction-pool",
-    "version": "3.2.1",
+    "version": "3.2.2-next.0",
     "description": "Transaction Pool Manager for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-transaction-pool/package.json
+++ b/packages/core-transaction-pool/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-transaction-pool",
-    "version": "3.2.2-next.1",
+    "version": "3.2.2",
     "description": "Transaction Pool Manager for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-transactions/package.json
+++ b/packages/core-transactions/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-transactions",
-    "version": "3.2.2-next.1",
+    "version": "3.2.2",
     "description": "Transaction Services for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-transactions/package.json
+++ b/packages/core-transactions/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-transactions",
-    "version": "3.2.1",
+    "version": "3.2.2-next.0",
     "description": "Transaction Services for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-transactions/package.json
+++ b/packages/core-transactions/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-transactions",
-    "version": "3.2.2-next.0",
+    "version": "3.2.2-next.1",
     "description": "Transaction Services for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-webhooks/package.json
+++ b/packages/core-webhooks/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-webhooks",
-    "version": "3.2.1",
+    "version": "3.2.2-next.0",
     "description": "Webhooks for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-webhooks/package.json
+++ b/packages/core-webhooks/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-webhooks",
-    "version": "3.2.2-next.1",
+    "version": "3.2.2",
     "description": "Webhooks for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-webhooks/package.json
+++ b/packages/core-webhooks/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-webhooks",
-    "version": "3.2.2-next.0",
+    "version": "3.2.2-next.1",
     "description": "Webhooks for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core",
-    "version": "3.2.2-next.1",
+    "version": "3.2.2",
     "description": "Core of the Solar Network Blockchain",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core",
-    "version": "3.2.1",
+    "version": "3.2.2-next.0",
     "description": "Core of the Solar Network Blockchain",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core",
-    "version": "3.2.2-next.0",
+    "version": "3.2.2-next.1",
     "description": "Core of the Solar Network Blockchain",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/crypto",
-    "version": "3.2.1",
+    "version": "3.2.2-next.0",
     "description": "Crypto utilities for the Solar Network Blockchain",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/crypto",
-    "version": "3.2.2-next.0",
+    "version": "3.2.2-next.1",
     "description": "Crypto utilities for the Solar Network Blockchain",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/crypto",
-    "version": "3.2.2-next.1",
+    "version": "3.2.2",
     "description": "Crypto utilities for the Solar Network Blockchain",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/crypto/src/networks/mainnet/milestones.json
+++ b/packages/crypto/src/networks/mainnet/milestones.json
@@ -31,6 +31,22 @@
             "minFee": 11299
         },
         "epoch": "2022-03-28T18:00:00.000Z",
+        "fees": {
+            "staticFees": {
+                "burn": 0,
+                "delegateRegistration": 7500000000,
+                "delegateResignation": 0,
+                "htlcClaim": 0,
+                "htlcLock": 5000000,
+                "htlcRefund": 0,
+                "ipfs": 5000000,
+                "multiPayment": 50000000,
+                "multiSignature": 5000000,
+                "secondSignature": 5000000,
+                "transfer": 5000000,
+                "vote": 5000000
+            }
+        },
         "multiPaymentLimit": 256,
         "onlyActiveDelegatesInCalculations": true,
         "reward": "0",

--- a/packages/crypto/src/networks/mainnet/milestones.json
+++ b/packages/crypto/src/networks/mainnet/milestones.json
@@ -15,14 +15,18 @@
         "dynamicFees": {
             "enabled": true,
             "addonBytes": {
-                "transfer": 99,
-                "secondSignature": 99,
+                "burn": 0,
                 "delegateRegistration": 663703,
-                "vote": 98,
-                "multiSignature": 16,
+                "delegateResignation": 0,
+                "htlcClaim": 0,
+                "htlcLock": 82,
+                "htlcRefund": 0,
                 "ipfs": 98,
                 "multiPayment": 85,
-                "htlcLock": 82
+                "multiSignature": 16,
+                "secondSignature": 99,
+                "transfer": 99,
+                "vote": 98
             },
             "minFee": 11299
         },

--- a/packages/crypto/src/networks/mainnet/network.json
+++ b/packages/crypto/src/networks/mainnet/network.json
@@ -1,5 +1,5 @@
 {
-    "name": "Solar",
+    "name": "mainnet",
     "messagePrefix": "Solar message:\n",
     "bip32": {
         "public": 70617039,

--- a/packages/crypto/src/networks/testnet/milestones.json
+++ b/packages/crypto/src/networks/testnet/milestones.json
@@ -15,14 +15,18 @@
         "dynamicFees": {
             "enabled": true,
             "addonBytes": {
-                "transfer": 99,
-                "secondSignature": 99,
+                "burn": 0,
                 "delegateRegistration": 663703,
-                "vote": 98,
-                "multiSignature": 16,
+                "delegateResignation": 0,
+                "htlcClaim": 0,
+                "htlcLock": 82,
+                "htlcRefund": 0,
                 "ipfs": 98,
                 "multiPayment": 85,
-                "htlcLock": 82
+                "multiSignature": 16,
+                "secondSignature": 99,
+                "transfer": 99,
+                "vote": 98
             },
             "minFee": 11299
         },

--- a/packages/crypto/src/networks/testnet/milestones.json
+++ b/packages/crypto/src/networks/testnet/milestones.json
@@ -31,6 +31,22 @@
             "minFee": 11299
         },
         "epoch": "2022-03-16T18:00:00.000Z",
+        "fees": {
+            "staticFees": {
+                "burn": 0,
+                "delegateRegistration": 7500000000,
+                "delegateResignation": 0,
+                "htlcClaim": 0,
+                "htlcLock": 5000000,
+                "htlcRefund": 0,
+                "ipfs": 5000000,
+                "multiPayment": 50000000,
+                "multiSignature": 5000000,
+                "secondSignature": 5000000,
+                "transfer": 5000000,
+                "vote": 5000000
+            }
+        },
         "multiPaymentLimit": 256,
         "onlyActiveDelegatesInCalculations": true,
         "reward": "0",

--- a/packages/crypto/src/networks/testnet/network.json
+++ b/packages/crypto/src/networks/testnet/network.json
@@ -1,6 +1,6 @@
 {
-    "name": "Solar",
-    "messagePrefix": "Solar message:\n",
+    "name": "testnet",
+    "messagePrefix": "Solar testnet message:\n",
     "bip32": {
         "public": 70617039,
         "private": 70615956

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/utils",
-    "version": "3.2.1",
+    "version": "3.2.2-next.0",
     "description": "Performance oriented implementations of commonly used functions in TypeScript.",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/utils",
-    "version": "3.2.2-next.0",
+    "version": "3.2.2-next.1",
     "description": "Performance oriented implementations of commonly used functions in TypeScript.",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/utils",
-    "version": "3.2.2-next.1",
+    "version": "3.2.2",
     "description": "Performance oriented implementations of commonly used functions in TypeScript.",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,7 +39,7 @@ importers:
       husky: 7.0.4
       js-yaml: 4.1.0
       lint-staged: 11.2.6
-      moment: 2.29.1
+      moment: 2.29.2
       moment-timezone: 0.5.33
       npm-check-updates: 11.8.5
       prettier: 2.4.1
@@ -87,7 +87,7 @@ importers:
       husky: 7.0.4
       js-yaml: 4.1.0
       lint-staged: 11.2.6
-      moment: 2.29.1
+      moment: 2.29.2
       moment-timezone: 0.5.33
       npm-check-updates: 11.8.5
       prettier: 2.4.1
@@ -9803,7 +9803,7 @@ packages:
   /moment-timezone/0.5.33:
     resolution: {integrity: sha512-PTc2vcT8K9J5/9rDEPe5czSIKgLoGsH8UNpA4qZTVw0Vd/Uz19geE9abbIOQKaAQFcnQ3v5YEXrbSc5BpshH+w==}
     dependencies:
-      moment: 2.29.1
+      moment: 2.29.2
     dev: true
 
   /moment-timezone/0.5.34:
@@ -9814,6 +9814,10 @@ packages:
 
   /moment/2.29.1:
     resolution: {integrity: sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==}
+
+  /moment/2.29.2:
+    resolution: {integrity: sha512-UgzG4rvxYpN15jgCmVJwac49h9ly9NurikMWGPdVxm8GZD6XjkKPxDTjQQ43gtGgnV3X0cAyWDdP2Wexoquifg==}
+    dev: true
 
   /mri/1.1.4:
     resolution: {integrity: sha512-6y7IjGPm8AzlvoUrwAaw1tLnUBudaS3752vcd8JtrpGGQn+rXIe63LFVHm/YMwtqAuh+LJPCFdlLYPWM1nYn6w==}


### PR DESCRIPTION
This PR releases Solar Core 3.2.2 for mainnet.

Changes since 3.2.1:

### Maintenance
\- installation script no longer throws an error if cron is not installed
\- dynamic fees now shown in the correct section of `/api/node/configuration`
\- zero fee transaction types now included in the dynamic fees section of `/api/node/configuration`
\- static fee values added for better wallet compatibility and to prevent overspending on fees
\- network names for mainnet and testnet now set correctly in crypto package
\- postgresql database permissions now always reset on core startup in case of unclean shutdown
\- version bump of `moment` dependency due to a security vulnerability in that package
\- merged bug fix for empty `orderBy` query parameter in api pagination from upstream code
\- fixed bug when sorting multiple `orderBy` values in api and shared with upstream
\- shell environment variables now passed to pm2 so `--update-env` works
\- red background used for cli warnings instead of yellow as some terminals do not display yellow backgrounds