### PR TITLE
release: mainnet 3.2.5

### DIFF
--- a/packages/core-api/package.json
+++ b/packages/core-api/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-api",
-    "version": "3.2.4",
+    "version": "3.2.5",
     "description": "Public API for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-blockchain/package.json
+++ b/packages/core-blockchain/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-blockchain",
-    "version": "3.2.4",
+    "version": "3.2.5",
     "description": "Blockchain Manager for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-cli/package.json
+++ b/packages/core-cli/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-cli",
-    "version": "3.2.4",
+    "version": "3.2.5",
     "description": "Command Line Interface to manage the Core of the Solar Network Blockchain",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-database/package.json
+++ b/packages/core-database/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-database",
-    "version": "3.2.4",
+    "version": "3.2.5",
     "description": "Database Interface for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-forger/package.json
+++ b/packages/core-forger/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-forger",
-    "version": "3.2.4",
+    "version": "3.2.5",
     "description": "Forger for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-kernel/package.json
+++ b/packages/core-kernel/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-kernel",
-    "version": "3.2.4",
+    "version": "3.2.5",
     "description": "Kernel of Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-logger-pino/package.json
+++ b/packages/core-logger-pino/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-logger-pino",
-    "version": "3.2.4",
+    "version": "3.2.5",
     "description": "Webhooks for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-p2p/package.json
+++ b/packages/core-p2p/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-p2p",
-    "version": "3.2.4",
+    "version": "3.2.5",
     "description": "P2P API for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-snapshots/package.json
+++ b/packages/core-snapshots/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-snapshots",
-    "version": "3.2.4",
+    "version": "3.2.5",
     "description": "Provides live local streamed snapshots functionality for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-state/package.json
+++ b/packages/core-state/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-state",
-    "version": "3.2.4",
+    "version": "3.2.5",
     "description": "State Management for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-transaction-pool/package.json
+++ b/packages/core-transaction-pool/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-transaction-pool",
-    "version": "3.2.4",
+    "version": "3.2.5",
     "description": "Transaction Pool Manager for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-transactions/package.json
+++ b/packages/core-transactions/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-transactions",
-    "version": "3.2.4",
+    "version": "3.2.5",
     "description": "Transaction Services for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-transactions/src/handlers/two/multi-signature-registration.ts
+++ b/packages/core-transactions/src/handlers/two/multi-signature-registration.ts
@@ -1,5 +1,5 @@
 import { Container, Contracts, Utils as AppUtils } from "@solar-network/core-kernel";
-import { Identities, Interfaces, Managers, Transactions } from "@solar-network/crypto";
+import { Identities, Interfaces, Transactions } from "@solar-network/crypto";
 
 import {
     InvalidMultiSignatureError,
@@ -54,7 +54,7 @@ export class MultiSignatureRegistrationTransactionHandler extends TransactionHan
     }
 
     public async isActivated(): Promise<boolean> {
-        return Managers.configManager.getMilestone().aip11 === true;
+        return false;
     }
 
     public async throwIfCannotBeApplied(

--- a/packages/core-webhooks/package.json
+++ b/packages/core-webhooks/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-webhooks",
-    "version": "3.2.4",
+    "version": "3.2.5",
     "description": "Webhooks for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core",
-    "version": "3.2.4",
+    "version": "3.2.5",
     "description": "Core of the Solar Network Blockchain",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/crypto",
-    "version": "3.2.4",
+    "version": "3.2.5",
     "description": "Crypto utilities for the Solar Network Blockchain",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/utils",
-    "version": "3.2.4",
+    "version": "3.2.5",
     "description": "Performance oriented implementations of commonly used functions in TypeScript.",
     "license": "CC-BY-ND-4.0",
     "contributors": [


### PR DESCRIPTION
This PR releases Solar Core 3.2.5 for mainnet.

Changes since 3.2.4:

\- disable multisignature registrations