### PR TITLE
refactor(core-transactions): more descriptive error when balance is insufficient

### DIFF
--- a/packages/core-transactions/src/errors.ts
+++ b/packages/core-transactions/src/errors.ts
@@ -76,8 +76,15 @@ export class ColdWalletError extends TransactionError {
 }
 
 export class InsufficientBalanceError extends TransactionError {
-    public constructor() {
-        super(`Insufficient balance in the wallet`);
+    public constructor(amount: Utils.BigNumber, sender: Contracts.State.Wallet) {
+        const balance: Utils.BigNumber = sender.getBalance();
+        super(
+            `Insufficient balance in the wallet: tried to send ${Utils.formatSatoshi(
+                amount,
+            )} but the wallet only has ${Utils.formatSatoshi(balance)} available (${Utils.formatSatoshi(
+                balance.minus(amount),
+            )})`,
+        );
     }
 }
 

--- a/packages/core-transactions/src/errors.ts
+++ b/packages/core-transactions/src/errors.ts
@@ -76,8 +76,7 @@ export class ColdWalletError extends TransactionError {
 }
 
 export class InsufficientBalanceError extends TransactionError {
-    public constructor(amount: Utils.BigNumber, sender: Contracts.State.Wallet) {
-        const balance: Utils.BigNumber = sender.getBalance();
+    public constructor(amount: Utils.BigNumber, balance: Utils.BigNumber) {
         super(
             `Insufficient balance in the wallet: tried to send ${Utils.formatSatoshi(
                 amount,

--- a/packages/core-transactions/src/handlers/core/multi-payment.ts
+++ b/packages/core-transactions/src/handlers/core/multi-payment.ts
@@ -54,7 +54,7 @@ export class MultiPaymentTransactionHandler extends TransactionHandler {
         const totalPaymentsAmount = payments.reduce((a, p) => a.plus(p.amount), Utils.BigNumber.ZERO);
 
         if (wallet.getBalance().minus(totalPaymentsAmount).minus(transaction.data.fee).isNegative()) {
-            throw new InsufficientBalanceError(totalPaymentsAmount.plus(transaction.data.fee), wallet);
+            throw new InsufficientBalanceError(totalPaymentsAmount.plus(transaction.data.fee), wallet.getBalance());
         }
 
         return super.throwIfCannotBeApplied(transaction, wallet);

--- a/packages/core-transactions/src/handlers/core/multi-payment.ts
+++ b/packages/core-transactions/src/handlers/core/multi-payment.ts
@@ -54,7 +54,7 @@ export class MultiPaymentTransactionHandler extends TransactionHandler {
         const totalPaymentsAmount = payments.reduce((a, p) => a.plus(p.amount), Utils.BigNumber.ZERO);
 
         if (wallet.getBalance().minus(totalPaymentsAmount).minus(transaction.data.fee).isNegative()) {
-            throw new InsufficientBalanceError();
+            throw new InsufficientBalanceError(totalPaymentsAmount.plus(transaction.data.fee), wallet);
         }
 
         return super.throwIfCannotBeApplied(transaction, wallet);

--- a/packages/core-transactions/src/handlers/transaction.ts
+++ b/packages/core-transactions/src/handlers/transaction.ts
@@ -221,7 +221,7 @@ export abstract class TransactionHandler {
         this.verifyTransactionNonceApply(sender, transaction);
 
         if (sender.getBalance().minus(data.amount).minus(data.fee).isNegative()) {
-            throw new InsufficientBalanceError(data.amount.plus(data.fee), sender);
+            throw new InsufficientBalanceError(data.amount.plus(data.fee), sender.getBalance());
         }
 
         if (data.senderPublicKey !== sender.getPublicKey()) {

--- a/packages/core-transactions/src/handlers/transaction.ts
+++ b/packages/core-transactions/src/handlers/transaction.ts
@@ -221,7 +221,7 @@ export abstract class TransactionHandler {
         this.verifyTransactionNonceApply(sender, transaction);
 
         if (sender.getBalance().minus(data.amount).minus(data.fee).isNegative()) {
-            throw new InsufficientBalanceError();
+            throw new InsufficientBalanceError(data.amount.plus(data.fee), sender);
         }
 
         if (data.senderPublicKey !== sender.getPublicKey()) {


### PR DESCRIPTION
This PR changes the `Insufficient balance in the wallet` error message to be more descriptive by showing the amount the wallet tried to send, the current balance of the wallet and the negative difference between the two values.

This can aid debugging of third party services and tools, for example when there are issues with voluntary reward sharing scripts run by delegates.