### PR TITLE
refactor: keep downloading blocks while p2p port is closed

### DIFF
--- a/packages/core-blockchain/src/blockchain.ts
+++ b/packages/core-blockchain/src/blockchain.ts
@@ -198,6 +198,7 @@ export class Blockchain implements Contracts.Blockchain.Blockchain {
     public async handleIncomingBlock(
         block: Interfaces.IBlockData,
         fromForger = false,
+        ip: string,
         fireBlockReceivedEvent = true,
     ): Promise<void> {
         const blockTimeLookup = await Utils.forgingInfoCalculator.getBlockTimeLookup(this.app, block.height);
@@ -230,12 +231,12 @@ export class Blockchain implements Contracts.Blockchain.Blockchain {
             this.enqueueBlocks([block]);
 
             if (fireBlockReceivedEvent) {
-                this.events.dispatch(Enums.BlockEvent.Received, block);
+                this.events.dispatch(Enums.BlockEvent.Received, { ...block, ip });
             }
         } else {
             this.logger.info(`Block disregarded because blockchain is not ready :exclamation:`);
 
-            this.events.dispatch(Enums.BlockEvent.Disregarded, block);
+            this.events.dispatch(Enums.BlockEvent.Disregarded, { ...block, ip });
         }
     }
 

--- a/packages/core-blockchain/src/state-machine/actions/check-later.ts
+++ b/packages/core-blockchain/src/state-machine/actions/check-later.ts
@@ -1,4 +1,4 @@
-import { Container, Contracts, Enums, Utils as AppUtils } from "@solar-network/core-kernel";
+import { Container, Contracts, Enums, Providers, Utils as AppUtils } from "@solar-network/core-kernel";
 import { Crypto, Managers, Utils } from "@solar-network/crypto";
 import delay from "delay";
 
@@ -11,6 +11,10 @@ export class CheckLater implements Action {
 
     @Container.inject(Container.Identifiers.BlockchainService)
     private readonly blockchain!: Contracts.Blockchain.Blockchain;
+
+    @Container.inject(Container.Identifiers.PluginConfiguration)
+    @Container.tagged("plugin", "@solar-network/core-p2p")
+    private readonly configuration!: Providers.PluginConfiguration;
 
     @Container.inject(Container.Identifiers.EventDispatcherService)
     private readonly events!: Contracts.Kernel.EventDispatcher;
@@ -131,7 +135,11 @@ export class CheckLater implements Action {
 
                 const stopDownloading = {
                     handle: ({ data }) => {
-                        if (data.ip !== "127.0.0.1") {
+                        const remoteAccess: string[] = this.configuration.getOptional<Array<string>>(
+                            "remoteAccess",
+                            [],
+                        );
+                        if (!remoteAccess.includes(data.ip)) {
                             this.events.forget(Enums.BlockEvent.Received, stopDownloading);
                             clearInterval(downloadInterval);
                         }

--- a/packages/core-blockchain/src/state-machine/actions/check-later.ts
+++ b/packages/core-blockchain/src/state-machine/actions/check-later.ts
@@ -118,7 +118,7 @@ export class CheckLater implements Action {
                                     )} and was downloaded from ${blocks[0].ip}`,
                                 );
 
-                                this.blockchain.handleIncomingBlock(blocks[0], false, false);
+                                this.blockchain.handleIncomingBlock(blocks[0], false, blocks[0].ip!, false);
                             } else {
                                 this.blockchain.enqueueBlocks(blocks);
                                 this.blockchain.dispatch("DOWNLOADED");
@@ -130,9 +130,11 @@ export class CheckLater implements Action {
                 }, 500);
 
                 const stopDownloading = {
-                    handle: () => {
-                        this.events.forget(Enums.BlockEvent.Received, stopDownloading);
-                        clearInterval(downloadInterval);
+                    handle: ({ data }) => {
+                        if (data.ip !== "127.0.0.1") {
+                            this.events.forget(Enums.BlockEvent.Received, stopDownloading);
+                            clearInterval(downloadInterval);
+                        }
                     },
                 };
 

--- a/packages/core-blockchain/src/state-machine/actions/check-later.ts
+++ b/packages/core-blockchain/src/state-machine/actions/check-later.ts
@@ -12,15 +12,15 @@ export class CheckLater implements Action {
     @Container.inject(Container.Identifiers.BlockchainService)
     private readonly blockchain!: Contracts.Blockchain.Blockchain;
 
-    @Container.inject(Container.Identifiers.PluginConfiguration)
-    @Container.tagged("plugin", "@solar-network/core-p2p")
-    private readonly configuration!: Providers.PluginConfiguration;
-
     @Container.inject(Container.Identifiers.EventDispatcherService)
     private readonly events!: Contracts.Kernel.EventDispatcher;
 
     @Container.inject(Container.Identifiers.LogService)
     private readonly logger!: Contracts.Kernel.Logger;
+
+    @Container.inject(Container.Identifiers.PluginConfiguration)
+    @Container.tagged("plugin", "@solar-network/core-p2p")
+    private readonly p2pConfiguration!: Providers.PluginConfiguration;
 
     @Container.inject(Container.Identifiers.PeerNetworkMonitor)
     private readonly peerNetworkMonitor!: Contracts.P2P.NetworkMonitor;
@@ -135,7 +135,7 @@ export class CheckLater implements Action {
 
                 const stopDownloading = {
                     handle: ({ data }) => {
-                        const remoteAccess: string[] = this.configuration.getOptional<Array<string>>(
+                        const remoteAccess: string[] = this.p2pConfiguration.getOptional<Array<string>>(
                             "remoteAccess",
                             [],
                         );

--- a/packages/core-kernel/src/contracts/blockchain/blockchain.ts
+++ b/packages/core-kernel/src/contracts/blockchain/blockchain.ts
@@ -49,7 +49,12 @@ export interface Blockchain {
     /**
      * Push a block to the process queue.
      */
-    handleIncomingBlock(block: Interfaces.IBlockData, fromForger: boolean, fireBlockReceivedEvent?: boolean): void;
+    handleIncomingBlock(
+        block: Interfaces.IBlockData,
+        fromForger: boolean,
+        ip: string,
+        fireBlockReceivedEvent?: boolean,
+    ): void;
 
     enqueueBlocks(blocks: Interfaces.IBlockData[]);
 

--- a/packages/core-p2p/src/socket-server/controllers/blocks.ts
+++ b/packages/core-p2p/src/socket-server/controllers/blocks.ts
@@ -110,15 +110,17 @@ export class BlocksController extends Controller {
 
         this.logger.debug(`The id of the new block is ${block.id}`);
 
+        const ip: string = mapAddr(request.info.remoteAddress);
+
         this.logger.debug(
             `It contains ${AppUtils.pluralize(
                 "transaction",
                 block.numberOfTransactions,
                 true,
-            )} and was received from ${mapAddr(request.info.remoteAddress)}`,
+            )} and was received from ${ip}`,
         );
 
-        await this.blockchain.handleIncomingBlock(block, fromForger);
+        this.blockchain.handleIncomingBlock(block, fromForger, ip);
 
         return { status: true, height: this.blockchain.getLastHeight() };
     }


### PR DESCRIPTION
Earlier enhancements to Solar Core have already made it flexible enough to stay in sync as a relay even when behind a firewall (i.e. when the P2P port is closed). However, it did not work if a forging node was behind a firewall. This PR makes it so forging nodes can also stay in sync behind a firewall or with the P2P port closed.

It is worth mentioning that this is primarily designed to maintain the health of the network to avoid missed blocks in the event that a forging node is not properly configured and is absolutely not intended to suggest that delegates should run their nodes with the P2P port closed due to the fact that such nodes will not receive transactions and there is a necessity that delegate nodes must be contactable by other delegate nodes in order to participate in consensus calculations. Future revisions will change the way this is implemented, and at that point it will be recommended to run a forging node behind a firewall, but for now it is important for delegate nodes to keep their P2P port open and accessible at all times.
