### PR TITLE
feat: support more hash algorithms for htlc

### DIFF
--- a/packages/core-transactions/src/handlers/two/htlc-claim.ts
+++ b/packages/core-transactions/src/handlers/two/htlc-claim.ts
@@ -1,5 +1,5 @@
 import { Container, Contracts, Utils as AppUtils } from "@solar-network/core-kernel";
-import { Crypto, Interfaces, Managers, Transactions, Utils } from "@solar-network/crypto";
+import { Crypto, Enums, Interfaces, Managers, Transactions, Utils } from "@solar-network/crypto";
 import { strict } from "assert";
 
 import { HtlcLockExpiredError, HtlcLockTransactionNotFoundError, HtlcSecretHashMismatchError } from "../../errors";
@@ -71,7 +71,49 @@ export class HtlcClaimTransactionHandler extends TransactionHandler {
         }
 
         const unlockSecretBytes = Buffer.from(claimAsset.unlockSecret, "hex");
-        const unlockSecretHash: string = Crypto.HashAlgorithms.sha256(unlockSecretBytes).toString("hex");
+
+        let hashAlgorithm: any;
+
+        switch (claimAsset.hashType) {
+            case Enums.HtlcSecretHashType.SHA256: {
+                hashAlgorithm = Crypto.HashAlgorithms.sha256;
+                break;
+            }
+            case Enums.HtlcSecretHashType.SHA384: {
+                hashAlgorithm = Crypto.HashAlgorithms.sha384;
+                break;
+            }
+            case Enums.HtlcSecretHashType.SHA512: {
+                hashAlgorithm = Crypto.HashAlgorithms.sha512;
+                break;
+            }
+            case Enums.HtlcSecretHashType.SHA3256: {
+                hashAlgorithm = Crypto.HashAlgorithms.sha3256;
+                break;
+            }
+            case Enums.HtlcSecretHashType.SHA3384: {
+                hashAlgorithm = Crypto.HashAlgorithms.sha3384;
+                break;
+            }
+            case Enums.HtlcSecretHashType.SHA3512: {
+                hashAlgorithm = Crypto.HashAlgorithms.sha3512;
+                break;
+            }
+            case Enums.HtlcSecretHashType.Keccak256: {
+                hashAlgorithm = Crypto.HashAlgorithms.keccak256;
+                break;
+            }
+            case Enums.HtlcSecretHashType.Keccak384: {
+                hashAlgorithm = Crypto.HashAlgorithms.keccak384;
+                break;
+            }
+            case Enums.HtlcSecretHashType.Keccak512: {
+                hashAlgorithm = Crypto.HashAlgorithms.keccak512;
+                break;
+            }
+        }
+
+        const unlockSecretHash: string = hashAlgorithm(unlockSecretBytes).toString("hex");
         if (lock.secretHash !== unlockSecretHash) {
             throw new HtlcSecretHashMismatchError();
         }

--- a/packages/crypto/src/crypto/hash-algorithms.ts
+++ b/packages/crypto/src/crypto/hash-algorithms.ts
@@ -1,32 +1,56 @@
-import { Hash160, Hash256, RIPEMD160, SHA1, SHA256 } from "bcrypto";
+import {
+    Hash256,
+    Keccak256,
+    Keccak384,
+    Keccak512,
+    RIPEMD160,
+    SHA3_256,
+    SHA3_384,
+    SHA3_512,
+    SHA256,
+    SHA384,
+    SHA512,
+} from "bcrypto";
 
 export class HashAlgorithms {
     public static ripemd160(buff: Buffer | string): Buffer {
         return RIPEMD160.digest(this.bufferize(buff));
     }
 
-    public static sha1(buff: Buffer | string): Buffer {
-        return SHA1.digest(this.bufferize(buff));
+    public static keccak256(buff: Buffer | string | Buffer[]): Buffer {
+        return HashAlgorithms.hash(buff, Keccak256);
+    }
+
+    public static keccak384(buff: Buffer | string | Buffer[]): Buffer {
+        return HashAlgorithms.hash(buff, Keccak384);
+    }
+
+    public static keccak512(buff: Buffer | string | Buffer[]): Buffer {
+        return HashAlgorithms.hash(buff, Keccak512);
     }
 
     public static sha256(buff: Buffer | string | Buffer[]): Buffer {
-        if (Array.isArray(buff)) {
-            let sha256 = SHA256.ctx;
-
-            sha256.init();
-
-            for (const element of buff) {
-                sha256 = sha256.update(element);
-            }
-
-            return sha256.final();
-        }
-
-        return SHA256.digest(this.bufferize(buff));
+        return HashAlgorithms.hash(buff, SHA256);
     }
 
-    public static hash160(buff: Buffer | string): Buffer {
-        return Hash160.digest(this.bufferize(buff));
+    public static sha384(buff: Buffer | string | Buffer[]): Buffer {
+        return HashAlgorithms.hash(buff, SHA384);
+    }
+
+    public static sha512(buff: Buffer | string | Buffer[]): Buffer {
+        return HashAlgorithms.hash(buff, SHA512);
+    }
+
+    public static sha3256(buff: Buffer | string | Buffer[]): Buffer {
+        return HashAlgorithms.hash(buff, SHA3_256);
+    }
+
+    public static sha3384(buff: Buffer | string | Buffer[]): Buffer {
+        return HashAlgorithms.hash(buff, SHA3_384);
+    }
+
+    public static sha3512(buff: Buffer | string | Buffer[]): Buffer {
+        return HashAlgorithms.hash(buff, SHA3_512);
     }
 
     public static hash256(buff: Buffer | string): Buffer {
@@ -35,5 +59,21 @@ export class HashAlgorithms {
 
     private static bufferize(buff: Buffer | string) {
         return buff instanceof Buffer ? buff : Buffer.from(buff);
+    }
+
+    private static hash(buff: Buffer | string | Buffer[], hasher: any): Buffer {
+        if (Array.isArray(buff)) {
+            let hasherCtx = hasher.ctx;
+
+            hasherCtx.init();
+
+            for (const element of buff) {
+                hasherCtx = hasherCtx.update(element);
+            }
+
+            return hasherCtx.final();
+        }
+
+        return hasher.digest(this.bufferize(buff));
     }
 }

--- a/packages/crypto/src/enums.ts
+++ b/packages/crypto/src/enums.ts
@@ -34,3 +34,15 @@ export enum HtlcLockExpirationType {
     EpochTimestamp = 1,
     BlockHeight = 2,
 }
+
+export enum HtlcSecretHashType {
+    SHA256 = 0,
+    SHA384 = 1,
+    SHA512 = 2,
+    SHA3256 = 3,
+    SHA3384 = 4,
+    SHA3512 = 5,
+    Keccak256 = 6,
+    Keccak384 = 7,
+    Keccak512 = 8,
+}

--- a/packages/crypto/src/interfaces/transactions.ts
+++ b/packages/crypto/src/interfaces/transactions.ts
@@ -1,6 +1,6 @@
 import { ErrorObject } from "ajv";
 
-import { HtlcLockExpirationType } from "../enums";
+import { HtlcLockExpirationType, HtlcSecretHashType } from "../enums";
 import { BigNumber, ByteBuffer } from "../utils";
 
 export interface ITransaction {
@@ -144,6 +144,7 @@ export interface IHtlcLockAsset {
 }
 
 export interface IHtlcClaimAsset {
+    hashType: HtlcSecretHashType;
     lockTransactionId: string;
     unlockSecret: string;
 }

--- a/packages/crypto/src/transactions/types/schemas.ts
+++ b/packages/crypto/src/transactions/types/schemas.ts
@@ -280,7 +280,13 @@ export const htlcLock = extend(transactionBaseSchema, {
                     type: "object",
                     required: ["secretHash", "expiration"],
                     properties: {
-                        secretHash: { allOf: [{ minLength: 64, maxLength: 64 }, { $ref: "hex" }] },
+                        secretHash: {
+                            oneOf: [
+                                { allOf: [{ minLength: 64, maxLength: 64 }, { $ref: "hex" }] },
+                                { allOf: [{ minLength: 96, maxLength: 96 }, { $ref: "hex" }] },
+                                { allOf: [{ minLength: 128, maxLength: 128 }, { $ref: "hex" }] },
+                            ],
+                        },
                         expiration: {
                             type: "object",
                             required: ["type", "value"],
@@ -310,8 +316,15 @@ export const htlcClaim = extend(transactionBaseSchema, {
                     type: "object",
                     required: ["lockTransactionId", "unlockSecret"],
                     properties: {
+                        hashType: { enum: [0, 1, 2, 3, 4, 5, 6, 7, 8] },
                         lockTransactionId: { $ref: "transactionId" },
-                        unlockSecret: { allOf: [{ minLength: 64, maxLength: 64 }, { $ref: "hex" }] },
+                        unlockSecret: {
+                            oneOf: [
+                                { allOf: [{ minLength: 64, maxLength: 64 }, { $ref: "hex" }] },
+                                { allOf: [{ minLength: 96, maxLength: 96 }, { $ref: "hex" }] },
+                                { allOf: [{ minLength: 128, maxLength: 128 }, { $ref: "hex" }] },
+                            ],
+                        },
                     },
                 },
             },

--- a/packages/crypto/src/transactions/types/two/htlc-lock.ts
+++ b/packages/crypto/src/transactions/types/two/htlc-lock.ts
@@ -30,12 +30,14 @@ export abstract class HtlcLockTransaction extends Transaction {
     public serialize(options?: ISerializeOptions): ByteBuffer | undefined {
         const { data } = this;
 
-        const buff: ByteBuffer = new ByteBuffer(Buffer.alloc(8 + 32 + 1 + 4 + 21));
+        const buff: ByteBuffer = new ByteBuffer(Buffer.alloc(99));
 
         buff.writeBigUInt64LE(data.amount.toBigInt());
 
         if (data.asset && data.asset.lock) {
-            buff.writeBuffer(Buffer.from(data.asset.lock.secretHash, "hex"));
+            const secretHash: Buffer = Buffer.from(data.asset.lock.secretHash, "hex");
+            buff.writeUInt8(secretHash.length);
+            buff.writeBuffer(secretHash);
             buff.writeUInt8(data.asset.lock.expiration.type);
             buff.writeUInt32LE(data.asset.lock.expiration.value);
         }
@@ -57,7 +59,8 @@ export abstract class HtlcLockTransaction extends Transaction {
         const { data } = this;
 
         const amount: BigNumber = BigNumber.make(buf.readBigUInt64LE().toString());
-        const secretHash: string = buf.readBuffer(32).toString("hex");
+        const secretHashLength: number = buf.readUInt8();
+        const secretHash: string = buf.readBuffer(secretHashLength).toString("hex");
         const expirationType: number = buf.readUInt8();
         const expirationValue: number = buf.readUInt32LE();
         const recipientId: string = Address.fromBuffer(buf.readBuffer(21));


### PR DESCRIPTION
The default implementation of HTLC is restricted to SHA256 hashes only. This PR introduces additional support for SHA384, SHA512, SHA3-256, SHA3-384, SHA3-512, Keccak256, Keccak384 and Keccak512 too, with an easily extensible system to add additional hash algorithms to HTLC transactions in the future if necessary. It updates the schema for HTLC Lock and HTLC Claim transactions to allow hashes of 64, 96 and 128 characters and extends the HTLC Claim transaction type to specify a `hashType` in the `claim` asset, where the value is a numerical enum corresponding to the following:

```
 SHA256 = 0,
 SHA384 = 1,
 SHA512 = 2,
 SHA3256 = 3,
 SHA3384 = 4,
 SHA3512 = 5,
 Keccak256 = 6,
 Keccak384 = 7,
 Keccak512 = 8
```

The `hashType` is optional and will default to SHA256 if omitted. The rationale is that any other forks of upstream's code might choose to use a different hash algorithm for any reason, and at least here we now have a system that already supports the common algorithms and any others can be added very easily.

This PR also removes `Hash160` from `crypto` since it was only ever used for BIP38 encryption which has been removed in Solar Core, as well as the `SHA1` algorithm which is cryptographically broken and was deprecated by NIST in 2011.

HTLC transactions will be activated on testnet in the next release of Solar Core.