### PR TITLE
refactor(core-blockchain): broadcast only if enough time left in slot

### DIFF
--- a/packages/core-blockchain/src/blockchain.ts
+++ b/packages/core-blockchain/src/blockchain.ts
@@ -227,6 +227,7 @@ export class Blockchain implements Contracts.Blockchain.Blockchain {
         this.pushPingBlock(block, fromForger);
 
         if (this.stateStore.isStarted()) {
+            block.fromForger = fromForger;
             this.dispatch("NEWBLOCK");
             this.enqueueBlocks([block]);
 

--- a/packages/crypto/src/interfaces/block.ts
+++ b/packages/crypto/src/interfaces/block.ts
@@ -43,6 +43,7 @@ export interface IBlockData {
     serialized?: string;
     transactions?: ITransactionData[];
     ip?: string;
+    fromForger?: boolean;
 }
 
 export interface IBlockJson {


### PR DESCRIPTION
Earlier today there was a brief period of degraded service on mainnet due to a temporary fork resulting from a delegate broadcasting its block late since the processing phase took considerably longer than usual. Usually block processing takes a fraction of a second, but on this occasion it took a full 8 seconds, so the propagation entered the next delegate's forging slot. This meant some nodes received the late delegate's block and other nodes received the next delegate's block, both at the same height. The likely cause for this delay and fork was resource starvation on the late forging delegate's server.

While we are certain there was no malicious intent and this was an accident, it is nevertheless an issue that we should resolve to minimise the risk of a future reoccurrence. We endeavour to fix all issues as soon as possible, so this same-day PR addresses this by ensuring that there are at least 2 seconds remaining after processing the block before broadcasting it. Otherwise, the block will be discarded and not propagated.