### PR TITLE
feat: load and save state to disk

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -289,11 +289,6 @@ async function addPlugins() {
     const listr = new Listr();
     const plugins = [
         {
-            package: "@alessiodf/rocket-boot",
-            command:
-                `"$SOLAR_DATA_PATH"/bin/node "$SOLAR_CORE_PATH"/packages/core/bin/run plugin:install @alessiodf/rocket-boot --network=${network} --token="$SOLAR_CORE_TOKEN" && "$SOLAR_DATA_PATH"/bin/node "$SOLAR_CORE_PATH"/packages/core/bin/run rocket:enable --force --network=${network} --token="$SOLAR_CORE_TOKEN"`,
-        },
-        {
             package: "@alessiodf/round-monitor",
             command:
                 `"$SOLAR_DATA_PATH"/bin/node "$SOLAR_CORE_PATH"/packages/core/bin/run plugin:install @alessiodf/round-monitor --network=${network} --token="$SOLAR_CORE_TOKEN" && "$SOLAR_DATA_PATH"/bin/node "$SOLAR_CORE_PATH"/packages/core/bin/run monitor:enable --disableServer --restartTimeBuffer=45 --force --network=${network} --token="$SOLAR_CORE_TOKEN"`,

--- a/packages/core-blockchain/src/state-machine/actions/index.ts
+++ b/packages/core-blockchain/src/state-machine/actions/index.ts
@@ -21,7 +21,7 @@ export const actions = {
     downloadFinished: DownloadFinished,
     downloadPaused: DownloadPaused,
     exitApp: ExitApp,
-    initialize: Initialize,
+    initialise: Initialize,
     rollbackDatabase: RollbackDatabase,
     startForkRecovery: StartForkRecovery,
     stopped: Stopped,

--- a/packages/core-blockchain/src/state-machine/machine.ts
+++ b/packages/core-blockchain/src/state-machine/machine.ts
@@ -1,17 +1,17 @@
-import { Machine } from "xstate";
+import { createMachine } from "xstate";
 
-export const blockchainMachine: any = Machine({
+export const blockchainMachine: any = createMachine({
     key: "blockchain",
     initial: "uninitialised",
     states: {
         uninitialised: {
             on: {
-                START: "initialize",
+                START: "initialise",
                 STOP: "stopped",
             },
         },
-        initialize: {
-            onEntry: ["initialize"],
+        initialise: {
+            onEntry: ["initialise"],
             on: {
                 NETWORKSTART: "idle",
                 STARTED: "syncWithNetwork",
@@ -102,7 +102,7 @@ export const blockchainMachine: any = Machine({
         rollback: {
             onEntry: ["rollbackDatabase"],
             on: {
-                SUCCESS: "initialize",
+                SUCCESS: "initialise",
                 FAILURE: "exit",
                 STOP: "stopped",
             },

--- a/packages/core-kernel/src/contracts/state/index.ts
+++ b/packages/core-kernel/src/contracts/state/index.ts
@@ -3,6 +3,8 @@ export * from "./block-store";
 export * from "./dpos";
 export * from "./round-state";
 export * from "./state-builder";
+export * from "./state-loader";
+export * from "./state-saver";
 export * from "./state-store";
 export * from "./transaction-store";
 export * from "./transaction-validator";

--- a/packages/core-kernel/src/contracts/state/state-loader.ts
+++ b/packages/core-kernel/src/contracts/state/state-loader.ts
@@ -1,0 +1,3 @@
+export interface StateLoader {
+    run(): Promise<boolean>;
+}

--- a/packages/core-kernel/src/contracts/state/state-saver.ts
+++ b/packages/core-kernel/src/contracts/state/state-saver.ts
@@ -1,0 +1,3 @@
+export interface StateSaver {
+    run(): Promise<void>;
+}

--- a/packages/core-kernel/src/contracts/state/wallets.ts
+++ b/packages/core-kernel/src/contracts/state/wallets.ts
@@ -129,6 +129,13 @@ export interface Wallet {
     getVoteBalance(): object;
 
     /**
+     * @param {string} delegate
+     * @param {Utils.BigNumber} balance
+     * @memberof Wallet
+     */
+    setVoteBalance(delegate: string, balance: Utils.BigNumber): void;
+
+    /**
      * @returns {Record<string, WalletVoteDistribution>}
      * @memberof Wallet
      */

--- a/packages/core-kernel/src/ioc/identifiers.ts
+++ b/packages/core-kernel/src/ioc/identifiers.ts
@@ -77,6 +77,8 @@ export const Identifiers = {
     StateBlockStore: Symbol.for("State<BlockStore>"),
     StateStore: Symbol.for("State<StateStore>"),
     StateBuilder: Symbol.for("State<StateBuilder>"),
+    StateLoader: Symbol.for("State<StateLoader>"),
+    StateSaver: Symbol.for("State<StateSaver>"),
     StateTransactionStore: Symbol.for("State<TransactionStore>"),
     StateWalletSyncService: Symbol.for("State<WalletSyncService>"),
     WalletFactory: Symbol.for("State<WalletFactory>"),

--- a/packages/core-state/package.json
+++ b/packages/core-state/package.json
@@ -26,6 +26,8 @@
         "@solar-network/crypto": "workspace:*",
         "immutable": "4.0.0-rc.14",
         "joi": "17.6.0",
+        "semver": "6.3.0",
         "xstate": "4.23.4"
-    }
+    },
+    "minimumSavedStateVersion": "3.3.0-next.0"
 }

--- a/packages/core-state/src/defaults.ts
+++ b/packages/core-state/src/defaults.ts
@@ -1,4 +1,7 @@
 export const defaults = {
+    maxSavedStates: 3,
+    maxSavedStateAge: 25000,
+    savedStatesPath: `${process.env.CORE_PATH_DATA}/saved-states`,
     storage: {
         maxLastBlocks: 100,
         maxLastTransactionIds: 10000,

--- a/packages/core-state/src/enums.ts
+++ b/packages/core-state/src/enums.ts
@@ -1,0 +1,15 @@
+export enum SavedStateValueType {
+    Undefined = 0,
+    String = 1,
+    HexString = 2,
+    Boolean = 3,
+    Integer = 4,
+    BigNumber = 5,
+    Array = 6,
+    Set = 7,
+    Object = 8,
+    Null = 9,
+    Signed = 10,
+    Decimal = 11,
+    SignedBigNumber = 12,
+}

--- a/packages/core-state/src/errors.ts
+++ b/packages/core-state/src/errors.ts
@@ -1,0 +1,33 @@
+import { Utils } from "@solar-network/core-kernel";
+
+export class BlockNotInDatabaseError extends Error {
+    public constructor(height: number) {
+        super(`The block from the saved state at height ${height.toLocaleString()} does not exist in the blockchain`);
+    }
+}
+
+export class CorruptSavedStateError extends Error {
+    public constructor(height: number) {
+        super(
+            `There was a data corruption error when restoring the saved state from height ${height.toLocaleString()}`,
+        );
+    }
+}
+
+export class IncompatibleSavedStateError extends Error {
+    public constructor(height: number) {
+        super(`The saved state from height ${height.toLocaleString()} is not compatible with this version of Core`);
+    }
+}
+
+export class StaleSavedStateError extends Error {
+    public constructor(height: number, snapshotHeight: number) {
+        const blocksAgo = snapshotHeight - height;
+        super(
+            `The saved state from height ${height.toLocaleString()} is too old (${blocksAgo.toLocaleString()} ${Utils.pluralize(
+                "block",
+                blocksAgo,
+            )} ago)`,
+        );
+    }
+}

--- a/packages/core-state/src/index.ts
+++ b/packages/core-state/src/index.ts
@@ -3,4 +3,5 @@ export * as Wallets from "./wallets";
 export { DatabaseInteraction } from "./database-interactions";
 export { DatabaseInterceptor } from "./database-interceptor";
 export { StateBuilder } from "./state-builder";
+export { StateLoader } from "./state-loader";
 export * as Stores from "./stores";

--- a/packages/core-state/src/index.ts
+++ b/packages/core-state/src/index.ts
@@ -3,5 +3,4 @@ export * as Wallets from "./wallets";
 export { DatabaseInteraction } from "./database-interactions";
 export { DatabaseInterceptor } from "./database-interceptor";
 export { StateBuilder } from "./state-builder";
-export { StateLoader } from "./state-loader";
 export * as Stores from "./stores";

--- a/packages/core-state/src/service-provider.ts
+++ b/packages/core-state/src/service-provider.ts
@@ -9,6 +9,8 @@ import { DatabaseInterceptor } from "./database-interceptor";
 import { DposPreviousRoundState, DposState } from "./dpos";
 import { RoundState } from "./round-state";
 import { StateBuilder } from "./state-builder";
+import { StateLoader } from "./state-loader";
+import { StateSaver } from "./state-saver";
 import { BlockStore } from "./stores/blocks";
 import { StateStore } from "./stores/state";
 import { TransactionStore } from "./stores/transactions";
@@ -99,6 +101,8 @@ export class ServiceProvider extends Providers.ServiceProvider {
         this.app.bind(Container.Identifiers.StateWalletSyncService).to(WalletSyncService).inSingletonScope();
 
         this.app.bind(Container.Identifiers.StateBuilder).to(StateBuilder);
+        this.app.bind(Container.Identifiers.StateLoader).to(StateLoader);
+        this.app.bind(Container.Identifiers.StateSaver).to(StateSaver);
 
         this.registerActions();
     }

--- a/packages/core-state/src/state-loader.ts
+++ b/packages/core-state/src/state-loader.ts
@@ -1,0 +1,319 @@
+import { DatabaseService, Repositories } from "@solar-network/core-database";
+import { Application, Container, Contracts, Enums, Providers, Utils as AppUtils } from "@solar-network/core-kernel";
+import { Interfaces, Utils } from "@solar-network/crypto";
+import { existsSync, lstatSync, mkdirSync, readdirSync, readFileSync, statSync, unlinkSync } from "fs";
+import { resolve } from "path";
+import semver from "semver";
+
+import { SavedStateValueType } from "./enums";
+import {
+    BlockNotInDatabaseError,
+    CorruptSavedStateError,
+    IncompatibleSavedStateError,
+    StaleSavedStateError,
+} from "./errors";
+
+@Container.injectable()
+export class StateLoader {
+    @Container.inject(Container.Identifiers.Application)
+    private readonly app!: Application;
+
+    @Container.inject(Container.Identifiers.BlockchainService)
+    private readonly blockchain!: Contracts.Blockchain.Blockchain;
+
+    @Container.inject(Container.Identifiers.DatabaseBlockRepository)
+    private readonly blockRepository!: Repositories.BlockRepository;
+
+    @Container.inject(Container.Identifiers.PluginConfiguration)
+    @Container.tagged("plugin", "@solar-network/core-state")
+    private readonly configuration!: Providers.PluginConfiguration;
+
+    @Container.inject(Container.Identifiers.DatabaseService)
+    private readonly databaseService!: DatabaseService;
+
+    @Container.inject(Container.Identifiers.EventDispatcherService)
+    private events!: Contracts.Kernel.EventDispatcher;
+
+    @Container.inject(Container.Identifiers.LogService)
+    private logger!: Contracts.Kernel.Logger;
+
+    @Container.inject(Container.Identifiers.StateMachine)
+    private readonly stateMachine;
+
+    @Container.inject(Container.Identifiers.WalletRepository)
+    @Container.tagged("state", "blockchain")
+    private readonly walletRepository!: Contracts.State.WalletRepository;
+
+    public async run(): Promise<boolean> {
+        let savedStatesPath: string = this.configuration.get("savedStatesPath") as string;
+
+        if (existsSync(savedStatesPath) && !lstatSync(savedStatesPath).isDirectory()) {
+            unlinkSync(savedStatesPath);
+        }
+
+        if (!savedStatesPath.endsWith("/")) {
+            savedStatesPath += "/";
+        }
+
+        if (!existsSync(savedStatesPath)) {
+            try {
+                mkdirSync(savedStatesPath, { recursive: true });
+            } catch (error) {
+                this.logger.error(`Could not create saved states path at ${savedStatesPath} :warning:`);
+            }
+        }
+
+        const purgeLock: string = `${process.env.CORE_PATH_TEMP}/purge-saved-states.lock`;
+
+        if (existsSync(purgeLock)) {
+            try {
+                unlinkSync(purgeLock);
+            } catch {
+                //
+            }
+
+            try {
+                for (const file of readdirSync(savedStatesPath)) {
+                    unlinkSync(`${savedStatesPath}/${file}`);
+                }
+            } catch {
+                //
+            }
+        }
+
+        readdirSync(savedStatesPath)
+            .filter((file) => file.endsWith(".tmp") || statSync(savedStatesPath + file).size < 8)
+            .map((file) => unlinkSync(savedStatesPath + file));
+
+        const stateFiles: Array<string> = readdirSync(savedStatesPath)
+            .map((file) => ({ name: file, time: statSync(savedStatesPath + file).mtime.getTime() }))
+            .sort((a, b) => b.time - a.time)
+            .map((file) => file.name);
+
+        let result: boolean;
+        if (stateFiles.length === 0) {
+            this.logger.info("No saved states exist so a fresh state will now be generated :bangbang:");
+            result = false;
+        } else {
+            result = await this.load(savedStatesPath, stateFiles);
+        }
+
+        const queue: Contracts.Kernel.Queue = this.blockchain.getQueue();
+        if (queue) {
+            const stateSaver: Contracts.State.StateSaver = this.app.get<Contracts.State.StateSaver>(
+                Container.Identifiers.StateSaver,
+            );
+            queue.removeAllListeners("drain");
+            queue.on("drain", async () => {
+                await stateSaver.run();
+                this.blockchain.dispatch("PROCESSFINISHED");
+            });
+        }
+
+        return result;
+    }
+
+    private decode(buffer: Utils.ByteBuffer): any {
+        const length: number = buffer.readUInt32LE();
+        const objectBuffer: Utils.ByteBuffer = new Utils.ByteBuffer(buffer.readBuffer(length));
+
+        const type: number = objectBuffer.readUInt8();
+
+        switch (type) {
+            case SavedStateValueType.String: {
+                return objectBuffer.readBuffer(length - 1).toString();
+            }
+            case SavedStateValueType.HexString: {
+                return objectBuffer.readBuffer(length - 1).toString("hex");
+            }
+            case SavedStateValueType.Boolean: {
+                return objectBuffer.readUInt8() === 1;
+            }
+            case SavedStateValueType.Decimal: {
+                return parseFloat(objectBuffer.readBuffer(length - 1).toString());
+            }
+            case SavedStateValueType.Integer: {
+                return objectBuffer.readUInt32LE();
+            }
+            case SavedStateValueType.Signed: {
+                return objectBuffer.readInt32LE();
+            }
+            case SavedStateValueType.BigNumber: {
+                return Utils.BigNumber.make(objectBuffer.readBigUInt64LE());
+            }
+            case SavedStateValueType.SignedBigNumber: {
+                return Utils.BigNumber.make(objectBuffer.readBigInt64LE());
+            }
+            case SavedStateValueType.Array:
+            case SavedStateValueType.Set: {
+                const array: any[] = [];
+                while (objectBuffer.getRemainderLength() > 0) {
+                    array.push(this.decode(objectBuffer));
+                }
+                return type == SavedStateValueType.Array ? array : new Set(array);
+            }
+            case SavedStateValueType.Object: {
+                const object: object = {};
+                while (objectBuffer.getRemainderLength() > 0) {
+                    object[this.decode(objectBuffer)] = this.decode(objectBuffer);
+                }
+                return object;
+                break;
+            }
+            case SavedStateValueType.Null: {
+                return null;
+                break;
+            }
+        }
+
+        return undefined;
+    }
+
+    private async load(savedStatesPath: string, stateFiles: Array<string>): Promise<boolean> {
+        this.walletRepository.reset();
+
+        if (stateFiles.length === 0) {
+            this.logger.info("There are no more saved states to try so a fresh state will now be generated :bangbang:");
+            return false;
+        }
+
+        const stateFile: string = stateFiles.shift() as string;
+
+        let success: boolean = false;
+
+        let blocksFromOurHeight: number = 0;
+        let height: number = 0;
+
+        let block: Interfaces.IBlock = this.stateMachine.stateStore.getLastBlock();
+
+        try {
+            const buffer: Utils.ByteBuffer = new Utils.ByteBuffer(readFileSync(savedStatesPath + stateFile));
+
+            const savedStateVersion: string = buffer.readBuffer(buffer.readUInt8()).toString();
+            height = buffer.readUInt32LE();
+            const { minimumSavedStateVersion } = require(resolve(__dirname, "../package.json"));
+            if (!semver.gte(savedStateVersion, minimumSavedStateVersion)) {
+                throw new IncompatibleSavedStateError(height);
+            }
+
+            if (block.data.id !== stateFile || block.data.height !== height) {
+                const blockFromDatabase: Interfaces.IBlockData = (await this.databaseService.findBlockByID([
+                    stateFile,
+                ]))![0];
+                if (!blockFromDatabase || blockFromDatabase.id !== stateFile || blockFromDatabase.height !== height) {
+                    throw new BlockNotInDatabaseError(height);
+                }
+                blocksFromOurHeight = block.data.height - height;
+                if (blocksFromOurHeight > (this.configuration.get("maxSavedStateAge") as number)) {
+                    throw new StaleSavedStateError(height, block.data.height);
+                }
+            }
+
+            this.logger.info("Restoring previously saved state :floppy_disk:");
+
+            const total: number = buffer.readUInt32LE();
+
+            try {
+                for (let count = 0; count < total; count++) {
+                    const bits: number = buffer.readUInt8();
+
+                    const address: string = buffer.readBuffer(34).toString();
+
+                    let attributes: object = {};
+                    let balance: bigint | number = 0;
+                    let nonce: bigint | number = 1;
+                    let publicKey: string | undefined;
+                    let voteBalance: object = {};
+
+                    if ((1 & bits) !== 0) {
+                        balance = buffer.readBigInt64LE();
+                    }
+
+                    if ((2 & bits) !== 0) {
+                        nonce = buffer.readBigUInt64LE();
+                    }
+
+                    if ((4 & bits) !== 0) {
+                        publicKey = buffer.readBuffer(33).toString("hex");
+                    }
+
+                    if ((8 & bits) !== 0) {
+                        const length: number = buffer.readUInt32LE();
+                        attributes = this.decode(new Utils.ByteBuffer(buffer.readBuffer(length)));
+                    }
+
+                    if ((16 & bits) !== 0) {
+                        const length: number = buffer.readUInt32LE();
+                        voteBalance = this.decode(new Utils.ByteBuffer(buffer.readBuffer(length)));
+                    }
+
+                    const wallet: Contracts.State.Wallet = this.walletRepository.createWallet(address);
+
+                    wallet.setBalance(Utils.BigNumber.make(balance));
+                    wallet.setNonce(Utils.BigNumber.make(nonce));
+
+                    if (publicKey) {
+                        wallet.setPublicKey(publicKey);
+                    }
+
+                    for (const attribute of Object.keys(attributes)) {
+                        wallet.setAttribute(attribute, attributes[attribute]);
+                    }
+
+                    for (const delegate of Object.keys(voteBalance)) {
+                        wallet.setVoteBalance(delegate, voteBalance[delegate]);
+                    }
+
+                    this.walletRepository.index(wallet);
+                }
+            } catch (error) {
+                throw new CorruptSavedStateError(height);
+            }
+
+            const delegates: number = Object.keys(this.walletRepository.allByUsername()).length;
+
+            if (delegates === 0) {
+                throw new CorruptSavedStateError(height);
+            }
+
+            if (blocksFromOurHeight > 0) {
+                this.logger.info(
+                    `Restored state is ${blocksFromOurHeight.toLocaleString()} ${AppUtils.pluralize(
+                        "block",
+                        blocksFromOurHeight,
+                    )} behind so the blockchain will roll back to height ${height.toLocaleString()} :repeat:`,
+                );
+                await this.blockRepository.deleteTopBlocks(blocksFromOurHeight);
+                block = await this.databaseService.getLastBlock();
+                this.stateMachine.stateStore.setLastBlock(block);
+                this.stateMachine.stateStore.setLastStoredBlockHeight(block.data.height);
+                this.logger.info(`Last block in database: ${block.data.height.toLocaleString()}`);
+            }
+
+            this.logger.info(`Number of registered delegates: ${delegates.toLocaleString()}`);
+
+            this.events.dispatch(Enums.StateEvent.BuilderFinished);
+
+            success = true;
+        } catch (error) {
+            unlinkSync(savedStatesPath + stateFile);
+            this.logger.warning(`${error.message} :warning:`);
+            if (stateFiles.length > 0) {
+                try {
+                    const buffer: Utils.ByteBuffer = new Utils.ByteBuffer(
+                        readFileSync(savedStatesPath + stateFiles[0]),
+                    );
+                    buffer.readBuffer(buffer.readUInt8());
+
+                    height = buffer.readUInt32LE();
+                    this.logger.info(`Trying an earlier saved state from height ${height.toLocaleString()}...`);
+                } catch {
+                    //
+                }
+            }
+            return this.load(savedStatesPath, stateFiles);
+        }
+
+        return success;
+    }
+}

--- a/packages/core-state/src/state-saver.ts
+++ b/packages/core-state/src/state-saver.ts
@@ -1,0 +1,256 @@
+import { Application, Container, Contracts, Providers } from "@solar-network/core-kernel";
+import { Interfaces, Utils } from "@solar-network/crypto";
+import { closeSync, existsSync, openSync, readdirSync, renameSync, statSync, unlinkSync, writeSync } from "fs";
+
+import { SavedStateValueType } from "./enums";
+
+@Container.injectable()
+export class StateSaver {
+    @Container.inject(Container.Identifiers.Application)
+    private readonly app!: Application;
+
+    @Container.inject(Container.Identifiers.PluginConfiguration)
+    @Container.tagged("plugin", "@solar-network/core-state")
+    private readonly configuration!: Providers.PluginConfiguration;
+
+    @Container.inject(Container.Identifiers.LogService)
+    private readonly logger!: Contracts.Kernel.Logger;
+
+    @Container.inject(Container.Identifiers.StateMachine)
+    private readonly stateMachine;
+
+    @Container.inject(Container.Identifiers.WalletRepository)
+    @Container.tagged("state", "blockchain")
+    private readonly walletRepository!: Contracts.State.WalletRepository;
+
+    private byteBufferArray = new Utils.ByteBufferArray();
+
+    public async run(): Promise<void> {
+        try {
+            const block: Interfaces.IBlock = this.stateMachine.stateStore.getLastBlock();
+
+            let savedStatesPath: string = this.configuration.get("savedStatesPath") as string;
+            if (!savedStatesPath.endsWith("/")) {
+                savedStatesPath += "/";
+            }
+
+            const stateFile: string = savedStatesPath + block.data.id!.toString();
+            const tempFile: string = stateFile + ".tmp";
+
+            if (existsSync(stateFile) || existsSync(tempFile)) {
+                return;
+            }
+            const fd: number = openSync(tempFile, "w");
+
+            const length: number = Object.keys(this.walletRepository.allByAddress()).length;
+
+            const buffer: Utils.ByteBuffer = new Utils.ByteBuffer(Buffer.alloc(5 * 1024 * 1024));
+            const secondaryBuffer: Utils.ByteBuffer = new Utils.ByteBuffer(Buffer.alloc(5 * 1024 * 1024));
+
+            const flush = () => {
+                writeSync(fd, buffer.getResult());
+                buffer.reset();
+            };
+
+            const version: string = this.app.version();
+
+            buffer.writeUInt8(version.length);
+            buffer.writeBuffer(Buffer.from(version));
+            buffer.writeUInt32LE(block.data.height);
+            buffer.writeUInt32LE(length);
+
+            for (const wallet of this.walletRepository.allByAddress()) {
+                let bits: number = 0;
+
+                if (!wallet.getBalance().isZero()) {
+                    bits += 1;
+                }
+
+                if (!wallet.getNonce().isEqualTo(1)) {
+                    bits += 2;
+                }
+
+                if (wallet.getPublicKey()) {
+                    bits += 4;
+                }
+
+                if (Object.keys(wallet.getAttributes()).length > 0) {
+                    bits += 8;
+                }
+
+                if (Object.keys(wallet.getVoteBalance()).length > 0) {
+                    bits += 16;
+                }
+
+                if (buffer.getRemainderLength() === 0) {
+                    flush();
+                }
+                buffer.writeUInt8(bits);
+
+                const addressBuffer: Buffer = Buffer.from(wallet.getAddress());
+                if (buffer.getRemainderLength() < addressBuffer.length) {
+                    flush();
+                }
+                buffer.writeBuffer(addressBuffer);
+
+                if (!wallet.getBalance().isZero()) {
+                    if (buffer.getRemainderLength() < 8) {
+                        flush();
+                    }
+                    buffer.writeBigInt64LE(wallet.getBalance().toBigInt());
+                }
+
+                if (!wallet.getNonce().isEqualTo(1)) {
+                    if (buffer.getRemainderLength() < 8) {
+                        flush();
+                    }
+                    buffer.writeBigUInt64LE(wallet.getNonce().toBigInt());
+                }
+
+                if (wallet.getPublicKey()) {
+                    const publicKey: Buffer = Buffer.from(wallet.getPublicKey()!, "hex");
+                    if (buffer.getRemainderLength() < publicKey.length) {
+                        flush();
+                    }
+                    buffer.writeBuffer(publicKey);
+                }
+
+                if (Object.keys(wallet.getAttributes()).length > 0) {
+                    secondaryBuffer.reset();
+                    this.byteBufferArray.reset();
+
+                    const encoded: Buffer = this.encode(wallet.getAttributes(), secondaryBuffer);
+                    if (buffer.getRemainderLength() < 8) {
+                        flush();
+                    }
+                    buffer.writeUInt32LE(encoded.length);
+
+                    if (buffer.getRemainderLength() < encoded.length) {
+                        flush();
+                    }
+                    buffer.writeBuffer(encoded);
+                }
+
+                if (Object.keys(wallet.getVoteBalance()).length > 0) {
+                    secondaryBuffer.reset();
+                    this.byteBufferArray.reset();
+
+                    const encoded: Buffer = this.encode(wallet.getVoteBalance(), secondaryBuffer);
+                    if (buffer.getRemainderLength() < 8) {
+                        flush();
+                    }
+                    buffer.writeUInt32LE(encoded.length);
+
+                    if (buffer.getRemainderLength() < encoded.length) {
+                        flush();
+                    }
+                    buffer.writeBuffer(encoded);
+                }
+            }
+
+            flush();
+            closeSync(fd);
+
+            renameSync(tempFile, stateFile);
+            readdirSync(savedStatesPath)
+                .filter((file) => file.endsWith(".tmp") || statSync(savedStatesPath + file).size === 0)
+                .map((file) => unlinkSync(savedStatesPath + file));
+
+            const maxSavedStates: number = this.configuration.get("maxSavedStates") as number;
+            if (maxSavedStates > 0) {
+                readdirSync(savedStatesPath)
+                    .map((file) => ({ name: file, time: statSync(savedStatesPath + file).mtime.getTime() }))
+                    .sort((a, b) => b.time - a.time)
+                    .slice(maxSavedStates)
+                    .map((file) => unlinkSync(savedStatesPath + file.name));
+            }
+        } catch (error) {
+            this.logger.error("An error occurred while trying to save the state :warning:");
+            this.logger.error(error.stack);
+        }
+    }
+
+    private encode(object: string | number | Record<string, any>, buffer: Utils.ByteBuffer) {
+        switch (typeof object) {
+            case "string": {
+                if (!(/^[0-9a-f]+$/.test(object) && object.length % 2 === 0)) {
+                    buffer.writeUInt32LE(object.length + 1);
+                    buffer.writeUInt8(SavedStateValueType.String);
+                    buffer.writeBuffer(Buffer.from(object));
+                } else {
+                    const hexBuffer = Buffer.from(object, "hex");
+                    buffer.writeUInt32LE(hexBuffer.length + 1);
+                    buffer.writeUInt8(SavedStateValueType.HexString);
+                    buffer.writeBuffer(hexBuffer);
+                }
+                break;
+            }
+            case "boolean": {
+                buffer.writeUInt32LE(2);
+                buffer.writeUInt8(SavedStateValueType.Boolean);
+                buffer.writeUInt8(object ? 1 : 0);
+                break;
+            }
+            case "number": {
+                if (object % 1 !== 0) {
+                    const stringifiedObject: string = object.toString();
+                    buffer.writeUInt32LE(stringifiedObject.length + 1);
+                    buffer.writeUInt8(SavedStateValueType.Decimal);
+                    buffer.writeBuffer(Buffer.from(stringifiedObject));
+                } else {
+                    buffer.writeUInt32LE(5);
+                    if (object >= 0) {
+                        buffer.writeUInt8(SavedStateValueType.Integer);
+                        buffer.writeUInt32LE(object);
+                    } else {
+                        buffer.writeUInt8(SavedStateValueType.Signed);
+                        buffer.writeInt32LE(object);
+                    }
+                }
+                break;
+            }
+            case "object": {
+                if (object instanceof Utils.BigNumber) {
+                    buffer.writeUInt32LE(9);
+                    if (!object.isNegative()) {
+                        buffer.writeUInt8(SavedStateValueType.BigNumber);
+                        buffer.writeBigUInt64LE(object.toBigInt());
+                    } else {
+                        buffer.writeUInt8(SavedStateValueType.SignedBigNumber);
+                        buffer.writeBigInt64LE(object.toBigInt());
+                    }
+                } else if (object instanceof Array || object instanceof Set) {
+                    const arrayBuffer: Utils.ByteBuffer = this.byteBufferArray.getByteBuffer();
+                    for (const value of object) {
+                        this.encode(value, arrayBuffer);
+                    }
+                    const bufferResult: Buffer = arrayBuffer.getResult();
+                    buffer.writeUInt32LE(bufferResult.length + 1);
+                    buffer.writeUInt8(object instanceof Array ? SavedStateValueType.Array : SavedStateValueType.Set);
+                    buffer.writeBuffer(bufferResult);
+                } else if (object instanceof Object) {
+                    const objectBuffer: Utils.ByteBuffer = this.byteBufferArray.getByteBuffer();
+                    for (const property in object) {
+                        if (object.hasOwnProperty(property)) {
+                            this.encode(property, objectBuffer);
+                            this.encode(object[property], objectBuffer);
+                        }
+                    }
+                    const bufferResult: Buffer = objectBuffer.getResult();
+                    buffer.writeUInt32LE(bufferResult.length + 1);
+                    buffer.writeUInt8(SavedStateValueType.Object);
+                    buffer.writeBuffer(bufferResult);
+                } else {
+                    buffer.writeUInt32LE(1);
+                    buffer.writeUInt8(SavedStateValueType.Null);
+                }
+                break;
+            }
+            case "undefined": {
+                buffer.writeUInt32LE(1);
+                buffer.writeUInt8(SavedStateValueType.Undefined);
+            }
+        }
+        return buffer.getResult();
+    }
+}

--- a/packages/core-state/src/wallets/wallet.ts
+++ b/packages/core-state/src/wallets/wallet.ts
@@ -208,6 +208,10 @@ export class Wallet implements Contracts.State.Wallet {
         return this.voteBalance;
     }
 
+    public setVoteBalance(delegate: string, balance: Utils.BigNumber) {
+        this.voteBalance[delegate] = balance;
+    }
+
     /**
      * @returns {Record<string, Contracts.State.WalletVoteDistribution>}
      * @memberof Wallet
@@ -245,8 +249,9 @@ export class Wallet implements Contracts.State.Wallet {
         });
 
         for (const delegate of Object.keys(votes)) {
-            this.voteBalance[delegate] = Utils.BigNumber.make(voteAmounts[delegate].balance).plus(
-                voteAmounts[delegate].lockedBalance,
+            this.setVoteBalance(
+                delegate,
+                Utils.BigNumber.make(voteAmounts[delegate].balance).plus(voteAmounts[delegate].lockedBalance),
             );
         }
     }

--- a/packages/core/src/commands/state-purge.ts
+++ b/packages/core/src/commands/state-purge.ts
@@ -1,0 +1,64 @@
+import { Commands, Container } from "@solar-network/core-cli";
+import { Networks } from "@solar-network/crypto";
+import { closeSync, openSync } from "fs";
+import Joi from "joi";
+
+@Container.injectable()
+export class Command extends Commands.Command {
+    /**
+     * The console command signature.
+     *
+     * @type {string}
+     * @memberof Command
+     */
+    public signature: string = "state:purge";
+
+    /**
+     * The console command description.
+     *
+     * @type {string}
+     * @memberof Command
+     */
+    public description: string = "Purge all saved states";
+
+    /**
+     * Configure the console command.
+     *
+     * @returns {void}
+     * @memberof Command
+     */
+    public configure(): void {
+        this.definition
+            .setFlag("force", "Force a purge", Joi.boolean())
+            .setFlag("token", "The name of the token", Joi.string().default("solar"))
+            .setFlag("network", "The name of the network", Joi.string().valid(...Object.keys(Networks)));
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @returns {Promise<void>}
+     * @memberof Command
+     */
+    public async execute(): Promise<void> {
+        if (!this.getFlag("force")) {
+            const confirmation: any = (
+                await this.components.prompt({
+                    type: "confirm",
+                    name: "value",
+                    message: "Purge all saved states so a fresh state will be generated on startup?",
+                })
+            ).value;
+
+            if (!confirmation) {
+                throw new Error("You'll need to confirm the input to continue");
+            }
+        }
+
+        try {
+            closeSync(openSync(this.app.getCorePath("temp", "purge-saved-states.lock"), "w"));
+        } catch {
+            //
+        }
+    }
+}

--- a/packages/crypto/src/utils/byte-buffer-array.ts
+++ b/packages/crypto/src/utils/byte-buffer-array.ts
@@ -1,0 +1,27 @@
+import { ByteBuffer } from "./byte-buffer";
+
+export class ByteBufferArray {
+    private readonly buffers: ByteBuffer[] = [];
+    private position = 0;
+
+    public getByteBuffer(): ByteBuffer {
+        let buffer: ByteBuffer;
+        if (this.buffers.length > this.position) {
+            buffer = this.buffers[this.position];
+        } else {
+            buffer = new ByteBuffer(Buffer.alloc(1 * 1024 * 1024));
+            this.buffers.push(buffer);
+        }
+
+        this.position++;
+        buffer.reset();
+        return buffer;
+    }
+
+    public reset(): void {
+        if (this.buffers.length > 10) {
+            this.buffers.splice(10);
+        }
+        this.position = 0;
+    }
+}

--- a/packages/crypto/src/utils/index.ts
+++ b/packages/crypto/src/utils/index.ts
@@ -5,6 +5,7 @@ import { Base58 } from "./base58";
 import { BigNumber } from "./bignum";
 import { calculateBlockTime, isNewBlockTime } from "./block-time-calculator";
 import { ByteBuffer } from "./byte-buffer";
+import { ByteBufferArray } from "./byte-buffer-array";
 import { isLocalHost, isValidPeer } from "./is-valid-peer";
 import { calculateReward } from "./reward-calculator";
 import { sortVotes } from "./sort-votes";
@@ -129,6 +130,7 @@ export {
     Base58,
     BigNumber,
     ByteBuffer,
+    ByteBufferArray,
     isValidPeer,
     isLocalHost,
     calculateBlockTime,


### PR DESCRIPTION
This PR directly implements loading and saving of the wallet state to disk so that it is not necessary to generate state on every boot, significantly reducing Core's startup time. Essentially, this directly implements a modified and bug fixed version of [Rocket Boot](https://marketsquare.io/projects/rocket-boot) in Core.

This was necessary because our Core code continues to diverge from upstream so our changes would result in the need to continually update the plugin while juggling to make sure it remained compatible with upstream's Core too. Therefore the decision was made to bring a modified version of the plugin directly inside Solar Core, while leaving the plain vanilla version as a plugin for use with upstream Core and its less modified derivatives.

The modifications in this integrated version also bring us several quality of life improvements. For example, now we have a `minimumSavedStateVersion` property, so if there are any breaking changes to the state structure in a future update, we can specify this so the saved state automatically gets discarded on the first post-update boot of Core, rather than requiring the user to manually purge the saved state files after updating as is the case with the plugin version (although users can still purge the saved state files manually if needed with the `solar state:purge` command). Also having the code directly inside Core means there is no need to separately update the plugin in addition to updating Core, as has been the case in the past.