### PR TITLE
release: mainnet 3.2.3

### DIFF
--- a/packages/core-api/package.json
+++ b/packages/core-api/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-api",
-    "version": "3.2.3-next.1",
+    "version": "3.2.3",
     "description": "Public API for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-api/package.json
+++ b/packages/core-api/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-api",
-    "version": "3.2.2",
+    "version": "3.2.3-next.0",
     "description": "Public API for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-api/package.json
+++ b/packages/core-api/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-api",
-    "version": "3.2.3-next.0",
+    "version": "3.2.3-next.1",
     "description": "Public API for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-api/src/controllers/blocks.ts
+++ b/packages/core-api/src/controllers/blocks.ts
@@ -17,9 +17,6 @@ export class BlocksController extends Controller {
     @Container.inject(Container.Identifiers.TransactionHistoryService)
     private readonly transactionHistoryService!: Contracts.Shared.TransactionHistoryService;
 
-    @Container.inject(Container.Identifiers.StateStore)
-    private readonly stateStore!: Contracts.State.StateStore;
-
     public async index(request: Hapi.Request, h: Hapi.ResponseToolkit): Promise<object> {
         if (request.query.transform) {
             const blockWithSomeTransactionsListResult = await this.blockHistoryService.listByCriteriaJoinTransactions(
@@ -43,23 +40,13 @@ export class BlocksController extends Controller {
     }
 
     public async first(request: Hapi.Request, h: Hapi.ResponseToolkit): Promise<object> {
-        const block = this.stateStore.getGenesisBlock();
-
-        if (request.query.transform) {
-            return this.respondWithResource(block, BlockWithTransactionsResource, true);
-        } else {
-            return this.respondWithResource(block.data, BlockResource, false);
-        }
+        request.params.id = 1;
+        return this.show(request, h);
     }
 
     public async last(request: Hapi.Request, h: Hapi.ResponseToolkit): Promise<object> {
-        const block = this.blockchain.getLastBlock();
-
-        if (request.query.transform) {
-            return this.respondWithResource(block, BlockWithTransactionsResource, true);
-        } else {
-            return this.respondWithResource(block.data, BlockResource, false);
-        }
+        request.params.id = this.blockchain.getLastHeight();
+        return this.show(request, h);
     }
 
     public async show(request: Hapi.Request, h: Hapi.ResponseToolkit): Promise<object> {

--- a/packages/core-blockchain/package.json
+++ b/packages/core-blockchain/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-blockchain",
-    "version": "3.2.2",
+    "version": "3.2.3-next.0",
     "description": "Blockchain Manager for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-blockchain/package.json
+++ b/packages/core-blockchain/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-blockchain",
-    "version": "3.2.3-next.0",
+    "version": "3.2.3-next.1",
     "description": "Blockchain Manager for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-blockchain/package.json
+++ b/packages/core-blockchain/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-blockchain",
-    "version": "3.2.3-next.1",
+    "version": "3.2.3",
     "description": "Blockchain Manager for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-cli/package.json
+++ b/packages/core-cli/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-cli",
-    "version": "3.2.2",
+    "version": "3.2.3-next.0",
     "description": "Command Line Interface to manage the Core of the Solar Network Blockchain",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-cli/package.json
+++ b/packages/core-cli/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-cli",
-    "version": "3.2.3-next.1",
+    "version": "3.2.3",
     "description": "Command Line Interface to manage the Core of the Solar Network Blockchain",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-cli/package.json
+++ b/packages/core-cli/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-cli",
-    "version": "3.2.3-next.0",
+    "version": "3.2.3-next.1",
     "description": "Command Line Interface to manage the Core of the Solar Network Blockchain",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-cli/src/plugins/suggest.ts
+++ b/packages/core-cli/src/plugins/suggest.ts
@@ -1,6 +1,6 @@
 import { minBy } from "@solar-network/utils";
 import Levenshtein from "fast-levenshtein";
-import { blue, red } from "kleur";
+import { blue, yellow } from "kleur";
 import { JsonObject } from "type-fest";
 
 import { Application } from "../application";
@@ -41,7 +41,7 @@ export class SuggestCommand {
 
         const suggestion: string = minBy(signatures, (c) => Levenshtein.get(signature, c));
 
-        this.app.get<any>(Identifiers.Warning).render(`${red(signature)} is not a ${context.bin} command`);
+        this.app.get<any>(Identifiers.Warning).render(`${yellow(signature)} is not a ${context.bin} command`);
 
         if (
             await this.app

--- a/packages/core-database/package.json
+++ b/packages/core-database/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-database",
-    "version": "3.2.3-next.1",
+    "version": "3.2.3",
     "description": "Database Interface for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-database/package.json
+++ b/packages/core-database/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-database",
-    "version": "3.2.3-next.0",
+    "version": "3.2.3-next.1",
     "description": "Database Interface for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-database/package.json
+++ b/packages/core-database/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-database",
-    "version": "3.2.2",
+    "version": "3.2.3-next.0",
     "description": "Database Interface for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-forger/package.json
+++ b/packages/core-forger/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-forger",
-    "version": "3.2.3-next.0",
+    "version": "3.2.3-next.1",
     "description": "Forger for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-forger/package.json
+++ b/packages/core-forger/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-forger",
-    "version": "3.2.2",
+    "version": "3.2.3-next.0",
     "description": "Forger for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-forger/package.json
+++ b/packages/core-forger/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-forger",
-    "version": "3.2.3-next.1",
+    "version": "3.2.3",
     "description": "Forger for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-kernel/package.json
+++ b/packages/core-kernel/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-kernel",
-    "version": "3.2.2",
+    "version": "3.2.3-next.0",
     "description": "Kernel of Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-kernel/package.json
+++ b/packages/core-kernel/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-kernel",
-    "version": "3.2.3-next.0",
+    "version": "3.2.3-next.1",
     "description": "Kernel of Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-kernel/package.json
+++ b/packages/core-kernel/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-kernel",
-    "version": "3.2.3-next.1",
+    "version": "3.2.3",
     "description": "Kernel of Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-logger-pino/package.json
+++ b/packages/core-logger-pino/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-logger-pino",
-    "version": "3.2.3-next.1",
+    "version": "3.2.3",
     "description": "Webhooks for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-logger-pino/package.json
+++ b/packages/core-logger-pino/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-logger-pino",
-    "version": "3.2.2",
+    "version": "3.2.3-next.0",
     "description": "Webhooks for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-logger-pino/package.json
+++ b/packages/core-logger-pino/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-logger-pino",
-    "version": "3.2.3-next.0",
+    "version": "3.2.3-next.1",
     "description": "Webhooks for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-p2p/package.json
+++ b/packages/core-p2p/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-p2p",
-    "version": "3.2.3-next.1",
+    "version": "3.2.3",
     "description": "P2P API for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-p2p/package.json
+++ b/packages/core-p2p/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-p2p",
-    "version": "3.2.3-next.0",
+    "version": "3.2.3-next.1",
     "description": "P2P API for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-p2p/package.json
+++ b/packages/core-p2p/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-p2p",
-    "version": "3.2.2",
+    "version": "3.2.3-next.0",
     "description": "P2P API for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-snapshots/package.json
+++ b/packages/core-snapshots/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-snapshots",
-    "version": "3.2.3-next.0",
+    "version": "3.2.3-next.1",
     "description": "Provides live local streamed snapshots functionality for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-snapshots/package.json
+++ b/packages/core-snapshots/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-snapshots",
-    "version": "3.2.2",
+    "version": "3.2.3-next.0",
     "description": "Provides live local streamed snapshots functionality for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-snapshots/package.json
+++ b/packages/core-snapshots/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-snapshots",
-    "version": "3.2.3-next.1",
+    "version": "3.2.3",
     "description": "Provides live local streamed snapshots functionality for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-state/package.json
+++ b/packages/core-state/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-state",
-    "version": "3.2.3-next.0",
+    "version": "3.2.3-next.1",
     "description": "State Management for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-state/package.json
+++ b/packages/core-state/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-state",
-    "version": "3.2.3-next.1",
+    "version": "3.2.3",
     "description": "State Management for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-state/package.json
+++ b/packages/core-state/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-state",
-    "version": "3.2.2",
+    "version": "3.2.3-next.0",
     "description": "State Management for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-transaction-pool/package.json
+++ b/packages/core-transaction-pool/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-transaction-pool",
-    "version": "3.2.3-next.0",
+    "version": "3.2.3-next.1",
     "description": "Transaction Pool Manager for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-transaction-pool/package.json
+++ b/packages/core-transaction-pool/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-transaction-pool",
-    "version": "3.2.2",
+    "version": "3.2.3-next.0",
     "description": "Transaction Pool Manager for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-transaction-pool/package.json
+++ b/packages/core-transaction-pool/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-transaction-pool",
-    "version": "3.2.3-next.1",
+    "version": "3.2.3",
     "description": "Transaction Pool Manager for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-transactions/package.json
+++ b/packages/core-transactions/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-transactions",
-    "version": "3.2.2",
+    "version": "3.2.3-next.0",
     "description": "Transaction Services for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-transactions/package.json
+++ b/packages/core-transactions/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-transactions",
-    "version": "3.2.3-next.1",
+    "version": "3.2.3",
     "description": "Transaction Services for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-transactions/package.json
+++ b/packages/core-transactions/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-transactions",
-    "version": "3.2.3-next.0",
+    "version": "3.2.3-next.1",
     "description": "Transaction Services for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-webhooks/package.json
+++ b/packages/core-webhooks/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-webhooks",
-    "version": "3.2.3-next.0",
+    "version": "3.2.3-next.1",
     "description": "Webhooks for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-webhooks/package.json
+++ b/packages/core-webhooks/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-webhooks",
-    "version": "3.2.3-next.1",
+    "version": "3.2.3",
     "description": "Webhooks for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-webhooks/package.json
+++ b/packages/core-webhooks/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-webhooks",
-    "version": "3.2.2",
+    "version": "3.2.3-next.0",
     "description": "Webhooks for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core",
-    "version": "3.2.3-next.0",
+    "version": "3.2.3-next.1",
     "description": "Core of the Solar Network Blockchain",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core",
-    "version": "3.2.3-next.1",
+    "version": "3.2.3",
     "description": "Core of the Solar Network Blockchain",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core",
-    "version": "3.2.2",
+    "version": "3.2.3-next.0",
     "description": "Core of the Solar Network Blockchain",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core/src/commands/database-create.ts
+++ b/packages/core/src/commands/database-create.ts
@@ -63,7 +63,7 @@ export class Command extends Commands.Command {
                 if (existsSync(pidFile) && statSync(pidFile).isFile()) {
                     try {
                         const pid: string = readFileSync(pidFile).toString().split("\n")[0];
-                        process.kill(+pid);
+                        process.kill(+pid, "SIGKILL");
                     } catch {
                         //
                     }

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/crypto",
-    "version": "3.2.3-next.1",
+    "version": "3.2.3",
     "description": "Crypto utilities for the Solar Network Blockchain",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/crypto",
-    "version": "3.2.3-next.0",
+    "version": "3.2.3-next.1",
     "description": "Crypto utilities for the Solar Network Blockchain",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/crypto",
-    "version": "3.2.2",
+    "version": "3.2.3-next.0",
     "description": "Crypto utilities for the Solar Network Blockchain",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/crypto/src/errors.ts
+++ b/packages/crypto/src/errors.ts
@@ -112,12 +112,6 @@ export class MaximumPaymentCountExceededError extends CryptoError {
     }
 }
 
-export class MinimumPaymentCountSubceededError extends CryptoError {
-    public constructor() {
-        super(`Number of payments less than the required minimum of 2`);
-    }
-}
-
 export class VendorFieldLengthExceededError extends CryptoError {
     public constructor(limit: number) {
         super(`Length of vendor field exceeded the allowed maximum ${limit}`);

--- a/packages/crypto/src/transactions/builders/index.ts
+++ b/packages/crypto/src/transactions/builders/index.ts
@@ -1,4 +1,4 @@
-import { BurnTransactionBuilder } from "./transactions/burn";
+import { BurnBuilder } from "./transactions/burn";
 import { DelegateRegistrationBuilder } from "./transactions/delegate-registration";
 import { DelegateResignationBuilder } from "./transactions/delegate-resignation";
 import { HtlcClaimBuilder } from "./transactions/htlc-claim";
@@ -59,7 +59,7 @@ export class BuilderFactory {
     }
 
     // Solar transactions
-    public static burn(): BurnTransactionBuilder {
-        return new BurnTransactionBuilder();
+    public static burn(): BurnBuilder {
+        return new BurnBuilder();
     }
 }

--- a/packages/crypto/src/transactions/builders/transactions/burn.ts
+++ b/packages/crypto/src/transactions/builders/transactions/burn.ts
@@ -3,7 +3,7 @@ import { BigNumber } from "../../../utils";
 import { Solar } from "../../types";
 import { TransactionBuilder } from "./transaction";
 
-export class BurnTransactionBuilder extends TransactionBuilder<BurnTransactionBuilder> {
+export class BurnBuilder extends TransactionBuilder<BurnBuilder> {
     public constructor() {
         super();
 
@@ -21,7 +21,7 @@ export class BurnTransactionBuilder extends TransactionBuilder<BurnTransactionBu
         return struct;
     }
 
-    protected instance(): BurnTransactionBuilder {
+    protected instance(): BurnBuilder {
         return this;
     }
 }

--- a/packages/crypto/src/transactions/builders/transactions/burn.ts
+++ b/packages/crypto/src/transactions/builders/transactions/burn.ts
@@ -16,6 +16,8 @@ export class BurnTransactionBuilder extends TransactionBuilder<BurnTransactionBu
     public getStruct(): ITransactionData {
         const struct: ITransactionData = super.getStruct();
         struct.amount = this.data.amount;
+
+        super.validate(struct);
         return struct;
     }
 

--- a/packages/crypto/src/transactions/builders/transactions/delegate-registration.ts
+++ b/packages/crypto/src/transactions/builders/transactions/delegate-registration.ts
@@ -29,6 +29,8 @@ export class DelegateRegistrationBuilder extends TransactionBuilder<DelegateRegi
         struct.amount = this.data.amount;
         struct.recipientId = this.data.recipientId;
         struct.asset = this.data.asset;
+
+        super.validate(struct);
         return struct;
     }
 

--- a/packages/crypto/src/transactions/builders/transactions/delegate-resignation.ts
+++ b/packages/crypto/src/transactions/builders/transactions/delegate-resignation.ts
@@ -18,6 +18,8 @@ export class DelegateResignationBuilder extends TransactionBuilder<DelegateResig
     public getStruct(): ITransactionData {
         const struct: ITransactionData = super.getStruct();
         struct.amount = this.data.amount;
+
+        super.validate(struct);
         return struct;
     }
 

--- a/packages/crypto/src/transactions/builders/transactions/htlc-claim.ts
+++ b/packages/crypto/src/transactions/builders/transactions/htlc-claim.ts
@@ -26,6 +26,8 @@ export class HtlcClaimBuilder extends TransactionBuilder<HtlcClaimBuilder> {
         const struct: ITransactionData = super.getStruct();
         struct.amount = this.data.amount;
         struct.asset = this.data.asset;
+
+        super.validate(struct);
         return struct;
     }
 

--- a/packages/crypto/src/transactions/builders/transactions/htlc-lock.ts
+++ b/packages/crypto/src/transactions/builders/transactions/htlc-lock.ts
@@ -30,6 +30,8 @@ export class HtlcLockBuilder extends TransactionBuilder<HtlcLockBuilder> {
         struct.amount = this.data.amount;
         struct.vendorField = this.data.vendorField;
         struct.asset = JSON.parse(JSON.stringify(this.data.asset));
+
+        super.validate(struct);
         return struct;
     }
 

--- a/packages/crypto/src/transactions/builders/transactions/htlc-refund.ts
+++ b/packages/crypto/src/transactions/builders/transactions/htlc-refund.ts
@@ -26,6 +26,8 @@ export class HtlcRefundBuilder extends TransactionBuilder<HtlcRefundBuilder> {
         const struct: ITransactionData = super.getStruct();
         struct.amount = this.data.amount;
         struct.asset = this.data.asset;
+
+        super.validate(struct);
         return struct;
     }
 

--- a/packages/crypto/src/transactions/builders/transactions/ipfs.ts
+++ b/packages/crypto/src/transactions/builders/transactions/ipfs.ts
@@ -28,6 +28,8 @@ export class IPFSBuilder extends TransactionBuilder<IPFSBuilder> {
         struct.vendorField = this.data.vendorField;
         struct.amount = this.data.amount;
         struct.asset = this.data.asset;
+
+        super.validate(struct);
         return struct;
     }
 

--- a/packages/crypto/src/transactions/builders/transactions/multi-payment.ts
+++ b/packages/crypto/src/transactions/builders/transactions/multi-payment.ts
@@ -1,4 +1,4 @@
-import { MaximumPaymentCountExceededError, MinimumPaymentCountSubceededError } from "../../../errors";
+import { MaximumPaymentCountExceededError } from "../../../errors";
 import { ITransactionData } from "../../../interfaces";
 import { configManager } from "../../../managers";
 import { BigNumber } from "../../../utils";
@@ -36,21 +36,13 @@ export class MultiPaymentBuilder extends TransactionBuilder<MultiPaymentBuilder>
     }
 
     public getStruct(): ITransactionData {
-        if (
-            !this.data.asset ||
-            !this.data.asset.payments ||
-            !Array.isArray(this.data.asset.payments) ||
-            this.data.asset.payments.length <= 1
-        ) {
-            throw new MinimumPaymentCountSubceededError();
-        }
-
         const struct: ITransactionData = super.getStruct();
         struct.senderPublicKey = this.data.senderPublicKey;
         struct.vendorField = this.data.vendorField;
         struct.amount = this.data.amount;
         struct.asset = this.data.asset;
 
+        super.validate(struct);
         return struct;
     }
 

--- a/packages/crypto/src/transactions/builders/transactions/multi-signature.ts
+++ b/packages/crypto/src/transactions/builders/transactions/multi-signature.ts
@@ -53,6 +53,7 @@ export class MultiSignatureBuilder extends TransactionBuilder<MultiSignatureBuil
         struct.recipientId = this.data.recipientId;
         struct.asset = this.data.asset;
 
+        super.validate(struct);
         return struct;
     }
 

--- a/packages/crypto/src/transactions/builders/transactions/second-signature.ts
+++ b/packages/crypto/src/transactions/builders/transactions/second-signature.ts
@@ -30,6 +30,8 @@ export class SecondSignatureBuilder extends TransactionBuilder<SecondSignatureBu
         struct.amount = this.data.amount;
         struct.recipientId = this.data.recipientId;
         struct.asset = this.data.asset;
+
+        super.validate(struct);
         return struct;
     }
 

--- a/packages/crypto/src/transactions/builders/transactions/transaction.ts
+++ b/packages/crypto/src/transactions/builders/transactions/transaction.ts
@@ -1,6 +1,10 @@
 import { Slots } from "../../../crypto";
 import { TransactionTypeGroup } from "../../../enums";
-import { MissingTransactionSignatureError, VendorFieldLengthExceededError } from "../../../errors";
+import {
+    MissingTransactionSignatureError,
+    TransactionSchemaError,
+    VendorFieldLengthExceededError,
+} from "../../../errors";
 import { Address, Keys } from "../../../identities";
 import { IKeyPair, ITransaction, ITransactionData } from "../../../interfaces";
 import { configManager } from "../../../managers/config";
@@ -175,6 +179,14 @@ export abstract class TransactionBuilder<TBuilder extends TransactionBuilder<TBu
         }
 
         return struct;
+    }
+
+    protected validate(struct: ITransactionData) {
+        const { error } = Verifier.verifySchema(struct, true);
+
+        if (error) {
+            throw new TransactionSchemaError(error);
+        }
     }
 
     private signWithKeyPair(keys: IKeyPair): TBuilder {

--- a/packages/crypto/src/transactions/builders/transactions/transfer.ts
+++ b/packages/crypto/src/transactions/builders/transactions/transfer.ts
@@ -30,6 +30,7 @@ export class TransferBuilder extends TransactionBuilder<TransferBuilder> {
         struct.vendorField = this.data.vendorField;
         struct.expiration = this.data.expiration;
 
+        super.validate(struct);
         return struct;
     }
 

--- a/packages/crypto/src/transactions/builders/transactions/vote.ts
+++ b/packages/crypto/src/transactions/builders/transactions/vote.ts
@@ -31,6 +31,8 @@ export class VoteBuilder extends TransactionBuilder<VoteBuilder> {
         struct.amount = this.data.amount;
         struct.recipientId = this.data.recipientId;
         struct.asset = this.data.asset;
+
+        super.validate(struct);
         return struct;
     }
 

--- a/packages/crypto/src/transactions/types/solar/burn.ts
+++ b/packages/crypto/src/transactions/types/solar/burn.ts
@@ -23,6 +23,7 @@ export class BurnTransaction extends Transaction {
             },
         });
     }
+
     public serialize(): ByteBuffer {
         const { data } = this;
         const buff: ByteBuffer = new ByteBuffer(Buffer.alloc(8));

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/utils",
-    "version": "3.2.3-next.1",
+    "version": "3.2.3",
     "description": "Performance oriented implementations of commonly used functions in TypeScript.",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/utils",
-    "version": "3.2.3-next.0",
+    "version": "3.2.3-next.1",
     "description": "Performance oriented implementations of commonly used functions in TypeScript.",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/utils",
-    "version": "3.2.2",
+    "version": "3.2.3-next.0",
     "description": "Performance oriented implementations of commonly used functions in TypeScript.",
     "license": "CC-BY-ND-4.0",
     "contributors": [


### PR DESCRIPTION
This PR releases Solar Core 3.2.3 for mainnet.

Changes since 3.2.2:

### Bug Fixes

\- fixed bug currently present in upstream's `core-api` package which causes an internal server error when accessing `/api/blocks/last` if the last block contains one or more multipayment transactions
\- postgres now killed when recreating the database so it can restart properly

### Maintenance
\- yellow text colour used for missing signature warning in cli so it is readable now
\- newline added between methods in burn transaction type for better readability
\- transaction builders now validate against schema
\- redundant minimum payments check in multipayments removed
\- burn builder renamed for consistency with other transaction types