### PR TITLE
feat: development funding via forging rewards

### DIFF
--- a/packages/core-api/src/resources-new/delegate.ts
+++ b/packages/core-api/src/resources-new/delegate.ts
@@ -28,6 +28,7 @@ export type DelegateResource = {
         fees: Utils.BigNumber;
         burnedFees: Utils.BigNumber;
         rewards: Utils.BigNumber;
+        devFunds: Utils.BigNumber;
         total: Utils.BigNumber;
     };
     version?: Semver;
@@ -70,6 +71,7 @@ export const delegateCriteriaSchemaObject = {
         burnedFees: Schemas.createRangeCriteriaSchema(Schemas.nonNegativeBigNumber),
         fees: Schemas.createRangeCriteriaSchema(Schemas.nonNegativeBigNumber),
         rewards: Schemas.createRangeCriteriaSchema(Schemas.nonNegativeBigNumber),
+        devFunds: Schemas.createRangeCriteriaSchema(Schemas.nonNegativeBigNumber),
         total: Schemas.createRangeCriteriaSchema(Schemas.nonNegativeBigNumber),
     },
     version: Schemas.createRangeCriteriaSchema(Schemas.semver),

--- a/packages/core-api/src/resources/block-with-transactions.ts
+++ b/packages/core-api/src/resources/block-with-transactions.ts
@@ -37,10 +37,17 @@ export class BlockWithTransactionsResource implements Resource {
             previous: blockData.previousBlock,
             forged: {
                 reward: blockData.reward.toFixed(),
+                devFund: blockData.devFund,
                 fee: blockData.totalFee.toFixed(),
                 burnedFee: blockData.burnedFee!.toFixed(),
                 amount: totalAmountTransferred.toFixed(),
-                total: blockData.reward.plus(blockData.totalFee).minus(blockData.burnedFee!).toFixed(),
+                total: blockData.reward
+                    .minus(
+                        Object.values(blockData.devFund!).reduce((prev, curr) => prev.plus(curr), Utils.BigNumber.ZERO),
+                    )
+                    .plus(blockData.totalFee)
+                    .minus(blockData.burnedFee!)
+                    .toFixed(),
             },
             payload: {
                 hash: blockData.payloadHash,

--- a/packages/core-api/src/services/delegate-search-service.ts
+++ b/packages/core-api/src/services/delegate-search-service.ts
@@ -86,9 +86,11 @@ export class DelegateSearchService {
                 fees: delegateAttribute.forgedFees,
                 burnedFees: delegateAttribute.burnedFees,
                 rewards: delegateAttribute.forgedRewards,
+                devFunds: delegateAttribute.devFunds,
                 total: delegateAttribute.forgedFees
                     .minus(delegateAttribute.burnedFees)
-                    .plus(delegateAttribute.forgedRewards),
+                    .plus(delegateAttribute.forgedRewards)
+                    .minus(delegateAttribute.devFunds),
             },
             version:
                 delegateAttribute.version && delegateAttribute.rank && delegateAttribute.rank <= activeDelegates

--- a/packages/core-api/src/www/api.json
+++ b/packages/core-api/src/www/api.json
@@ -746,6 +746,29 @@
                         }
                     },
                     {
+                        "name": "forged.devFunds",
+                        "in": "query",
+                        "description": "Exact amount, in satoshis, of all development funds raised by the delegate(s) to be returned",
+                        "schema": {
+                            "$ref": "#/components/schemas/zeroOrMore"
+                        }
+                    },
+                    {
+                        "name": "forged.devFunds.from",
+                        "in": "query",
+                        "description": "Minimum amount, in satoshis, of all development funds raised by the delegate(s) to be returned",
+                        "schema": {
+                            "$ref": "#/components/schemas/zeroOrMore"
+                        }
+                    },
+                    {
+                        "name": "forged.devFunds.to",
+                        "in": "query",
+                        "description": "Maximum amount, in satoshis, of all all development funds raised by the delegate(s) to be returned",
+                        "schema": {
+                            "$ref": "#/components/schemas/zeroOrMore"
+                        }
+                    },                    {
                         "name": "forged.total",
                         "in": "query",
                         "description": "Exact amount, in satoshis, of all unburned fees plus block rewards earned by the delegate(s) to be returned",
@@ -902,6 +925,8 @@
                                 "blocks.produced:desc",
                                 "forged.burnedFees:asc",
                                 "forged.burnedFees:desc",
+                                "forged.devFunds:asc",
+                                "forged.devFunds:desc",
                                 "forged.fees:asc",
                                 "forged.fees:desc",
                                 "forged.rewards:asc",

--- a/packages/core-database/src/migrations/20220507000000-add-dev_fund-column-to-blocks-table.ts
+++ b/packages/core-database/src/migrations/20220507000000-add-dev_fund-column-to-blocks-table.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddDevFundColumnToBlocksTable20220507000000 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<any> {
+        await queryRunner.query(`
+            ALTER TABLE blocks ADD COLUMN dev_fund JSONB;
+
+            CREATE INDEX blocks_dev_fund ON blocks(dev_fund);
+        `);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<any> {
+        await queryRunner.query(`
+            DROP INDEX blocks_dev_fund;
+
+            ALTER TABLE blocks DROP COLUMN dev_fund;
+        `);
+    }
+}

--- a/packages/core-database/src/migrations/20220507000000-add-dev_fund-column-to-blocks-table.ts
+++ b/packages/core-database/src/migrations/20220507000000-add-dev_fund-column-to-blocks-table.ts
@@ -3,7 +3,7 @@ import { MigrationInterface, QueryRunner } from "typeorm";
 export class AddDevFundColumnToBlocksTable20220507000000 implements MigrationInterface {
     public async up(queryRunner: QueryRunner): Promise<any> {
         await queryRunner.query(`
-            ALTER TABLE blocks ADD COLUMN dev_fund JSONB;
+            ALTER TABLE blocks ADD COLUMN dev_fund JSONB NOT NULL DEFAULT '{}'::jsonb;
 
             CREATE INDEX blocks_dev_fund ON blocks(dev_fund);
         `);

--- a/packages/core-database/src/models/block.ts
+++ b/packages/core-database/src/models/block.ts
@@ -78,6 +78,11 @@ export class Block implements Contracts.Database.BlockModel {
     public reward!: Utils.BigNumber;
 
     @Column({
+        type: "jsonb",
+    })
+    public devFund!: Record<string, Utils.BigNumber>;
+
+    @Column({
         type: "integer",
         nullable: false,
     })

--- a/packages/core-kernel/src/contracts/database/models.ts
+++ b/packages/core-kernel/src/contracts/database/models.ts
@@ -11,6 +11,7 @@ export interface BlockModel {
     totalFee: Utils.BigNumber;
     burnedFee: Utils.BigNumber;
     reward: Utils.BigNumber;
+    devFund: Record<string, Utils.BigNumber>;
     payloadLength: number;
     payloadHash: string;
     generatorPublicKey: string;

--- a/packages/core-kernel/src/contracts/state/wallets.ts
+++ b/packages/core-kernel/src/contracts/state/wallets.ts
@@ -144,6 +144,7 @@ export interface WalletDelegateAttributes {
     forgedFees: Utils.BigNumber;
     burnedFees: Utils.BigNumber;
     forgedRewards: Utils.BigNumber;
+    devFunds: Utils.BigNumber;
     producedBlocks: number;
     rank?: number;
     lastBlock?: Interfaces.IBlockData;

--- a/packages/core-snapshots/src/codecs/message-pack-codec.ts
+++ b/packages/core-snapshots/src/codecs/message-pack-codec.ts
@@ -19,11 +19,19 @@ export class MessagePackCodec implements Codec {
         return itemToReturn;
     }
 
-    public encodeBlock(block: { Block_burned_fee: Utils.BigNumber; Block_id: string }): Buffer {
+    public encodeBlock(block: {
+        Block_burned_fee: Utils.BigNumber;
+        Block_dev_fund: Utils.BigNumber;
+        Block_id: string;
+    }): Buffer {
         try {
             const blockCamelized = camelizeKeys(MessagePackCodec.removePrefix(block, "Block_"));
 
-            return encode([block.Block_burned_fee, Blocks.Serializer.serialize(blockCamelized, true)]);
+            return encode([
+                block.Block_burned_fee,
+                block.Block_dev_fund,
+                Blocks.Serializer.serialize(blockCamelized, true),
+            ]);
         } catch (err) {
             throw new CodecException.BlockEncodeException(block.Block_id, err.message);
         }
@@ -31,9 +39,10 @@ export class MessagePackCodec implements Codec {
 
     public decodeBlock(buffer: Buffer): Models.Block {
         try {
-            const [burnedFee, serialized] = decode(buffer);
+            const [burnedFee, devFund, serialized] = decode(buffer);
             const data = Blocks.Deserializer.deserialize(serialized, false).data as Models.Block;
             data.burnedFee = burnedFee;
+            data.devFund = devFund;
             return data;
         } catch (err) {
             throw new CodecException.BlockDecodeException(undefined, err.message);

--- a/packages/core-state/src/state-builder.ts
+++ b/packages/core-state/src/state-builder.ts
@@ -82,6 +82,18 @@ export class StateBuilder {
             const wallet = this.walletRepository.findByPublicKey(block.generatorPublicKey);
             wallet.increaseBalance(Utils.BigNumber.make(block.rewards));
         }
+
+        const devFunds = await this.blockRepository.getDevFunds();
+
+        for (const devFund of devFunds) {
+            const amount: Utils.BigNumber = Utils.BigNumber.make(devFund.amount);
+
+            const devFundWallet = this.walletRepository.findByAddress(devFund.address);
+            devFundWallet.increaseBalance(amount);
+
+            const delegateWallet = this.walletRepository.findByPublicKey(devFund.generatorPublicKey);
+            delegateWallet.decreaseBalance(amount);
+        }
     }
 
     private async buildSentTransactions(): Promise<void> {

--- a/packages/core-transactions/src/handlers/core/delegate-registration.ts
+++ b/packages/core-transactions/src/handlers/core/delegate-registration.ts
@@ -26,6 +26,7 @@ export class DelegateRegistrationTransactionHandler extends TransactionHandler {
             "delegate.forgedFees", // Used by the API
             "delegate.burnedFees", // Used by the API
             "delegate.forgedRewards", // Used by the API
+            "delegate.devFunds", // Used by the API
             "delegate.forgedTotal", // Used by the API
             "delegate.lastBlock",
             "delegate.producedBlocks", // Used by the API
@@ -61,6 +62,7 @@ export class DelegateRegistrationTransactionHandler extends TransactionHandler {
                 forgedFees: Utils.BigNumber.ZERO,
                 burnedFees: Utils.BigNumber.ZERO,
                 forgedRewards: Utils.BigNumber.ZERO,
+                devFunds: Utils.BigNumber.ZERO,
                 producedBlocks: 0,
                 rank: undefined,
                 voters: 0,
@@ -83,6 +85,7 @@ export class DelegateRegistrationTransactionHandler extends TransactionHandler {
             delegate.burnedFees = delegate.forgedFees.plus(block.burnedFees);
             delegate.forgedFees = delegate.forgedFees.plus(block.totalFees);
             delegate.forgedRewards = delegate.forgedRewards.plus(block.totalRewards);
+            delegate.devFunds = delegate.devFunds.plus(block.devFunds || Utils.BigNumber.ZERO);
             delegate.producedBlocks += +block.totalProduced;
         }
 
@@ -181,6 +184,7 @@ export class DelegateRegistrationTransactionHandler extends TransactionHandler {
             forgedFees: Utils.BigNumber.ZERO,
             burnedFees: Utils.BigNumber.ZERO,
             forgedRewards: Utils.BigNumber.ZERO,
+            devFunds: Utils.BigNumber.ZERO,
             producedBlocks: 0,
             round: 0,
             voters: 0,

--- a/packages/crypto/src/blocks/block.ts
+++ b/packages/crypto/src/blocks/block.ts
@@ -3,7 +3,7 @@ import { Hash, HashAlgorithms, Slots } from "../crypto";
 import { BlockSchemaError } from "../errors";
 import { IBlock, IBlockData, IBlockJson, IBlockVerification, ITransaction, ITransactionData } from "../interfaces";
 import { configManager } from "../managers/config";
-import { BigNumber, isException } from "../utils";
+import { BigNumber, calculateDevFund, isException } from "../utils";
 import { validator } from "../validation";
 import { Serializer } from "./serializer";
 
@@ -28,6 +28,8 @@ export class Block implements IBlock {
         delete this.data.transactions;
 
         this.data.burnedFee = this.getBurnedFees();
+
+        this.data.devFund = calculateDevFund(this.data.height, this.data.reward);
 
         this.verification = this.verify();
     }
@@ -92,7 +94,7 @@ export class Block implements IBlock {
     }
 
     public getBurnedFees(): BigNumber {
-        let fees = BigNumber.ZERO;
+        let fees: BigNumber = BigNumber.ZERO;
         for (const transaction of this.transactions) {
             transaction.setBurnedFee(this.data.height);
             fees = fees.plus(transaction.data.burnedFee!);
@@ -103,6 +105,7 @@ export class Block implements IBlock {
     public getHeader(): IBlockData {
         const header: IBlockData = Object.assign({}, this.data);
         delete header.burnedFee;
+        delete header.devFund;
         delete header.transactions;
         return header;
     }

--- a/packages/crypto/src/interfaces/block.ts
+++ b/packages/crypto/src/interfaces/block.ts
@@ -34,6 +34,7 @@ export interface IBlockData {
     totalFee: BigNumber;
     burnedFee?: BigNumber;
     reward: BigNumber;
+    devFund?: Record<string, BigNumber>;
     payloadLength: number;
     payloadHash: string;
     generatorPublicKey: string;
@@ -55,6 +56,7 @@ export interface IBlockJson {
     totalFee: string;
     burnedFee: string;
     reward: string;
+    devFund: string;
     payloadLength: number;
     payloadHash: string;
     generatorPublicKey: string;

--- a/packages/crypto/src/utils/index.ts
+++ b/packages/crypto/src/utils/index.ts
@@ -109,4 +109,19 @@ export const isSupportedTransactionVersion = (version: number): boolean => {
     return false;
 };
 
+export const calculateDevFund = (height: number, reward: BigNumber): Record<string, BigNumber> => {
+    const constants = configManager.getMilestone(height);
+    const devFund = {};
+
+    if (!constants.devFund) {
+        return {};
+    }
+
+    for (const [wallet, percentage] of Object.entries(constants.devFund)) {
+        devFund[wallet] = reward.times(Math.round((percentage as number) * 100)).dividedBy(10000);
+    }
+
+    return devFund;
+};
+
 export { Base58, BigNumber, ByteBuffer, isValidPeer, isLocalHost, calculateBlockTime, isNewBlockTime, calculateReward };


### PR DESCRIPTION
This PR adds a flexible framework and logic to automatically allocate a percentage of block rewards to fund aspects of future development. Due to the nature of this change, a governance vote seeking approval was held among all active delegates that were forging at the time, and was overwhelmingly approved by 89% of the delegates. [The full proposal and breakdown of votes can be seen in a frontend interface here.](https://cloudflare-ipfs.com/ipfs/QmVntbyU3YRs2gc2cdK3Qk83hAeHvXv6iySTKHkoyM2V7N)

For context, no public sharing or contributing delegates rejected the proposal as the only 2 delegates that did reject it are private non-sharing, non-contributing delegates that are represented by the same entity.

The approved proposal decided to allocate 5% of block rewards for this funding, and this will be set by a milestone in a separate commit. It is also important to note that this does not increase inflation or change the amount of SXP produced per block or round.