### PR TITLE
release: mainnet 3.3.1

### DIFF
--- a/packages/core-api/package.json
+++ b/packages/core-api/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-api",
-    "version": "3.3.0",
+    "version": "3.3.1",
     "description": "Public API for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-api/src/www/api.json
+++ b/packages/core-api/src/www/api.json
@@ -2587,11 +2587,11 @@
             },
             "username": {
                 "type": "string",
-                "pattern": "^[a-z0-9!@$&_.]{1,20}$"
+                "pattern": "^(?=.*[a-z!@$&_.])([a-z0-9!@$&_.]?){1,20}$"
             },
             "walletIdentifier": {
                 "type": "string",
-                "pattern": "^S([A-HJ-NP-Za-km-z1-9]{33})$|^[0-9a-fA-F]{66}$|^[a-z0-9!@$&_.]{1,20}$"
+                "pattern": "^S([A-HJ-NP-Za-km-z1-9]{33})$|^[0-9a-fA-F]{66}$|^(?=.*[a-z!@$&_.])([a-z0-9!@$&_.]?){1,20}$"
             },
             "zeroOrMore": {
                 "type": "integer",

--- a/packages/core-blockchain/package.json
+++ b/packages/core-blockchain/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-blockchain",
-    "version": "3.3.0",
+    "version": "3.3.1",
     "description": "Blockchain Manager for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-cli/package.json
+++ b/packages/core-cli/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-cli",
-    "version": "3.3.0",
+    "version": "3.3.1",
     "description": "Command Line Interface to manage the Core of the Solar Network Blockchain",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-database/package.json
+++ b/packages/core-database/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-database",
-    "version": "3.3.0",
+    "version": "3.3.1",
     "description": "Database Interface for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-forger/package.json
+++ b/packages/core-forger/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-forger",
-    "version": "3.3.0",
+    "version": "3.3.1",
     "description": "Forger for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-kernel/package.json
+++ b/packages/core-kernel/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-kernel",
-    "version": "3.3.0",
+    "version": "3.3.1",
     "description": "Kernel of Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-logger-pino/package.json
+++ b/packages/core-logger-pino/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-logger-pino",
-    "version": "3.3.0",
+    "version": "3.3.1",
     "description": "Webhooks for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-p2p/package.json
+++ b/packages/core-p2p/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-p2p",
-    "version": "3.3.0",
+    "version": "3.3.1",
     "description": "P2P API for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-snapshots/package.json
+++ b/packages/core-snapshots/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-snapshots",
-    "version": "3.3.0",
+    "version": "3.3.1",
     "description": "Provides live local streamed snapshots functionality for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-state/package.json
+++ b/packages/core-state/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-state",
-    "version": "3.3.0",
+    "version": "3.3.1",
     "description": "State Management for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-transaction-pool/package.json
+++ b/packages/core-transaction-pool/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-transaction-pool",
-    "version": "3.3.0",
+    "version": "3.3.1",
     "description": "Transaction Pool Manager for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-transactions/package.json
+++ b/packages/core-transactions/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-transactions",
-    "version": "3.3.0",
+    "version": "3.3.1",
     "description": "Transaction Services for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core-webhooks/package.json
+++ b/packages/core-webhooks/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core-webhooks",
-    "version": "3.3.0",
+    "version": "3.3.1",
     "description": "Webhooks for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core",
-    "version": "3.3.0",
+    "version": "3.3.1",
     "description": "Core of the Solar Network Blockchain",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/crypto",
-    "version": "3.3.0",
+    "version": "3.3.1",
     "description": "Crypto utilities for the Solar Network Blockchain",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/crypto/src/validation/schemas.ts
+++ b/packages/crypto/src/validation/schemas.ts
@@ -48,7 +48,7 @@ export const schemas = {
     walletVoteUsername: {
         $id: "walletVoteUsername",
         allOf: [
-            { type: "string", pattern: "^[+|-][a-z0-9!@$&_.]+$" },
+            { type: "string", pattern: "^[+|-](?=.*[a-z!@$&_.])([a-z0-9!@$&_.]?)+$" },
             { minLength: 2, maxLength: 21 },
         ],
     },
@@ -61,7 +61,7 @@ export const schemas = {
     username: {
         $id: "delegateUsername",
         allOf: [
-            { type: "string", pattern: "^[a-z0-9!@$&_.]+$" },
+            { type: "string", pattern: "^(?=.*[a-z!@$&_.])([a-z0-9!@$&_.]?)+$" },
             { minLength: 1, maxLength: 20 },
         ],
     },

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/utils",
-    "version": "3.3.0",
+    "version": "3.3.1",
     "description": "Performance oriented implementations of commonly used functions",
     "license": "CC-BY-ND-4.0",
     "contributors": [


### PR DESCRIPTION
This PR releases Solar Core 3.3.1 for mainnet.

Changes since 3.3.0:

\- tighter crypto schema validation