### PR TITLE
feat: add delegate.voters attribute

### DIFF
--- a/packages/core-api/src/resources-new/delegate.ts
+++ b/packages/core-api/src/resources-new/delegate.ts
@@ -14,6 +14,7 @@ export type DelegateResource = {
     address: string;
     publicKey: string;
     votes: Utils.BigNumber;
+    voters: number;
     rank: number;
     isResigned: boolean;
     blocks: {
@@ -47,6 +48,7 @@ export const delegateCriteriaSchemaObject = {
     address: walletCriteriaSchemaObject.address,
     publicKey: walletCriteriaSchemaObject.publicKey,
     votes: Schemas.createRangeCriteriaSchema(Schemas.nonNegativeBigNumber),
+    voters: Schemas.createRangeCriteriaSchema(Joi.number().integer().min(0)),
     rank: Schemas.createRangeCriteriaSchema(Joi.number().integer().min(1)),
     isResigned: Joi.boolean(),
     blocks: {

--- a/packages/core-api/src/services/delegate-search-service.ts
+++ b/packages/core-api/src/services/delegate-search-service.ts
@@ -72,6 +72,7 @@ export class DelegateSearchService {
             address: wallet.getAddress(),
             publicKey: publicKey!,
             votes: delegateAttribute.voteBalance,
+            voters: delegateAttribute.voters,
             rank: delegateAttribute.rank,
             isResigned: !!delegateAttribute.resigned,
             blocks: {

--- a/packages/core-api/src/www/api.json
+++ b/packages/core-api/src/www/api.json
@@ -676,7 +676,7 @@
                     {
                         "name": "forged.fees",
                         "in": "query",
-                        "description": "Exact amount, in satoshis, of all fees forged by the delegates(s) to be returned",
+                        "description": "Exact amount, in satoshis, of all fees forged by the delegate(s) to be returned",
                         "schema": {
                             "$ref": "#/components/schemas/zeroOrMore"
                         }
@@ -684,7 +684,7 @@
                     {
                         "name": "forged.fees.from",
                         "in": "query",
-                        "description": "Minimum amount, in satoshis, of all fees forged by the delegates(s) to be returned",
+                        "description": "Minimum amount, in satoshis, of all fees forged by the delegate(s) to be returned",
                         "schema": {
                             "$ref": "#/components/schemas/zeroOrMore"
                         }
@@ -692,7 +692,7 @@
                     {
                         "name": "forged.fees.to",
                         "in": "query",
-                        "description": "Maximum amount, in satoshis, of all fees forged by the delegates(s) to be returned",
+                        "description": "Maximum amount, in satoshis, of all fees forged by the delegate(s) to be returned",
                         "schema": {
                             "$ref": "#/components/schemas/zeroOrMore"
                         }
@@ -700,7 +700,7 @@
                     {
                         "name": "forged.burnedFees",
                         "in": "query",
-                        "description": "Exact amount, in satoshis, of all fees burned by the delegates(s) to be returned",
+                        "description": "Exact amount, in satoshis, of all fees burned by the delegate(s) to be returned",
                         "schema": {
                             "$ref": "#/components/schemas/zeroOrMore"
                         }
@@ -708,7 +708,7 @@
                     {
                         "name": "forged.burnedFees.from",
                         "in": "query",
-                        "description": "Minimum amount, in satoshis, of all fees burned by the delegates(s) to be returned",
+                        "description": "Minimum amount, in satoshis, of all fees burned by the delegate(s) to be returned",
                         "schema": {
                             "$ref": "#/components/schemas/zeroOrMore"
                         }
@@ -716,7 +716,7 @@
                     {
                         "name": "forged.burnedFees.to",
                         "in": "query",
-                        "description": "Maximum amount, in satoshis, of all fees burned by the delegates(s) to be returned",
+                        "description": "Maximum amount, in satoshis, of all fees burned by the delegate(s) to be returned",
                         "schema": {
                             "$ref": "#/components/schemas/zeroOrMore"
                         }
@@ -724,7 +724,7 @@
                     {
                         "name": "forged.rewards",
                         "in": "query",
-                        "description": "Exact amount, in satoshis, of all block rewards earned by the delegates(s) to be returned",
+                        "description": "Exact amount, in satoshis, of all block rewards earned by the delegate(s) to be returned",
                         "schema": {
                             "$ref": "#/components/schemas/zeroOrMore"
                         }
@@ -732,7 +732,7 @@
                     {
                         "name": "forged.rewards.from",
                         "in": "query",
-                        "description": "Minimum amount, in satoshis, of all block rewards earned by the delegates(s) to be returned",
+                        "description": "Minimum amount, in satoshis, of all block rewards earned by the delegate(s) to be returned",
                         "schema": {
                             "$ref": "#/components/schemas/zeroOrMore"
                         }
@@ -740,7 +740,7 @@
                     {
                         "name": "forged.rewards.to",
                         "in": "query",
-                        "description": "Maximum amount, in satoshis, of all block rewards earned by the delegates(s) to be returned",
+                        "description": "Maximum amount, in satoshis, of all block rewards earned by the delegate(s) to be returned",
                         "schema": {
                             "$ref": "#/components/schemas/zeroOrMore"
                         }
@@ -748,7 +748,7 @@
                     {
                         "name": "forged.total",
                         "in": "query",
-                        "description": "Exact amount, in satoshis, of all unburned fees plus block rewards earned by the delegates(s) to be returned",
+                        "description": "Exact amount, in satoshis, of all unburned fees plus block rewards earned by the delegate(s) to be returned",
                         "schema": {
                             "$ref": "#/components/schemas/zeroOrMore"
                         }
@@ -756,7 +756,7 @@
                     {
                         "name": "forged.total.from",
                         "in": "query",
-                        "description": "Minimum amount, in satoshis, of all unburned fees plus block rewards earned by the delegates(s) to be returned",
+                        "description": "Minimum amount, in satoshis, of all unburned fees plus block rewards earned by the delegate(s) to be returned",
                         "schema": {
                             "$ref": "#/components/schemas/zeroOrMore"
                         }
@@ -764,7 +764,7 @@
                     {
                         "name": "forged.total.to",
                         "in": "query",
-                        "description": "Maximum amount, in satoshis, of all unburned fees plus block rewards earned by the delegates(s) to be returned",
+                        "description": "Maximum amount, in satoshis, of all unburned fees plus block rewards earned by the delegate(s) to be returned",
                         "schema": {
                             "$ref": "#/components/schemas/zeroOrMore"
                         }
@@ -772,7 +772,7 @@
                     {
                         "name": "votes",
                         "in": "query",
-                        "description": "Exact amount of vote weight for the delegates(s) to be returned",
+                        "description": "Exact amount of vote weight for the delegate(s) to be returned",
                         "schema": {
                             "$ref": "#/components/schemas/zeroOrMore"
                         }
@@ -780,7 +780,7 @@
                     {
                         "name": "votes.from",
                         "in": "query",
-                        "description": "Minimum amount of vote weight for the delegates(s) to be returned",
+                        "description": "Minimum amount of vote weight for the delegate(s) to be returned",
                         "schema": {
                             "$ref": "#/components/schemas/zeroOrMore"
                         }
@@ -788,7 +788,31 @@
                     {
                         "name": "votes.to",
                         "in": "query",
-                        "description": "Maximum amount of vote weight for the delegates(s) to be returned",
+                        "description": "Maximum amount of vote weight for the delegate(s) to be returned",
+                        "schema": {
+                            "$ref": "#/components/schemas/zeroOrMore"
+                        }
+                    },
+                    {
+                        "name": "voters",
+                        "in": "query",
+                        "description": "Exact number of voters for the delegate(s) to be returned",
+                        "schema": {
+                            "$ref": "#/components/schemas/zeroOrMore"
+                        }
+                    },
+                    {
+                        "name": "voters.from",
+                        "in": "query",
+                        "description": "Minimum number of voters for the delegate(s) to be returned",
+                        "schema": {
+                            "$ref": "#/components/schemas/zeroOrMore"
+                        }
+                    },
+                    {
+                        "name": "voters.to",
+                        "in": "query",
+                        "description": "Maximum number of voters for the delegate(s) to be returned",
                         "schema": {
                             "$ref": "#/components/schemas/zeroOrMore"
                         }
@@ -796,7 +820,7 @@
                     {
                         "name": "blocks.produced",
                         "in": "query",
-                        "description": "Exact number of blocks produced by the delegates(s) to be returned",
+                        "description": "Exact number of blocks produced by the delegate(s) to be returned",
                         "schema": {
                             "$ref": "#/components/schemas/zeroOrMore"
                         }
@@ -804,7 +828,7 @@
                     {
                         "name": "blocks.produced.from",
                         "in": "query",
-                        "description": "Minimum number of blocks produced by the delegates(s) to be returned",
+                        "description": "Minimum number of blocks produced by the delegate(s) to be returned",
                         "schema": {
                             "$ref": "#/components/schemas/zeroOrMore"
                         }
@@ -812,7 +836,7 @@
                     {
                         "name": "blocks.produced.to",
                         "in": "query",
-                        "description": "Maximum number of blocks produced by the delegates(s) to be returned",
+                        "description": "Maximum number of blocks produced by the delegate(s) to be returned",
                         "schema": {
                             "$ref": "#/components/schemas/zeroOrMore"
                         }
@@ -828,7 +852,7 @@
                     {
                         "name": "rank.from",
                         "in": "query",
-                        "description": "Lowest rank of the delegates(s) to be returned",
+                        "description": "Lowest rank of the delegate(s) to be returned",
                         "schema": {
                             "$ref": "#/components/schemas/oneOrMore"
                         }
@@ -836,7 +860,7 @@
                     {
                         "name": "rank.to",
                         "in": "query",
-                        "description": "Highest rank of the delegates(s) to be returned",
+                        "description": "Highest rank of the delegate(s) to be returned",
                         "schema": {
                             "$ref": "#/components/schemas/oneOrMore"
                         }
@@ -852,7 +876,7 @@
                     {
                         "name": "version.from",
                         "in": "query",
-                        "description": "Earliest node version running on the delegates(s) to be returned",
+                        "description": "Earliest node version running on the delegate(s) to be returned",
                         "schema": {
                             "$ref": "#/components/schemas/semver"
                         }
@@ -860,7 +884,7 @@
                     {
                         "name": "version.to",
                         "in": "query",
-                        "description": "Latest node version running on the delegates(s) to be returned",
+                        "description": "Latest node version running on the delegate(s) to be returned",
                         "schema": {
                             "$ref": "#/components/schemas/semver"
                         }
@@ -895,7 +919,9 @@
                                 "version:asc",
                                 "version:desc",
                                 "votes:asc",
-                                "votes:desc"
+                                "votes:desc",
+                                "voters:asc",
+                                "voters:desc"
                             ]
                         }
                     }

--- a/packages/core-kernel/src/contracts/state/wallets.ts
+++ b/packages/core-kernel/src/contracts/state/wallets.ts
@@ -140,6 +140,7 @@ export type WalletFactory = (address: string) => Wallet;
 export interface WalletDelegateAttributes {
     username: string;
     voteBalance: Utils.BigNumber;
+    voters: number;
     forgedFees: Utils.BigNumber;
     burnedFees: Utils.BigNumber;
     forgedRewards: Utils.BigNumber;

--- a/packages/core-state/src/dpos/dpos.ts
+++ b/packages/core-state/src/dpos/dpos.ts
@@ -40,6 +40,7 @@ export class DposState implements Contracts.State.DposState {
                     voter.getAttribute("vote"),
                 );
 
+                delegate.setAttribute("delegate.voters", delegate.getAttribute("delegate.voters") + 1);
                 const voteBalance: Utils.BigNumber = delegate.getAttribute("delegate.voteBalance");
 
                 const lockedBalance = voter.getAttribute("htlc.lockedBalance", Utils.BigNumber.ZERO);

--- a/packages/core-transactions/src/handlers/one/delegate-registration.ts
+++ b/packages/core-transactions/src/handlers/one/delegate-registration.ts
@@ -33,6 +33,7 @@ export class DelegateRegistrationTransactionHandler extends TransactionHandler {
             "delegate.username",
             "delegate.version", // Used by the API
             "delegate.voteBalance",
+            "delegate.voters", // Used by the API
             "delegate",
         ];
     }
@@ -128,6 +129,7 @@ export class DelegateRegistrationTransactionHandler extends TransactionHandler {
             forgedRewards: Utils.BigNumber.ZERO,
             producedBlocks: 0,
             round: 0,
+            voters: 0,
         });
 
         this.walletRepository.index(sender);

--- a/packages/core-transactions/src/handlers/one/vote.ts
+++ b/packages/core-transactions/src/handlers/one/vote.ts
@@ -134,16 +134,26 @@ export class VoteTransactionHandler extends TransactionHandler {
         Utils.assert.defined<string[]>(transaction.data.asset?.votes);
 
         for (const vote of transaction.data.asset.votes) {
+            let delegateWallet: Contracts.State.Wallet;
+            let delegateVote: string = vote.slice(1);
+            if (delegateVote.length !== 66) {
+                delegateWallet = this.walletRepository.findByUsername(delegateVote);
+                delegateVote = delegateWallet.getPublicKey()!;
+            } else {
+                delegateWallet = this.walletRepository.findByPublicKey(delegateVote);
+            }
+
+            let voters: number = delegateWallet.getAttribute("delegate.voters");
+
             if (vote.startsWith("+")) {
-                let delegateVote: string = vote.slice(1);
-                if (delegateVote.length !== 66) {
-                    const delegateWallet: Contracts.State.Wallet = this.walletRepository.findByUsername(delegateVote);
-                    delegateVote = delegateWallet.getPublicKey()!;
-                }
+                voters++;
                 sender.setAttribute("vote", delegateVote);
             } else {
+                voters--;
                 sender.forgetAttribute("vote");
             }
+
+            delegateWallet.setAttribute("delegate.voters", voters);
         }
     }
 
@@ -157,16 +167,26 @@ export class VoteTransactionHandler extends TransactionHandler {
         Utils.assert.defined<Interfaces.ITransactionAsset>(transaction.data.asset?.votes);
 
         for (const vote of transaction.data.asset.votes.slice().reverse()) {
+            let delegateWallet: Contracts.State.Wallet;
+            let delegateVote: string = vote.slice(1);
+            if (delegateVote.length !== 66) {
+                delegateWallet = this.walletRepository.findByUsername(delegateVote);
+                delegateVote = delegateWallet.getPublicKey()!;
+            } else {
+                delegateWallet = this.walletRepository.findByPublicKey(delegateVote);
+            }
+
+            let voters: number = delegateWallet.getAttribute("delegate.voters");
+
             if (vote.startsWith("+")) {
+                voters--;
                 sender.forgetAttribute("vote");
             } else {
-                let delegateVote: string = vote.slice(1);
-                if (delegateVote.length !== 66) {
-                    const delegateWallet: Contracts.State.Wallet = this.walletRepository.findByUsername(delegateVote);
-                    delegateVote = delegateWallet.getPublicKey()!;
-                }
+                voters++;
                 sender.setAttribute("vote", delegateVote);
             }
+
+            delegateWallet.setAttribute("delegate.voters", voters);
         }
     }
 

--- a/packages/core-transactions/src/handlers/two/delegate-registration.ts
+++ b/packages/core-transactions/src/handlers/two/delegate-registration.ts
@@ -33,6 +33,7 @@ export class DelegateRegistrationTransactionHandler extends One.DelegateRegistra
                 forgedRewards: Utils.BigNumber.ZERO,
                 producedBlocks: 0,
                 rank: undefined,
+                voters: 0,
             });
 
             this.walletRepository.index(wallet);


### PR DESCRIPTION
Core's Public API lacks an easy way to see how many wallets are voting for each delegate without querying each delegate's endpoint individually. This PR improves on this by adding a `delegate.voters` attribute to all delegates, with the total number of wallets voting for that delegate. This information is now exposed via `/api/delegates` and `/api/delegates/{id}`.

This brings the same functionality as the [@dpos-info/core-voter-count](https://github.com/dpos-info/core-voter-count) plugin but natively in Core and we would like to recognise, acknowledge and thank them their reference implementation. Implementing it natively in Core also means new search and sorting criteria has been added to the `/api/delegates` API endpoint for the `voters` attribute and it will continue to work correctly with several upcoming changes to Solar which would otherwise break the plugin.