### PR TITLE
feat(crypto): bip340 schnorr signatures

### DIFF
--- a/packages/core-snapshots/src/verifier.ts
+++ b/packages/core-snapshots/src/verifier.ts
@@ -1,5 +1,5 @@
 import { Models } from "@solar-network/core-database";
-import { Blocks, Crypto, Interfaces, Transactions } from "@solar-network/crypto";
+import { Blocks, Crypto, Interfaces, Managers, Transactions } from "@solar-network/crypto";
 
 import * as Exceptions from "./exceptions/verifier";
 
@@ -41,7 +41,14 @@ export class Verifier {
             const bytes = Blocks.Serializer.serialize(block.data, false);
             const hash = Crypto.HashAlgorithms.sha256(bytes);
 
-            isVerified = Crypto.Hash.verifySchnorr(hash, blockEntity.blockSignature, blockEntity.generatorPublicKey);
+            const { bip340 } = Managers.configManager.getMilestone(blockEntity.height);
+
+            isVerified = Crypto.Hash.verifySchnorr(
+                hash,
+                blockEntity.blockSignature,
+                blockEntity.generatorPublicKey,
+                bip340,
+            );
         } catch (err) {
             throw new Exceptions.BlockVerifyException(blockEntity.id, err.message);
         }

--- a/packages/crypto/src/blocks/block.ts
+++ b/packages/crypto/src/blocks/block.ts
@@ -126,6 +126,7 @@ export class Block implements IBlock {
     }
 
     public verifySignature(): boolean {
+        const { bip340 } = configManager.getMilestone(this.data.height);
         const bytes: Buffer = Serializer.serialize(this.data, false);
         const hash: Buffer = HashAlgorithms.sha256(bytes);
 
@@ -133,7 +134,7 @@ export class Block implements IBlock {
             throw new Error();
         }
 
-        return Hash.verifySchnorr(hash, this.data.blockSignature, this.data.generatorPublicKey);
+        return Hash.verifySchnorr(hash, this.data.blockSignature, this.data.generatorPublicKey, bip340);
     }
 
     public toJson(): IBlockJson {

--- a/packages/crypto/src/blocks/factory.ts
+++ b/packages/crypto/src/blocks/factory.ts
@@ -1,5 +1,6 @@
 import { Hash, HashAlgorithms } from "../crypto";
 import { IBlock, IBlockData, IBlockJson, IKeyPair, ITransaction } from "../interfaces";
+import { configManager } from "../managers";
 import { BigNumber } from "../utils";
 import { Block } from "./block";
 import { Deserializer } from "./deserializer";
@@ -7,12 +8,14 @@ import { Serializer } from "./serializer";
 
 export class BlockFactory {
     public static make(data: IBlockData, keys: IKeyPair): IBlock | undefined {
+        const { bip340 } = configManager.getMilestone(data.height);
+
         data.generatorPublicKey = keys.publicKey;
 
         const payloadHash: Buffer = Serializer.serialize(data, false);
         const hash: Buffer = HashAlgorithms.sha256(payloadHash);
 
-        data.blockSignature = Hash.signSchnorr(hash, keys);
+        data.blockSignature = Hash.signSchnorr(hash, keys, bip340);
         data.id = Block.getId(data);
 
         return this.fromData(data);

--- a/packages/crypto/src/crypto/hash.ts
+++ b/packages/crypto/src/crypto/hash.ts
@@ -41,10 +41,6 @@ export class Hash {
         const digest: Buffer = hash.length !== 32 ? HashAlgorithms.sha256(hash) : hash;
         let key: Buffer = Buffer.from(keys.privateKey, "hex");
 
-        if (key.length === 33) {
-            key = key.slice(1);
-        }
-
         return schnorr.sign(digest, key).toString("hex");
     }
 

--- a/packages/crypto/src/crypto/hash.ts
+++ b/packages/crypto/src/crypto/hash.ts
@@ -1,17 +1,60 @@
-import { secp256k1 } from "bcrypto";
+import { schnorr, secp256k1 } from "bcrypto";
 
 import { IKeyPair } from "../interfaces";
+import { HashAlgorithms } from "./hash-algorithms";
 
 export class Hash {
-    public static signSchnorr(hash: Buffer, keys: IKeyPair): string {
+    public static signSchnorr(hash: Buffer, keys: IKeyPair, bip340?: boolean): string {
+        if (!bip340) {
+            return Hash.signSchnorrLegacy(hash, keys);
+        }
+
+        return Hash.signSchnorrBip340(hash, keys);
+    }
+
+    public static verifySchnorr(
+        hash: Buffer,
+        signature: Buffer | string,
+        publicKey: Buffer | string,
+        bip340?: boolean,
+    ): boolean {
+        if (!bip340) {
+            return Hash.verifySchnorrLegacy(hash, signature, publicKey);
+        }
+
+        return Hash.verifySchnorrBip340(hash, signature, publicKey);
+    }
+
+    public static signSchnorrLegacy(hash: Buffer, keys: IKeyPair): string {
         return secp256k1.schnorrSign(hash, Buffer.from(keys.privateKey, "hex")).toString("hex");
     }
 
-    public static verifySchnorr(hash: Buffer, signature: Buffer | string, publicKey: Buffer | string): boolean {
+    public static verifySchnorrLegacy(hash: Buffer, signature: Buffer | string, publicKey: Buffer | string): boolean {
         return secp256k1.schnorrVerify(
             hash,
             signature instanceof Buffer ? signature : Buffer.from(signature, "hex"),
             publicKey instanceof Buffer ? publicKey : Buffer.from(publicKey, "hex"),
         );
+    }
+
+    public static signSchnorrBip340(hash: Buffer, keys: IKeyPair): string {
+        const digest: Buffer = hash.length !== 32 ? HashAlgorithms.sha256(hash) : hash;
+        let key: Buffer = Buffer.from(keys.privateKey, "hex");
+
+        if (key.length === 33) {
+            key = key.slice(1);
+        }
+
+        return schnorr.sign(digest, key).toString("hex");
+    }
+
+    public static verifySchnorrBip340(hash: Buffer, signature: Buffer | string, publicKey: Buffer | string): boolean {
+        const digest: Buffer = hash.length !== 32 ? HashAlgorithms.sha256(hash) : hash;
+        let key: Buffer = publicKey instanceof Buffer ? publicKey : Buffer.from(publicKey, "hex");
+        if (key.length === 33) {
+            key = key.slice(1);
+        }
+
+        return schnorr.verify(digest, signature instanceof Buffer ? signature : Buffer.from(signature, "hex"), key);
     }
 }

--- a/packages/crypto/src/interfaces/transactions.ts
+++ b/packages/crypto/src/interfaces/transactions.ts
@@ -50,7 +50,7 @@ export interface ITransactionAsset {
 }
 
 export interface ITransactionData {
-    version?: number;
+    version: number;
     network?: number;
 
     typeGroup?: number;

--- a/packages/crypto/src/transactions/builders/transactions/transaction.ts
+++ b/packages/crypto/src/transactions/builders/transactions/transaction.ts
@@ -27,7 +27,7 @@ export abstract class TransactionBuilder<TBuilder extends TransactionBuilder<TBu
             timestamp: Slots.getTime(),
             typeGroup: TransactionTypeGroup.Test,
             nonce: BigNumber.ZERO,
-            version: configManager.getMilestone().aip11 ? 0x02 : 0x01,
+            version: configManager.getMilestone().bip340 ? 0x03 : 0x02,
         } as ITransactionData;
     }
 
@@ -213,7 +213,6 @@ export abstract class TransactionBuilder<TBuilder extends TransactionBuilder<TBu
             this.data.signatures = [];
         }
 
-        this.version(2);
         Signer.multiSign(this.getSigningObject(), keys, index);
 
         return this.instance();

--- a/packages/crypto/src/transactions/signer.ts
+++ b/packages/crypto/src/transactions/signer.ts
@@ -10,7 +10,7 @@ export class Signer {
         }
 
         const hash: Buffer = Utils.toHash(transaction, options);
-        const signature: string = Hash.signSchnorr(hash, keys);
+        const signature: string = Hash.signSchnorr(hash, keys, transaction.version > 2);
 
         if (!transaction.signature && !options.excludeMultiSignature) {
             transaction.signature = signature;
@@ -21,7 +21,7 @@ export class Signer {
 
     public static secondSign(transaction: ITransactionData, keys: IKeyPair): string {
         const hash: Buffer = Utils.toHash(transaction, { excludeSecondSignature: true });
-        const signature: string = Hash.signSchnorr(hash, keys);
+        const signature: string = Hash.signSchnorr(hash, keys, transaction.version > 2);
 
         if (!transaction.secondSignature) {
             transaction.secondSignature = signature;
@@ -43,7 +43,7 @@ export class Signer {
             excludeMultiSignature: true,
         });
 
-        const signature: string = Hash.signSchnorr(hash, keys);
+        const signature: string = Hash.signSchnorr(hash, keys, transaction.version > 2);
         const indexedSignature = `${numberToHex(index)}${signature}`;
         transaction.signatures.push(indexedSignature);
 

--- a/packages/crypto/src/transactions/types/schemas.ts
+++ b/packages/crypto/src/transactions/types/schemas.ts
@@ -22,7 +22,7 @@ export const transactionBaseSchema: Record<string, any> = {
     else: { required: ["type", "senderPublicKey", "fee", "amount", "nonce"] },
     properties: {
         id: { anyOf: [{ $ref: "transactionId" }, { type: "null" }] },
-        version: { enum: [1, 2] },
+        version: { enum: [2, 3] },
         network: { $ref: "networkByte" },
         timestamp: { type: "integer", minimum: 0 },
         nonce: { bignumber: { minimum: 0 } },

--- a/packages/crypto/src/transactions/verifier.ts
+++ b/packages/crypto/src/transactions/verifier.ts
@@ -35,7 +35,7 @@ export class Verifier {
             disableVersionCheck: options?.disableVersionCheck,
             excludeSecondSignature: true,
         });
-        return this.internalVerifySignature(hash, secondSignature, publicKey);
+        return this.internalVerifySignature(hash, secondSignature, publicKey, transaction.version > 2);
     }
 
     public static verifySignatures(transaction: ITransactionData, multiSignature: IMultiSignatureAsset): boolean {
@@ -70,7 +70,7 @@ export class Verifier {
                 const partialSignature: string = signature.slice(2, 130);
                 const publicKey: string = publicKeys[publicKeyIndex];
 
-                if (Hash.verifySchnorr(hash, partialSignature, publicKey)) {
+                if (Hash.verifySchnorr(hash, partialSignature, publicKey, transaction.version > 2)) {
                     verifiedSignatures++;
                 }
 
@@ -99,7 +99,7 @@ export class Verifier {
             excludeSecondSignature: true,
         });
 
-        return this.internalVerifySignature(hash, signature, senderPublicKey);
+        return this.internalVerifySignature(hash, signature, senderPublicKey, data.version > 2);
     }
 
     public static verifySchema(data: ITransactionData, strict = true): ISchemaValidationResult {
@@ -114,7 +114,12 @@ export class Verifier {
         return validator.validate(strict ? `${$id}Strict` : `${$id}`, data);
     }
 
-    private static internalVerifySignature(hash: Buffer, signature: string, publicKey: string): boolean {
-        return Hash.verifySchnorr(hash, signature, publicKey);
+    private static internalVerifySignature(
+        hash: Buffer,
+        signature: string,
+        publicKey: string,
+        bip340: boolean,
+    ): boolean {
+        return Hash.verifySchnorr(hash, signature, publicKey, bip340);
     }
 }

--- a/packages/crypto/src/utils/index.ts
+++ b/packages/crypto/src/utils/index.ts
@@ -96,17 +96,17 @@ export const numberToHex = (num: number, padding = 2): string => {
 export const maxVendorFieldLength = (height?: number): number => configManager.getMilestone(height).vendorFieldLength;
 
 export const isSupportedTransactionVersion = (version: number): boolean => {
-    const aip11: boolean = configManager.getMilestone().aip11;
+    const { acceptLegacySchnorrTransactions, bip340 } = configManager.getMilestone();
 
-    if (aip11 && version !== 2) {
-        return false;
+    if (bip340 && (version === 3 || (version === 2 && acceptLegacySchnorrTransactions))) {
+        return true;
     }
 
-    if (!aip11 && version !== 1) {
-        return false;
+    if (!bip340 && version === 2) {
+        return true;
     }
 
-    return true;
+    return false;
 };
 
 export { Base58, BigNumber, ByteBuffer, isValidPeer, isLocalHost, calculateBlockTime, isNewBlockTime, calculateReward };


### PR DESCRIPTION
The code we inherited from upstream uses a deprecated and potentially vulnerable version of Schnorr signatures originally used in Bitcoin Cash which the Bitcoin Core team found too problematic and never actually implemented.

This pull request introduces the necessary changes to add BIP340 Schnorr signatures to Solar's `crypto` library and deprecates the legacy Schnorr signatures. It will also require some changes to `core-transactions` and further generic refactoring of `crypto` which will follow in separate PRs.

Upon the activation of the new `bip340` milestone (height to be confirmed), all blocks and messages must immediately be signed using BIP340 Schnorr signatures. Legacy Schnorr signatures will be invalid for those as soon as the milestone is hit. The activation of the milestone will also introduce version 3 transactions which are exclusively signed using BIP340 Schnorr signatures, while version 2 transactions will continue to be exclusively signed using legacy Schnorr signatures. For a transitional period, both versions will be accepted, until the `acceptLegacySchnorrTransactions` milestone value is set to `false` in a future update when version 2 transactions will be deactivated and everything will be exclusively using BIP340 Schnorr signatures from that point onwards. This transitional period should give users enough time to update their tools or scripts to use BIP340 Schnorr signatures.

One main difference is that BIP340 public keys are 32 bytes long, because they only record the X coordinate. By comparison, ECDSA and legacy Schnorr public keys are 33 bytes long because they are compressed keys that also include an extra byte to determine whether the Y coordinate is odd or even in addition to the X coordinate. Since BIP340 always uses an even Y coordinate, the extra byte is no longer required. However, this could be problematic since wallet addresses are derived from the 33 byte public key and if we were to switch to 32 byte public keys, addresses would change and this would cause a lot of other problems and spaghetti code so we do not consider this to be an acceptable tradeoff.

Therefore, we will continue to use 33 byte compressed public keys in blocks and transactions and for translating a public key to an address, but under the hood during the signing and verification process for BIP340 Schnorr signatures, we slice the first byte of the public key and use the even Y coordinate. That is also the case if the compressed key indicates that the Y coordinate was originally odd under the legacy Schnorr signature scheme. This approach has been fully tested against the BIP340 reference implementation and poses no security risk while maintaining total compatibility with the existing wallet addressing system and means we do not have to immediately change to bech32 or similar, although this remains under consideration for the future. However, it is because we will continue to store the 33 byte compressed public key that we need to bump the transaction version, to distinguish a legacy Schnorr-signed transaction from a BIP340 Schnorr-signed transaction.

Although the security risk for our particular environment is already very low due to other mitigating steps we previously took, such as removing ECDSA, we do take security extremely seriously, and for that reason we are migrating to the BIP340 Schnorr signature algorithm which does not suffer from the same issues and weaknesses as the current implementation. It also means that our upcoming Ledger app can use the native Ledger BIP340 crypto API so we don't have to roll our own signing implementation, since the latter approach should always be avoided in cryptography where possible.

There are several other benefits too, and ultimately, making the switch to BIP340 opens more doors to really let Schnorr shine in Solar.