### PR TITLE
fix(core-api): use blockHistoryService for first and last block retrieval

### DIFF
--- a/packages/core-api/src/controllers/blocks.ts
+++ b/packages/core-api/src/controllers/blocks.ts
@@ -17,9 +17,6 @@ export class BlocksController extends Controller {
     @Container.inject(Container.Identifiers.TransactionHistoryService)
     private readonly transactionHistoryService!: Contracts.Shared.TransactionHistoryService;
 
-    @Container.inject(Container.Identifiers.StateStore)
-    private readonly stateStore!: Contracts.State.StateStore;
-
     public async index(request: Hapi.Request, h: Hapi.ResponseToolkit): Promise<object> {
         if (request.query.transform) {
             const blockWithSomeTransactionsListResult = await this.blockHistoryService.listByCriteriaJoinTransactions(
@@ -43,23 +40,13 @@ export class BlocksController extends Controller {
     }
 
     public async first(request: Hapi.Request, h: Hapi.ResponseToolkit): Promise<object> {
-        const block = this.stateStore.getGenesisBlock();
-
-        if (request.query.transform) {
-            return this.respondWithResource(block, BlockWithTransactionsResource, true);
-        } else {
-            return this.respondWithResource(block.data, BlockResource, false);
-        }
+        request.params.id = 1;
+        return this.show(request, h);
     }
 
     public async last(request: Hapi.Request, h: Hapi.ResponseToolkit): Promise<object> {
-        const block = this.blockchain.getLastBlock();
-
-        if (request.query.transform) {
-            return this.respondWithResource(block, BlockWithTransactionsResource, true);
-        } else {
-            return this.respondWithResource(block.data, BlockResource, false);
-        }
+        request.params.id = this.blockchain.getLastHeight();
+        return this.show(request, h);
     }
 
     public async show(request: Hapi.Request, h: Hapi.ResponseToolkit): Promise<object> {


### PR DESCRIPTION
There is a bug in the upstream code for the Public API which means `/api/blocks/last` raises an Internal Server Error and dumps log spam if the last block in the blockchain contains any multipayments. It would also affect `/api/blocks/first` if the genesis block contained one or more multipayments.

This PR fixes the bug by calling the `show` method for `first` and `last` in the `BlocksController` so it now fetches the relevant block via the `blockHistoryService` instead of directly from the `blockchain` object. Another benefit of taking this approach is that now the blocks returned via `first` and `last` using `?transform=false` are the same structure as when fetching blocks by height or id. For example, the responses from `/api/blocks/first?transform=false` and `/api/blocks/1?transform=false` were not identical. Now they are.