### PR TITLE
refactor(crypto): disallow voting by public key in v3 transactions

### DIFF
--- a/packages/crypto/src/transactions/types/schemas.ts
+++ b/packages/crypto/src/transactions/types/schemas.ts
@@ -123,6 +123,21 @@ export const delegateRegistration = extend(transactionBaseSchema, {
 export const vote = extend(transactionBaseSchema, {
     $id: "vote",
     required: ["asset"],
+    if: { properties: { version: { anyOf: [{ const: 2 }] } } },
+    then: {
+        properties: {
+            asset: {
+                properties: { votes: { items: { $ref: "walletVoteUsernameOrPublicKey" } } },
+            },
+        },
+    },
+    else: {
+        properties: {
+            asset: {
+                properties: { votes: { items: { $ref: "walletVoteUsername" } } },
+            },
+        },
+    },
     properties: {
         type: { transactionType: TransactionType.Core.Vote },
         amount: { bignumber: { minimum: 0, maximum: 0 } },
@@ -137,7 +152,6 @@ export const vote = extend(transactionBaseSchema, {
                     minItems: 1,
                     maxItems: 2,
                     additionalItems: false,
-                    items: { $ref: "walletVote" },
                 },
             },
         },

--- a/packages/crypto/src/validation/schemas.ts
+++ b/packages/crypto/src/validation/schemas.ts
@@ -37,17 +37,25 @@ export const schemas = {
         allOf: [{ minLength: 66, maxLength: 66 }, { $ref: "hex" }, { transform: ["toLowerCase"] }],
     },
 
-    walletVote: {
-        $id: "walletVote",
+    walletVotePublicKey: {
+        $id: "walletVotePublicKey",
         allOf: [
-            {
-                oneOf: [
-                    { type: "string", pattern: "^[+|-][a-zA-Z0-9]{66}$" },
-                    { type: "string", pattern: "^[+|-][a-z0-9!@$&_.]+$", minLength: 2, maxLength: 21 },
-                ],
-            },
-            { transform: ["toLowerCase"] },
+            { type: "string", pattern: "^[+|-][a-f0-9]{66}$" },
+            { minLength: 67, maxLength: 67 },
         ],
+    },
+
+    walletVoteUsername: {
+        $id: "walletVoteUsername",
+        allOf: [
+            { type: "string", pattern: "^[+|-][a-z0-9!@$&_.]+$" },
+            { minLength: 2, maxLength: 21 },
+        ],
+    },
+
+    walletVoteUsernameOrPublicKey: {
+        $id: "walletVoteUsernameOrPublicKey",
+        oneOf: [{ $ref: "walletVoteUsername" }, { $ref: "walletVotePublicKey" }],
     },
 
     username: {
@@ -55,7 +63,6 @@ export const schemas = {
         allOf: [
             { type: "string", pattern: "^[a-z0-9!@$&_.]+$" },
             { minLength: 1, maxLength: 20 },
-            { transform: ["toLowerCase"] },
         ],
     },
 


### PR DESCRIPTION
The upstream code only allows vote transactions to use the public key in the asset. Since Solar's launch on mainnet, we have also allowed (and preferred) vote transactions with the username in the asset, since this is more compact (meaning fewer bytes per transaction, ergo a lower fee) and provides a better user experience for the upcoming Ledger app.

We kept support for voting via public key to maintain compatibility with the upstream wallet and tooling, however, enough time has passed now to finally drop support for the public key in the asset. This will come into effect with version 3 transactions, since the upstream wallet and tooling will not support them anyway.