### PR TITLE
release: mainnet 3.2.4

### DIFF
--- a/packages/core-api/package.json
+++ b/packages/core-api/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-api",
-    "version": "3.2.4-next.0",
+    "version": "3.2.4-next.1",
     "description": "Public API for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-api/package.json
+++ b/packages/core-api/package.json
@@ -31,6 +31,7 @@
         "joi": "17.6.0",
         "nanomatch": "1.2.13",
         "node-cache": "5.1.2",
+        "qs": "6.10.3",
         "rate-limiter-flexible": "1.3.2",
         "semver": "6.3.0"
     },
@@ -39,6 +40,7 @@
         "@types/hapi__hapi": "20.0.9",
         "@types/hapi__joi": "17.1.7",
         "@types/ip": "1.1.0",
+        "@types/qs": "6.9.7",
         "@types/semver": "6.2.3",
         "lodash.clonedeep": "4.5.0"
     }

--- a/packages/core-api/package.json
+++ b/packages/core-api/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-api",
-    "version": "3.2.3",
+    "version": "3.2.4-next.0",
     "description": "Public API for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-api/package.json
+++ b/packages/core-api/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-api",
-    "version": "3.2.4-next.1",
+    "version": "3.2.4",
     "description": "Public API for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-api/src/plugins/pagination/ext.ts
+++ b/packages/core-api/src/plugins/pagination/ext.ts
@@ -2,7 +2,7 @@
 
 import Hoek from "@hapi/hoek";
 import { Utils } from "@solar-network/core-kernel";
-import Qs from "querystring";
+import qs from "qs";
 
 export class Ext {
     private readonly routePathPrefix = "/api";
@@ -67,43 +67,16 @@ export class Ext {
             pageCount = Math.trunc(totalCount / currentLimit) + (totalCount % currentLimit === 0 ? 0 : 1);
         }
 
-        const toDotNotation = (object: object, prefix: string = ""): Record<string, any> => {
-            let dotObject: object = {};
-
-            const recurse = (recursedObject: object, recursedPrefix: string, array: boolean = false): object => {
-                for (const [key, value] of Object.entries(recursedObject)) {
-                    if (value && typeof value === "object") {
-                        if (Array.isArray(value))
-                            dotObject = recurse(value, (recursedPrefix ? recursedPrefix + "." : "") + key, true);
-                        else {
-                            if (array) {
-                                dotObject = recurse(value, recursedPrefix ? recursedPrefix : "");
-                            } else {
-                                dotObject = recurse(value, (recursedPrefix ? recursedPrefix + "." : "") + key);
-                            }
-                        }
-                    } else {
-                        if (array) {
-                            dotObject[recursedPrefix] = value;
-                        } else if (recursedPrefix) {
-                            dotObject[recursedPrefix + "." + key] = value;
-                        } else {
-                            dotObject[key] = value;
-                        }
-                    }
-                }
-                return dotObject;
-            };
-
-            return recurse(object, prefix);
-        };
-
         const getUri = (page: number | null): string | null =>
             /* istanbul ignore next */
             // tslint:disable-next-line: no-null-keyword
             page
                 ? baseUri +
-                  Qs.stringify(Hoek.applyToDefaults(toDotNotation({ ...query, ...request.orig.query }), { page }))
+                  qs.stringify(Hoek.applyToDefaults({ ...query, ...request.orig.query }, { page }), {
+                      allowDots: true,
+                      arrayFormat: "comma",
+                      encode: false,
+                  })
                 : null;
 
         const newSource = {

--- a/packages/core-api/src/plugins/pagination/ext.ts
+++ b/packages/core-api/src/plugins/pagination/ext.ts
@@ -67,10 +67,44 @@ export class Ext {
             pageCount = Math.trunc(totalCount / currentLimit) + (totalCount % currentLimit === 0 ? 0 : 1);
         }
 
+        const toDotNotation = (object: object, prefix: string = ""): Record<string, any> => {
+            let dotObject: object = {};
+
+            const recurse = (recursedObject: object, recursedPrefix: string, array: boolean = false): object => {
+                for (const [key, value] of Object.entries(recursedObject)) {
+                    if (value && typeof value === "object") {
+                        if (Array.isArray(value))
+                            dotObject = recurse(value, (recursedPrefix ? recursedPrefix + "." : "") + key, true);
+                        else {
+                            if (array) {
+                                dotObject = recurse(value, recursedPrefix ? recursedPrefix : "");
+                            } else {
+                                dotObject = recurse(value, (recursedPrefix ? recursedPrefix + "." : "") + key);
+                            }
+                        }
+                    } else {
+                        if (array) {
+                            dotObject[recursedPrefix] = value;
+                        } else if (recursedPrefix) {
+                            dotObject[recursedPrefix + "." + key] = value;
+                        } else {
+                            dotObject[key] = value;
+                        }
+                    }
+                }
+                return dotObject;
+            };
+
+            return recurse(object, prefix);
+        };
+
         const getUri = (page: number | null): string | null =>
             /* istanbul ignore next */
             // tslint:disable-next-line: no-null-keyword
-            page ? baseUri + Qs.stringify(Hoek.applyToDefaults({ ...query, ...request.orig.query }, { page })) : null;
+            page
+                ? baseUri +
+                  Qs.stringify(Hoek.applyToDefaults(toDotNotation({ ...query, ...request.orig.query }), { page }))
+                : null;
 
         const newSource = {
             meta: {

--- a/packages/core-blockchain/package.json
+++ b/packages/core-blockchain/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-blockchain",
-    "version": "3.2.3",
+    "version": "3.2.4-next.0",
     "description": "Blockchain Manager for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-blockchain/package.json
+++ b/packages/core-blockchain/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-blockchain",
-    "version": "3.2.4-next.1",
+    "version": "3.2.4",
     "description": "Blockchain Manager for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-blockchain/package.json
+++ b/packages/core-blockchain/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-blockchain",
-    "version": "3.2.4-next.0",
+    "version": "3.2.4-next.1",
     "description": "Blockchain Manager for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-cli/package.json
+++ b/packages/core-cli/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-cli",
-    "version": "3.2.3",
+    "version": "3.2.4-next.0",
     "description": "Command Line Interface to manage the Core of the Solar Network Blockchain",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-cli/package.json
+++ b/packages/core-cli/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-cli",
-    "version": "3.2.4-next.1",
+    "version": "3.2.4",
     "description": "Command Line Interface to manage the Core of the Solar Network Blockchain",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-cli/package.json
+++ b/packages/core-cli/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-cli",
-    "version": "3.2.4-next.0",
+    "version": "3.2.4-next.1",
     "description": "Command Line Interface to manage the Core of the Solar Network Blockchain",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-database/package.json
+++ b/packages/core-database/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-database",
-    "version": "3.2.4-next.0",
+    "version": "3.2.4-next.1",
     "description": "Database Interface for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-database/package.json
+++ b/packages/core-database/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-database",
-    "version": "3.2.3",
+    "version": "3.2.4-next.0",
     "description": "Database Interface for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-database/package.json
+++ b/packages/core-database/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-database",
-    "version": "3.2.4-next.1",
+    "version": "3.2.4",
     "description": "Database Interface for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-forger/package.json
+++ b/packages/core-forger/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-forger",
-    "version": "3.2.3",
+    "version": "3.2.4-next.0",
     "description": "Forger for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-forger/package.json
+++ b/packages/core-forger/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-forger",
-    "version": "3.2.4-next.0",
+    "version": "3.2.4-next.1",
     "description": "Forger for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-forger/package.json
+++ b/packages/core-forger/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-forger",
-    "version": "3.2.4-next.1",
+    "version": "3.2.4",
     "description": "Forger for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-kernel/package.json
+++ b/packages/core-kernel/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-kernel",
-    "version": "3.2.4-next.1",
+    "version": "3.2.4",
     "description": "Kernel of Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-kernel/package.json
+++ b/packages/core-kernel/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-kernel",
-    "version": "3.2.4-next.0",
+    "version": "3.2.4-next.1",
     "description": "Kernel of Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-kernel/package.json
+++ b/packages/core-kernel/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-kernel",
-    "version": "3.2.3",
+    "version": "3.2.4-next.0",
     "description": "Kernel of Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-logger-pino/package.json
+++ b/packages/core-logger-pino/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-logger-pino",
-    "version": "3.2.3",
+    "version": "3.2.4-next.0",
     "description": "Webhooks for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-logger-pino/package.json
+++ b/packages/core-logger-pino/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-logger-pino",
-    "version": "3.2.4-next.1",
+    "version": "3.2.4",
     "description": "Webhooks for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-logger-pino/package.json
+++ b/packages/core-logger-pino/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-logger-pino",
-    "version": "3.2.4-next.0",
+    "version": "3.2.4-next.1",
     "description": "Webhooks for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-p2p/package.json
+++ b/packages/core-p2p/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-p2p",
-    "version": "3.2.4-next.0",
+    "version": "3.2.4-next.1",
     "description": "P2P API for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-p2p/package.json
+++ b/packages/core-p2p/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-p2p",
-    "version": "3.2.3",
+    "version": "3.2.4-next.0",
     "description": "P2P API for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-p2p/package.json
+++ b/packages/core-p2p/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-p2p",
-    "version": "3.2.4-next.1",
+    "version": "3.2.4",
     "description": "P2P API for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-p2p/src/defaults.ts
+++ b/packages/core-p2p/src/defaults.ts
@@ -23,10 +23,6 @@ export const defaults = {
      */
     getBlocksTimeout: 30000,
     /**
-     * The maximum number of peers we will broadcast data to
-     */
-    maxPeersBroadcast: 20,
-    /**
      * The maximum authorized number of peers sharing same ip /24 subnet
      */
     maxSameSubnetPeers: process.env.CORE_P2P_MAX_PEERS_SAME_SUBNET || 256,

--- a/packages/core-p2p/src/peer-communicator.ts
+++ b/packages/core-p2p/src/peer-communicator.ts
@@ -447,7 +447,7 @@ export class PeerCommunicator implements Contracts.P2P.PeerCommunicator {
             default:
                 /* istanbul ignore else */
                 if (process.env.CORE_P2P_PEER_VERIFIER_DEBUG_EXTRA) {
-                    this.logger.debug(`Socket error (peer ${peer.ip}) : ${error.message} :warning:`);
+                    this.logger.debug(`Socket error (peer ${peer.ip}): ${error.message} :warning:`);
                 }
                 /* istanbul ignore else */
                 if (disconnect) {

--- a/packages/core-p2p/src/peer-connector.ts
+++ b/packages/core-p2p/src/peer-connector.ts
@@ -102,9 +102,11 @@ export class PeerConnector implements Contracts.P2P.PeerConnector {
         this.lastConnectionCreate.set(peer.ip, Date.now());
 
         connection.onError = (error) => {
-            this.logger.debug(
-                `Socket error (peer ${Utils.IpAddress.normalizeAddress(peer.ip)}) : ${error.message} :warning:`,
-            );
+            if (error.message !== "Connection timed out") {
+                this.logger.debug(
+                    `Socket error (peer ${Utils.IpAddress.normalizeAddress(peer.ip)}): ${error.message} :warning:`,
+                );
+            }
             this.disconnect(peer);
         };
 

--- a/packages/core-p2p/src/service-provider.ts
+++ b/packages/core-p2p/src/service-provider.ts
@@ -66,7 +66,6 @@ export class ServiceProvider extends Providers.ServiceProvider {
             minimumNetworkReach: Joi.number().integer().min(0).required(),
             verifyTimeout: Joi.number().integer().min(0).required(),
             getBlocksTimeout: Joi.number().integer().min(0).required(),
-            maxPeersBroadcast: Joi.number().integer().min(0).required(),
             maxSameSubnetPeers: Joi.number().integer().min(0).required(),
             maxPeerSequentialErrors: Joi.number().integer().min(0).required(),
             whitelist: Joi.array().items(Joi.string()).required(),

--- a/packages/core-p2p/src/transaction-broadcaster.ts
+++ b/packages/core-p2p/src/transaction-broadcaster.ts
@@ -1,4 +1,4 @@
-import { Container, Contracts, Providers, Utils } from "@solar-network/core-kernel";
+import { Container, Contracts, Utils } from "@solar-network/core-kernel";
 import { Interfaces, Transactions } from "@solar-network/crypto";
 
 import { PeerCommunicator } from "./peer-communicator";
@@ -7,10 +7,6 @@ import { PeerCommunicator } from "./peer-communicator";
 export class TransactionBroadcaster implements Contracts.P2P.TransactionBroadcaster {
     @Container.inject(Container.Identifiers.LogService)
     private readonly logger!: Contracts.Kernel.Logger;
-
-    @Container.inject(Container.Identifiers.PluginConfiguration)
-    @Container.tagged("plugin", "@solar-network/core-p2p")
-    private readonly configuration!: Providers.PluginConfiguration;
 
     @Container.inject(Container.Identifiers.PeerRepository)
     private readonly repository!: Contracts.P2P.PeerRepository;
@@ -24,8 +20,7 @@ export class TransactionBroadcaster implements Contracts.P2P.TransactionBroadcas
             return;
         }
 
-        const maxPeersBroadcast: number = this.configuration.getRequired<number>("maxPeersBroadcast");
-        const peers: Contracts.P2P.Peer[] = Utils.take(Utils.shuffle(this.repository.getPeers()), maxPeersBroadcast);
+        const peers: Contracts.P2P.Peer[] = this.repository.getPeers();
 
         const transactionsStr = Utils.pluralize("transaction", transactions.length, true);
         const peersStr = Utils.pluralize("peer", peers.length, true);

--- a/packages/core-snapshots/package.json
+++ b/packages/core-snapshots/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-snapshots",
-    "version": "3.2.4-next.1",
+    "version": "3.2.4",
     "description": "Provides live local streamed snapshots functionality for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-snapshots/package.json
+++ b/packages/core-snapshots/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-snapshots",
-    "version": "3.2.3",
+    "version": "3.2.4-next.0",
     "description": "Provides live local streamed snapshots functionality for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-snapshots/package.json
+++ b/packages/core-snapshots/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-snapshots",
-    "version": "3.2.4-next.0",
+    "version": "3.2.4-next.1",
     "description": "Provides live local streamed snapshots functionality for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-state/package.json
+++ b/packages/core-state/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-state",
-    "version": "3.2.3",
+    "version": "3.2.4-next.0",
     "description": "State Management for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-state/package.json
+++ b/packages/core-state/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-state",
-    "version": "3.2.4-next.1",
+    "version": "3.2.4",
     "description": "State Management for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-state/package.json
+++ b/packages/core-state/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-state",
-    "version": "3.2.4-next.0",
+    "version": "3.2.4-next.1",
     "description": "State Management for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-transaction-pool/package.json
+++ b/packages/core-transaction-pool/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-transaction-pool",
-    "version": "3.2.4-next.0",
+    "version": "3.2.4-next.1",
     "description": "Transaction Pool Manager for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-transaction-pool/package.json
+++ b/packages/core-transaction-pool/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-transaction-pool",
-    "version": "3.2.3",
+    "version": "3.2.4-next.0",
     "description": "Transaction Pool Manager for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-transaction-pool/package.json
+++ b/packages/core-transaction-pool/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-transaction-pool",
-    "version": "3.2.4-next.1",
+    "version": "3.2.4",
     "description": "Transaction Pool Manager for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-transactions/package.json
+++ b/packages/core-transactions/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-transactions",
-    "version": "3.2.4-next.0",
+    "version": "3.2.4-next.1",
     "description": "Transaction Services for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-transactions/package.json
+++ b/packages/core-transactions/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-transactions",
-    "version": "3.2.3",
+    "version": "3.2.4-next.0",
     "description": "Transaction Services for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-transactions/package.json
+++ b/packages/core-transactions/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-transactions",
-    "version": "3.2.4-next.1",
+    "version": "3.2.4",
     "description": "Transaction Services for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-webhooks/package.json
+++ b/packages/core-webhooks/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-webhooks",
-    "version": "3.2.3",
+    "version": "3.2.4-next.0",
     "description": "Webhooks for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-webhooks/package.json
+++ b/packages/core-webhooks/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-webhooks",
-    "version": "3.2.4-next.0",
+    "version": "3.2.4-next.1",
     "description": "Webhooks for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-webhooks/package.json
+++ b/packages/core-webhooks/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-webhooks",
-    "version": "3.2.4-next.1",
+    "version": "3.2.4",
     "description": "Webhooks for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core",
-    "version": "3.2.4-next.0",
+    "version": "3.2.4-next.1",
     "description": "Core of the Solar Network Blockchain",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core",
-    "version": "3.2.4-next.1",
+    "version": "3.2.4",
     "description": "Core of the Solar Network Blockchain",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core",
-    "version": "3.2.3",
+    "version": "3.2.4-next.0",
     "description": "Core of the Solar Network Blockchain",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/crypto",
-    "version": "3.2.4-next.0",
+    "version": "3.2.4-next.1",
     "description": "Crypto utilities for the Solar Network Blockchain",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/crypto",
-    "version": "3.2.3",
+    "version": "3.2.4-next.0",
     "description": "Crypto utilities for the Solar Network Blockchain",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/crypto",
-    "version": "3.2.4-next.1",
+    "version": "3.2.4",
     "description": "Crypto utilities for the Solar Network Blockchain",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/utils",
-    "version": "3.2.4-next.0",
+    "version": "3.2.4-next.1",
     "description": "Performance oriented implementations of commonly used functions in TypeScript.",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/utils",
-    "version": "3.2.4-next.1",
+    "version": "3.2.4",
     "description": "Performance oriented implementations of commonly used functions in TypeScript.",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/utils",
-    "version": "3.2.3",
+    "version": "3.2.4-next.0",
     "description": "Performance oriented implementations of commonly used functions in TypeScript.",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3964,7 +3964,7 @@ packages:
       '@opencensus/core': 0.0.9
       '@opencensus/propagation-b3': 0.0.8
       '@pm2/agent-node': 1.1.10
-      async: 2.6.3
+      async: 2.6.4
       debug: 4.1.1
       eventemitter2: 6.4.5
       require-in-the-middle: 5.1.0
@@ -5239,8 +5239,8 @@ packages:
       shimmer: 1.2.1
     dev: false
 
-  /async/2.6.3:
-    resolution: {integrity: sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==}
+  /async/2.6.4:
+    resolution: {integrity: sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==}
     dependencies:
       lodash: 4.17.21
     dev: false

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -186,11 +186,13 @@ importers:
       '@types/hapi__hapi': 20.0.9
       '@types/hapi__joi': 17.1.7
       '@types/ip': 1.1.0
+      '@types/qs': 6.9.7
       '@types/semver': 6.2.3
       joi: 17.6.0
       lodash.clonedeep: 4.5.0
       nanomatch: 1.2.13
       node-cache: 5.1.2
+      qs: 6.10.3
       rate-limiter-flexible: 1.3.2
       semver: 6.3.0
     dependencies:
@@ -206,6 +208,7 @@ importers:
       joi: 17.6.0
       nanomatch: 1.2.13
       node-cache: 5.1.2
+      qs: 6.10.3
       rate-limiter-flexible: 1.3.2
       semver: 6.3.0
     devDependencies:
@@ -213,6 +216,7 @@ importers:
       '@types/hapi__hapi': 20.0.9
       '@types/hapi__joi': 17.1.7
       '@types/ip': 1.1.0
+      '@types/qs': 6.9.7
       '@types/semver': 6.2.3
       lodash.clonedeep: 4.5.0
 
@@ -4546,6 +4550,10 @@ packages:
     resolution: {integrity: sha512-wpRerjHDxFBQ4r8XNv3xHJZeuqrBBoeQ/fhgkooV2F7KsPIYRROb/+f9ODgZfOEyO5/w2ej4YQdpPPXipT8DAA==}
     dependencies:
       '@types/node': 17.0.21
+    dev: true
+
+  /@types/qs/6.9.7:
+    resolution: {integrity: sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==}
     dev: true
 
   /@types/readable-stream/2.3.11:
@@ -11139,6 +11147,13 @@ packages:
     transitivePeerDependencies:
       - supports-color
     dev: true
+
+  /qs/6.10.3:
+    resolution: {integrity: sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==}
+    engines: {node: '>=0.6'}
+    dependencies:
+      side-channel: 1.0.4
+    dev: false
 
   /qs/6.5.3:
     resolution: {integrity: sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==}


### PR DESCRIPTION
This PR releases Solar Core 3.2.4 for mainnet.

Changes since 3.2.3:

### Bug Fixes

\- fixed pagination bugs in `core-api` originally present in upstream code

### Maintenance
\- connection timed out errors are no longer printed to reduce pollution in logs
\- `async` dependency updated from 2.6.3 to 2.6.4 to address a prototype pollution vulnerability
\- merged `core-api` changes from upstream code to use `qs` instead of `querystring`
\- transactions are now broadcast to all peers rather than only 20