### PR TITLE
feat: poll for unconfirmed transactions

### DIFF
--- a/packages/core-forger/src/client.ts
+++ b/packages/core-forger/src/client.ts
@@ -154,7 +154,9 @@ export class Client {
      * @memberof Client
      */
     public async getTransactions(): Promise<Contracts.P2P.ForgingTransactions> {
-        return this.emit<Contracts.P2P.ForgingTransactions>("p2p.internal.getUnconfirmedTransactions");
+        return this.emit<Contracts.P2P.ForgingTransactions>("p2p.transactions.getUnconfirmedTransactions", {
+            headers: { port: 0, version: this.app.version() },
+        });
     }
 
     /**
@@ -245,13 +247,13 @@ export class Client {
     private getCodec(event: string) {
         const codecs = {
             "p2p.internal.emitEvent": Codecs.emitEvent,
-            "p2p.internal.getUnconfirmedTransactions": Codecs.getUnconfirmedTransactions,
             "p2p.internal.getCurrentRound": Codecs.getCurrentRound,
             "p2p.internal.getNetworkState": Codecs.getNetworkState,
             "p2p.internal.getSlotNumber": Codecs.getSlotNumber,
             "p2p.internal.syncBlockchain": Codecs.syncBlockchain,
             "p2p.blocks.postBlock": Codecs.postBlock,
             "p2p.peer.getStatus": Codecs.getStatus,
+            "p2p.transactions.getUnconfirmedTransactions": Codecs.getUnconfirmedTransactions,
         };
 
         return codecs[event];

--- a/packages/core-kernel/src/contracts/p2p/network-monitor.ts
+++ b/packages/core-kernel/src/contracts/p2p/network-monitor.ts
@@ -40,6 +40,7 @@ export interface NetworkMonitor {
         timeout?: number,
         checkThrottle?: boolean,
     ): Promise<Interfaces.IBlockData[]>;
+    downloadTransactions(): Promise<Buffer[]>;
     broadcastBlock(block: Interfaces.IBlock): Promise<void>;
     isColdStart(): boolean;
     completeColdStart(): void;

--- a/packages/core-kernel/src/contracts/p2p/peer-communicator.ts
+++ b/packages/core-kernel/src/contracts/p2p/peer-communicator.ts
@@ -31,5 +31,9 @@ export interface PeerCommunicator {
         }: { fromBlockHeight: number; blockLimit?: number; headersOnly?: boolean },
     ): Promise<Interfaces.IBlockData[]>;
 
+    getUnconfirmedTransactions(peer: Peer): Promise<Buffer[]>;
+
     wouldThrottleOnDownload(peer: Peer): Promise<boolean>;
+
+    wouldThrottleOnFetchingTransactions(peer: Peer): Promise<boolean>;
 }

--- a/packages/core-kernel/src/contracts/p2p/server.ts
+++ b/packages/core-kernel/src/contracts/p2p/server.ts
@@ -38,6 +38,6 @@ export interface Status {
 }
 
 export interface UnconfirmedTransactions {
-    transactions: string[];
+    transactions: Buffer[];
     poolSize: number;
 }

--- a/packages/core-p2p/src/peer-communicator.ts
+++ b/packages/core-p2p/src/peer-communicator.ts
@@ -323,8 +323,31 @@ export class PeerCommunicator implements Contracts.P2P.PeerCommunicator {
         return peerBlocks;
     }
 
+    public async getUnconfirmedTransactions(peer: Contracts.P2P.Peer): Promise<Buffer[]> {
+        const getUnconfirmedTransactionsTimeout = 10000;
+        const { maxPayload, maxTransactions } = Managers.configManager.getMilestone().block;
+        const { transactions } = await this.emit(
+            peer,
+            "p2p.transactions.getUnconfirmedTransactions",
+            {},
+            getUnconfirmedTransactionsTimeout,
+            maxPayload,
+            false,
+        );
+
+        if (!transactions || !transactions.length || transactions.length > maxTransactions) {
+            return [];
+        }
+
+        return transactions;
+    }
+
     public async wouldThrottleOnDownload(peer: Contracts.P2P.Peer): Promise<boolean> {
         return await this.wouldThrottle(peer, "p2p.blocks.getBlocks");
+    }
+
+    public async wouldThrottleOnFetchingTransactions(peer: Contracts.P2P.Peer): Promise<boolean> {
+        return await this.wouldThrottle(peer, "p2p.transactions.getUnconfirmedTransactions");
     }
 
     private validatePeerConfig(peer: Contracts.P2P.Peer, config: Contracts.P2P.PeerConfig): boolean {

--- a/packages/core-p2p/src/schemas.ts
+++ b/packages/core-p2p/src/schemas.ts
@@ -6,6 +6,10 @@ const maxDelegates = Managers.configManager
     .getMilestones()
     .reduce((acc, curr) => Math.max(acc, curr.activeDelegates), 0);
 
+const maxTransactions = Managers.configManager
+    .getMilestones()
+    .reduce((acc, curr) => Math.max(acc, curr.block.maxTransactions), 0);
+
 export const replySchemas = {
     "p2p.peer.getCommonBlocks": {
         type: "object",
@@ -226,6 +230,14 @@ export const replySchemas = {
         properties: {
             status: { type: "boolean" },
             height: { type: "integer", minimum: 1 },
+        },
+    },
+    "p2p.transactions.getUnconfirmedTransactions": {
+        type: "object",
+        additionalProperties: false,
+        properties: {
+            poolSize: { type: "integer", minimum: 0 },
+            transactions: { type: "array", maxItems: maxTransactions },
         },
     },
     "p2p.transactions.postTransactions": {

--- a/packages/core-p2p/src/socket-server/codecs/internal.ts
+++ b/packages/core-p2p/src/socket-server/codecs/internal.ts
@@ -9,17 +9,6 @@ export const emitEvent = {
     },
 };
 
-export const getUnconfirmedTransactions = {
-    request: {
-        serialise: (obj: object): Buffer => Buffer.from(JSON.stringify(obj)),
-        deserialise: (payload: Buffer): object => JSON.parse(payload.toString()),
-    },
-    response: {
-        serialise: (obj: object): Buffer => Buffer.from(JSON.stringify(obj)),
-        deserialise: (payload: Buffer): object => JSON.parse(payload.toString()),
-    },
-};
-
 export const getCurrentRound = {
     request: {
         serialise: (obj: object): Buffer => Buffer.from(JSON.stringify(obj)),

--- a/packages/core-p2p/src/socket-server/codecs/proto/protos.d.ts
+++ b/packages/core-p2p/src/socket-server/codecs/proto/protos.d.ts
@@ -2135,6 +2135,204 @@ export namespace shared {
 /** Namespace transactions. */
 export namespace transactions {
 
+    /** Properties of a GetUnconfirmedTransactionsRequest. */
+    interface IGetUnconfirmedTransactionsRequest {
+
+        /** GetUnconfirmedTransactionsRequest countOnly */
+        countOnly?: (boolean|null);
+
+        /** GetUnconfirmedTransactionsRequest headers */
+        headers?: (shared.IHeaders|null);
+    }
+
+    /** Represents a GetUnconfirmedTransactionsRequest. */
+    class GetUnconfirmedTransactionsRequest implements IGetUnconfirmedTransactionsRequest {
+
+        /**
+         * Constructs a new GetUnconfirmedTransactionsRequest.
+         * @param [properties] Properties to set
+         */
+        constructor(properties?: transactions.IGetUnconfirmedTransactionsRequest);
+
+        /** GetUnconfirmedTransactionsRequest countOnly. */
+        public countOnly: boolean;
+
+        /** GetUnconfirmedTransactionsRequest headers. */
+        public headers?: (shared.IHeaders|null);
+
+        /**
+         * Creates a new GetUnconfirmedTransactionsRequest instance using the specified properties.
+         * @param [properties] Properties to set
+         * @returns GetUnconfirmedTransactionsRequest instance
+         */
+        public static create(properties?: transactions.IGetUnconfirmedTransactionsRequest): transactions.GetUnconfirmedTransactionsRequest;
+
+        /**
+         * Encodes the specified GetUnconfirmedTransactionsRequest message. Does not implicitly {@link transactions.GetUnconfirmedTransactionsRequest.verify|verify} messages.
+         * @param message GetUnconfirmedTransactionsRequest message or plain object to encode
+         * @param [writer] Writer to encode to
+         * @returns Writer
+         */
+        public static encode(message: transactions.IGetUnconfirmedTransactionsRequest, writer?: $protobuf.Writer): $protobuf.Writer;
+
+        /**
+         * Encodes the specified GetUnconfirmedTransactionsRequest message, length delimited. Does not implicitly {@link transactions.GetUnconfirmedTransactionsRequest.verify|verify} messages.
+         * @param message GetUnconfirmedTransactionsRequest message or plain object to encode
+         * @param [writer] Writer to encode to
+         * @returns Writer
+         */
+        public static encodeDelimited(message: transactions.IGetUnconfirmedTransactionsRequest, writer?: $protobuf.Writer): $protobuf.Writer;
+
+        /**
+         * Decodes a GetUnconfirmedTransactionsRequest message from the specified reader or buffer.
+         * @param reader Reader or buffer to decode from
+         * @param [length] Message length if known beforehand
+         * @returns GetUnconfirmedTransactionsRequest
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): transactions.GetUnconfirmedTransactionsRequest;
+
+        /**
+         * Decodes a GetUnconfirmedTransactionsRequest message from the specified reader or buffer, length delimited.
+         * @param reader Reader or buffer to decode from
+         * @returns GetUnconfirmedTransactionsRequest
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): transactions.GetUnconfirmedTransactionsRequest;
+
+        /**
+         * Verifies a GetUnconfirmedTransactionsRequest message.
+         * @param message Plain object to verify
+         * @returns `null` if valid, otherwise the reason why it is not
+         */
+        public static verify(message: { [k: string]: any }): (string|null);
+
+        /**
+         * Creates a GetUnconfirmedTransactionsRequest message from a plain object. Also converts values to their respective internal types.
+         * @param object Plain object
+         * @returns GetUnconfirmedTransactionsRequest
+         */
+        public static fromObject(object: { [k: string]: any }): transactions.GetUnconfirmedTransactionsRequest;
+
+        /**
+         * Creates a plain object from a GetUnconfirmedTransactionsRequest message. Also converts values to other types if specified.
+         * @param message GetUnconfirmedTransactionsRequest
+         * @param [options] Conversion options
+         * @returns Plain object
+         */
+        public static toObject(message: transactions.GetUnconfirmedTransactionsRequest, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+        /**
+         * Converts this GetUnconfirmedTransactionsRequest to JSON.
+         * @returns JSON object
+         */
+        public toJSON(): { [k: string]: any };
+    }
+
+    /** Properties of a GetUnconfirmedTransactionsResponse. */
+    interface IGetUnconfirmedTransactionsResponse {
+
+        /** GetUnconfirmedTransactionsResponse poolSize */
+        poolSize?: (number|null);
+
+        /** GetUnconfirmedTransactionsResponse transactions */
+        transactions?: (Uint8Array|null);
+
+        /** GetUnconfirmedTransactionsResponse headers */
+        headers?: (shared.IHeaders|null);
+    }
+
+    /** Represents a GetUnconfirmedTransactionsResponse. */
+    class GetUnconfirmedTransactionsResponse implements IGetUnconfirmedTransactionsResponse {
+
+        /**
+         * Constructs a new GetUnconfirmedTransactionsResponse.
+         * @param [properties] Properties to set
+         */
+        constructor(properties?: transactions.IGetUnconfirmedTransactionsResponse);
+
+        /** GetUnconfirmedTransactionsResponse poolSize. */
+        public poolSize: number;
+
+        /** GetUnconfirmedTransactionsResponse transactions. */
+        public transactions: Uint8Array;
+
+        /** GetUnconfirmedTransactionsResponse headers. */
+        public headers?: (shared.IHeaders|null);
+
+        /**
+         * Creates a new GetUnconfirmedTransactionsResponse instance using the specified properties.
+         * @param [properties] Properties to set
+         * @returns GetUnconfirmedTransactionsResponse instance
+         */
+        public static create(properties?: transactions.IGetUnconfirmedTransactionsResponse): transactions.GetUnconfirmedTransactionsResponse;
+
+        /**
+         * Encodes the specified GetUnconfirmedTransactionsResponse message. Does not implicitly {@link transactions.GetUnconfirmedTransactionsResponse.verify|verify} messages.
+         * @param message GetUnconfirmedTransactionsResponse message or plain object to encode
+         * @param [writer] Writer to encode to
+         * @returns Writer
+         */
+        public static encode(message: transactions.IGetUnconfirmedTransactionsResponse, writer?: $protobuf.Writer): $protobuf.Writer;
+
+        /**
+         * Encodes the specified GetUnconfirmedTransactionsResponse message, length delimited. Does not implicitly {@link transactions.GetUnconfirmedTransactionsResponse.verify|verify} messages.
+         * @param message GetUnconfirmedTransactionsResponse message or plain object to encode
+         * @param [writer] Writer to encode to
+         * @returns Writer
+         */
+        public static encodeDelimited(message: transactions.IGetUnconfirmedTransactionsResponse, writer?: $protobuf.Writer): $protobuf.Writer;
+
+        /**
+         * Decodes a GetUnconfirmedTransactionsResponse message from the specified reader or buffer.
+         * @param reader Reader or buffer to decode from
+         * @param [length] Message length if known beforehand
+         * @returns GetUnconfirmedTransactionsResponse
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): transactions.GetUnconfirmedTransactionsResponse;
+
+        /**
+         * Decodes a GetUnconfirmedTransactionsResponse message from the specified reader or buffer, length delimited.
+         * @param reader Reader or buffer to decode from
+         * @returns GetUnconfirmedTransactionsResponse
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): transactions.GetUnconfirmedTransactionsResponse;
+
+        /**
+         * Verifies a GetUnconfirmedTransactionsResponse message.
+         * @param message Plain object to verify
+         * @returns `null` if valid, otherwise the reason why it is not
+         */
+        public static verify(message: { [k: string]: any }): (string|null);
+
+        /**
+         * Creates a GetUnconfirmedTransactionsResponse message from a plain object. Also converts values to their respective internal types.
+         * @param object Plain object
+         * @returns GetUnconfirmedTransactionsResponse
+         */
+        public static fromObject(object: { [k: string]: any }): transactions.GetUnconfirmedTransactionsResponse;
+
+        /**
+         * Creates a plain object from a GetUnconfirmedTransactionsResponse message. Also converts values to other types if specified.
+         * @param message GetUnconfirmedTransactionsResponse
+         * @param [options] Conversion options
+         * @returns Plain object
+         */
+        public static toObject(message: transactions.GetUnconfirmedTransactionsResponse, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+        /**
+         * Converts this GetUnconfirmedTransactionsResponse to JSON.
+         * @returns JSON object
+         */
+        public toJSON(): { [k: string]: any };
+    }
+
     /** Properties of a PostTransactionsRequest. */
     interface IPostTransactionsRequest {
 

--- a/packages/core-p2p/src/socket-server/codecs/proto/protos.js
+++ b/packages/core-p2p/src/socket-server/codecs/proto/protos.js
@@ -5105,6 +5105,467 @@ $root.transactions = (function() {
      */
     var transactions = {};
 
+    transactions.GetUnconfirmedTransactionsRequest = (function() {
+
+        /**
+         * Properties of a GetUnconfirmedTransactionsRequest.
+         * @memberof transactions
+         * @interface IGetUnconfirmedTransactionsRequest
+         * @property {boolean|null} [countOnly] GetUnconfirmedTransactionsRequest countOnly
+         * @property {shared.IHeaders|null} [headers] GetUnconfirmedTransactionsRequest headers
+         */
+
+        /**
+         * Constructs a new GetUnconfirmedTransactionsRequest.
+         * @memberof transactions
+         * @classdesc Represents a GetUnconfirmedTransactionsRequest.
+         * @implements IGetUnconfirmedTransactionsRequest
+         * @constructor
+         * @param {transactions.IGetUnconfirmedTransactionsRequest=} [properties] Properties to set
+         */
+        function GetUnconfirmedTransactionsRequest(properties) {
+            if (properties)
+                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                    if (properties[keys[i]] != null)
+                        this[keys[i]] = properties[keys[i]];
+        }
+
+        /**
+         * GetUnconfirmedTransactionsRequest countOnly.
+         * @member {boolean} countOnly
+         * @memberof transactions.GetUnconfirmedTransactionsRequest
+         * @instance
+         */
+        GetUnconfirmedTransactionsRequest.prototype.countOnly = false;
+
+        /**
+         * GetUnconfirmedTransactionsRequest headers.
+         * @member {shared.IHeaders|null|undefined} headers
+         * @memberof transactions.GetUnconfirmedTransactionsRequest
+         * @instance
+         */
+        GetUnconfirmedTransactionsRequest.prototype.headers = null;
+
+        /**
+         * Creates a new GetUnconfirmedTransactionsRequest instance using the specified properties.
+         * @function create
+         * @memberof transactions.GetUnconfirmedTransactionsRequest
+         * @static
+         * @param {transactions.IGetUnconfirmedTransactionsRequest=} [properties] Properties to set
+         * @returns {transactions.GetUnconfirmedTransactionsRequest} GetUnconfirmedTransactionsRequest instance
+         */
+        GetUnconfirmedTransactionsRequest.create = function create(properties) {
+            return new GetUnconfirmedTransactionsRequest(properties);
+        };
+
+        /**
+         * Encodes the specified GetUnconfirmedTransactionsRequest message. Does not implicitly {@link transactions.GetUnconfirmedTransactionsRequest.verify|verify} messages.
+         * @function encode
+         * @memberof transactions.GetUnconfirmedTransactionsRequest
+         * @static
+         * @param {transactions.IGetUnconfirmedTransactionsRequest} message GetUnconfirmedTransactionsRequest message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        GetUnconfirmedTransactionsRequest.encode = function encode(message, writer) {
+            if (!writer)
+                writer = $Writer.create();
+            if (message.countOnly != null && Object.hasOwnProperty.call(message, "countOnly"))
+                writer.uint32(/* id 1, wireType 0 =*/8).bool(message.countOnly);
+            if (message.headers != null && Object.hasOwnProperty.call(message, "headers"))
+                $root.shared.Headers.encode(message.headers, writer.uint32(/* id 2, wireType 2 =*/18).fork()).ldelim();
+            return writer;
+        };
+
+        /**
+         * Encodes the specified GetUnconfirmedTransactionsRequest message, length delimited. Does not implicitly {@link transactions.GetUnconfirmedTransactionsRequest.verify|verify} messages.
+         * @function encodeDelimited
+         * @memberof transactions.GetUnconfirmedTransactionsRequest
+         * @static
+         * @param {transactions.IGetUnconfirmedTransactionsRequest} message GetUnconfirmedTransactionsRequest message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        GetUnconfirmedTransactionsRequest.encodeDelimited = function encodeDelimited(message, writer) {
+            return this.encode(message, writer).ldelim();
+        };
+
+        /**
+         * Decodes a GetUnconfirmedTransactionsRequest message from the specified reader or buffer.
+         * @function decode
+         * @memberof transactions.GetUnconfirmedTransactionsRequest
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @param {number} [length] Message length if known beforehand
+         * @returns {transactions.GetUnconfirmedTransactionsRequest} GetUnconfirmedTransactionsRequest
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        GetUnconfirmedTransactionsRequest.decode = function decode(reader, length) {
+            if (!(reader instanceof $Reader))
+                reader = $Reader.create(reader);
+            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.transactions.GetUnconfirmedTransactionsRequest();
+            while (reader.pos < end) {
+                var tag = reader.uint32();
+                switch (tag >>> 3) {
+                case 1:
+                    message.countOnly = reader.bool();
+                    break;
+                case 2:
+                    message.headers = $root.shared.Headers.decode(reader, reader.uint32());
+                    break;
+                default:
+                    reader.skipType(tag & 7);
+                    break;
+                }
+            }
+            return message;
+        };
+
+        /**
+         * Decodes a GetUnconfirmedTransactionsRequest message from the specified reader or buffer, length delimited.
+         * @function decodeDelimited
+         * @memberof transactions.GetUnconfirmedTransactionsRequest
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @returns {transactions.GetUnconfirmedTransactionsRequest} GetUnconfirmedTransactionsRequest
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        GetUnconfirmedTransactionsRequest.decodeDelimited = function decodeDelimited(reader) {
+            if (!(reader instanceof $Reader))
+                reader = new $Reader(reader);
+            return this.decode(reader, reader.uint32());
+        };
+
+        /**
+         * Verifies a GetUnconfirmedTransactionsRequest message.
+         * @function verify
+         * @memberof transactions.GetUnconfirmedTransactionsRequest
+         * @static
+         * @param {Object.<string,*>} message Plain object to verify
+         * @returns {string|null} `null` if valid, otherwise the reason why it is not
+         */
+        GetUnconfirmedTransactionsRequest.verify = function verify(message) {
+            if (typeof message !== "object" || message === null)
+                return "object expected";
+            if (message.countOnly != null && message.hasOwnProperty("countOnly"))
+                if (typeof message.countOnly !== "boolean")
+                    return "countOnly: boolean expected";
+            if (message.headers != null && message.hasOwnProperty("headers")) {
+                var error = $root.shared.Headers.verify(message.headers);
+                if (error)
+                    return "headers." + error;
+            }
+            return null;
+        };
+
+        /**
+         * Creates a GetUnconfirmedTransactionsRequest message from a plain object. Also converts values to their respective internal types.
+         * @function fromObject
+         * @memberof transactions.GetUnconfirmedTransactionsRequest
+         * @static
+         * @param {Object.<string,*>} object Plain object
+         * @returns {transactions.GetUnconfirmedTransactionsRequest} GetUnconfirmedTransactionsRequest
+         */
+        GetUnconfirmedTransactionsRequest.fromObject = function fromObject(object) {
+            if (object instanceof $root.transactions.GetUnconfirmedTransactionsRequest)
+                return object;
+            var message = new $root.transactions.GetUnconfirmedTransactionsRequest();
+            if (object.countOnly != null)
+                message.countOnly = Boolean(object.countOnly);
+            if (object.headers != null) {
+                if (typeof object.headers !== "object")
+                    throw TypeError(".transactions.GetUnconfirmedTransactionsRequest.headers: object expected");
+                message.headers = $root.shared.Headers.fromObject(object.headers);
+            }
+            return message;
+        };
+
+        /**
+         * Creates a plain object from a GetUnconfirmedTransactionsRequest message. Also converts values to other types if specified.
+         * @function toObject
+         * @memberof transactions.GetUnconfirmedTransactionsRequest
+         * @static
+         * @param {transactions.GetUnconfirmedTransactionsRequest} message GetUnconfirmedTransactionsRequest
+         * @param {$protobuf.IConversionOptions} [options] Conversion options
+         * @returns {Object.<string,*>} Plain object
+         */
+        GetUnconfirmedTransactionsRequest.toObject = function toObject(message, options) {
+            if (!options)
+                options = {};
+            var object = {};
+            if (options.defaults) {
+                object.countOnly = false;
+                object.headers = null;
+            }
+            if (message.countOnly != null && message.hasOwnProperty("countOnly"))
+                object.countOnly = message.countOnly;
+            if (message.headers != null && message.hasOwnProperty("headers"))
+                object.headers = $root.shared.Headers.toObject(message.headers, options);
+            return object;
+        };
+
+        /**
+         * Converts this GetUnconfirmedTransactionsRequest to JSON.
+         * @function toJSON
+         * @memberof transactions.GetUnconfirmedTransactionsRequest
+         * @instance
+         * @returns {Object.<string,*>} JSON object
+         */
+        GetUnconfirmedTransactionsRequest.prototype.toJSON = function toJSON() {
+            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+        };
+
+        return GetUnconfirmedTransactionsRequest;
+    })();
+
+    transactions.GetUnconfirmedTransactionsResponse = (function() {
+
+        /**
+         * Properties of a GetUnconfirmedTransactionsResponse.
+         * @memberof transactions
+         * @interface IGetUnconfirmedTransactionsResponse
+         * @property {number|null} [poolSize] GetUnconfirmedTransactionsResponse poolSize
+         * @property {Uint8Array|null} [transactions] GetUnconfirmedTransactionsResponse transactions
+         * @property {shared.IHeaders|null} [headers] GetUnconfirmedTransactionsResponse headers
+         */
+
+        /**
+         * Constructs a new GetUnconfirmedTransactionsResponse.
+         * @memberof transactions
+         * @classdesc Represents a GetUnconfirmedTransactionsResponse.
+         * @implements IGetUnconfirmedTransactionsResponse
+         * @constructor
+         * @param {transactions.IGetUnconfirmedTransactionsResponse=} [properties] Properties to set
+         */
+        function GetUnconfirmedTransactionsResponse(properties) {
+            if (properties)
+                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                    if (properties[keys[i]] != null)
+                        this[keys[i]] = properties[keys[i]];
+        }
+
+        /**
+         * GetUnconfirmedTransactionsResponse poolSize.
+         * @member {number} poolSize
+         * @memberof transactions.GetUnconfirmedTransactionsResponse
+         * @instance
+         */
+        GetUnconfirmedTransactionsResponse.prototype.poolSize = 0;
+
+        /**
+         * GetUnconfirmedTransactionsResponse transactions.
+         * @member {Uint8Array} transactions
+         * @memberof transactions.GetUnconfirmedTransactionsResponse
+         * @instance
+         */
+        GetUnconfirmedTransactionsResponse.prototype.transactions = $util.newBuffer([]);
+
+        /**
+         * GetUnconfirmedTransactionsResponse headers.
+         * @member {shared.IHeaders|null|undefined} headers
+         * @memberof transactions.GetUnconfirmedTransactionsResponse
+         * @instance
+         */
+        GetUnconfirmedTransactionsResponse.prototype.headers = null;
+
+        /**
+         * Creates a new GetUnconfirmedTransactionsResponse instance using the specified properties.
+         * @function create
+         * @memberof transactions.GetUnconfirmedTransactionsResponse
+         * @static
+         * @param {transactions.IGetUnconfirmedTransactionsResponse=} [properties] Properties to set
+         * @returns {transactions.GetUnconfirmedTransactionsResponse} GetUnconfirmedTransactionsResponse instance
+         */
+        GetUnconfirmedTransactionsResponse.create = function create(properties) {
+            return new GetUnconfirmedTransactionsResponse(properties);
+        };
+
+        /**
+         * Encodes the specified GetUnconfirmedTransactionsResponse message. Does not implicitly {@link transactions.GetUnconfirmedTransactionsResponse.verify|verify} messages.
+         * @function encode
+         * @memberof transactions.GetUnconfirmedTransactionsResponse
+         * @static
+         * @param {transactions.IGetUnconfirmedTransactionsResponse} message GetUnconfirmedTransactionsResponse message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        GetUnconfirmedTransactionsResponse.encode = function encode(message, writer) {
+            if (!writer)
+                writer = $Writer.create();
+            if (message.poolSize != null && Object.hasOwnProperty.call(message, "poolSize"))
+                writer.uint32(/* id 1, wireType 0 =*/8).uint32(message.poolSize);
+            if (message.transactions != null && Object.hasOwnProperty.call(message, "transactions"))
+                writer.uint32(/* id 2, wireType 2 =*/18).bytes(message.transactions);
+            if (message.headers != null && Object.hasOwnProperty.call(message, "headers"))
+                $root.shared.Headers.encode(message.headers, writer.uint32(/* id 3, wireType 2 =*/26).fork()).ldelim();
+            return writer;
+        };
+
+        /**
+         * Encodes the specified GetUnconfirmedTransactionsResponse message, length delimited. Does not implicitly {@link transactions.GetUnconfirmedTransactionsResponse.verify|verify} messages.
+         * @function encodeDelimited
+         * @memberof transactions.GetUnconfirmedTransactionsResponse
+         * @static
+         * @param {transactions.IGetUnconfirmedTransactionsResponse} message GetUnconfirmedTransactionsResponse message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        GetUnconfirmedTransactionsResponse.encodeDelimited = function encodeDelimited(message, writer) {
+            return this.encode(message, writer).ldelim();
+        };
+
+        /**
+         * Decodes a GetUnconfirmedTransactionsResponse message from the specified reader or buffer.
+         * @function decode
+         * @memberof transactions.GetUnconfirmedTransactionsResponse
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @param {number} [length] Message length if known beforehand
+         * @returns {transactions.GetUnconfirmedTransactionsResponse} GetUnconfirmedTransactionsResponse
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        GetUnconfirmedTransactionsResponse.decode = function decode(reader, length) {
+            if (!(reader instanceof $Reader))
+                reader = $Reader.create(reader);
+            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.transactions.GetUnconfirmedTransactionsResponse();
+            while (reader.pos < end) {
+                var tag = reader.uint32();
+                switch (tag >>> 3) {
+                case 1:
+                    message.poolSize = reader.uint32();
+                    break;
+                case 2:
+                    message.transactions = reader.bytes();
+                    break;
+                case 3:
+                    message.headers = $root.shared.Headers.decode(reader, reader.uint32());
+                    break;
+                default:
+                    reader.skipType(tag & 7);
+                    break;
+                }
+            }
+            return message;
+        };
+
+        /**
+         * Decodes a GetUnconfirmedTransactionsResponse message from the specified reader or buffer, length delimited.
+         * @function decodeDelimited
+         * @memberof transactions.GetUnconfirmedTransactionsResponse
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @returns {transactions.GetUnconfirmedTransactionsResponse} GetUnconfirmedTransactionsResponse
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        GetUnconfirmedTransactionsResponse.decodeDelimited = function decodeDelimited(reader) {
+            if (!(reader instanceof $Reader))
+                reader = new $Reader(reader);
+            return this.decode(reader, reader.uint32());
+        };
+
+        /**
+         * Verifies a GetUnconfirmedTransactionsResponse message.
+         * @function verify
+         * @memberof transactions.GetUnconfirmedTransactionsResponse
+         * @static
+         * @param {Object.<string,*>} message Plain object to verify
+         * @returns {string|null} `null` if valid, otherwise the reason why it is not
+         */
+        GetUnconfirmedTransactionsResponse.verify = function verify(message) {
+            if (typeof message !== "object" || message === null)
+                return "object expected";
+            if (message.poolSize != null && message.hasOwnProperty("poolSize"))
+                if (!$util.isInteger(message.poolSize))
+                    return "poolSize: integer expected";
+            if (message.transactions != null && message.hasOwnProperty("transactions"))
+                if (!(message.transactions && typeof message.transactions.length === "number" || $util.isString(message.transactions)))
+                    return "transactions: buffer expected";
+            if (message.headers != null && message.hasOwnProperty("headers")) {
+                var error = $root.shared.Headers.verify(message.headers);
+                if (error)
+                    return "headers." + error;
+            }
+            return null;
+        };
+
+        /**
+         * Creates a GetUnconfirmedTransactionsResponse message from a plain object. Also converts values to their respective internal types.
+         * @function fromObject
+         * @memberof transactions.GetUnconfirmedTransactionsResponse
+         * @static
+         * @param {Object.<string,*>} object Plain object
+         * @returns {transactions.GetUnconfirmedTransactionsResponse} GetUnconfirmedTransactionsResponse
+         */
+        GetUnconfirmedTransactionsResponse.fromObject = function fromObject(object) {
+            if (object instanceof $root.transactions.GetUnconfirmedTransactionsResponse)
+                return object;
+            var message = new $root.transactions.GetUnconfirmedTransactionsResponse();
+            if (object.poolSize != null)
+                message.poolSize = object.poolSize >>> 0;
+            if (object.transactions != null)
+                if (typeof object.transactions === "string")
+                    $util.base64.decode(object.transactions, message.transactions = $util.newBuffer($util.base64.length(object.transactions)), 0);
+                else if (object.transactions.length)
+                    message.transactions = object.transactions;
+            if (object.headers != null) {
+                if (typeof object.headers !== "object")
+                    throw TypeError(".transactions.GetUnconfirmedTransactionsResponse.headers: object expected");
+                message.headers = $root.shared.Headers.fromObject(object.headers);
+            }
+            return message;
+        };
+
+        /**
+         * Creates a plain object from a GetUnconfirmedTransactionsResponse message. Also converts values to other types if specified.
+         * @function toObject
+         * @memberof transactions.GetUnconfirmedTransactionsResponse
+         * @static
+         * @param {transactions.GetUnconfirmedTransactionsResponse} message GetUnconfirmedTransactionsResponse
+         * @param {$protobuf.IConversionOptions} [options] Conversion options
+         * @returns {Object.<string,*>} Plain object
+         */
+        GetUnconfirmedTransactionsResponse.toObject = function toObject(message, options) {
+            if (!options)
+                options = {};
+            var object = {};
+            if (options.defaults) {
+                object.poolSize = 0;
+                if (options.bytes === String)
+                    object.transactions = "";
+                else {
+                    object.transactions = [];
+                    if (options.bytes !== Array)
+                        object.transactions = $util.newBuffer(object.transactions);
+                }
+                object.headers = null;
+            }
+            if (message.poolSize != null && message.hasOwnProperty("poolSize"))
+                object.poolSize = message.poolSize;
+            if (message.transactions != null && message.hasOwnProperty("transactions"))
+                object.transactions = options.bytes === String ? $util.base64.encode(message.transactions, 0, message.transactions.length) : options.bytes === Array ? Array.prototype.slice.call(message.transactions) : message.transactions;
+            if (message.headers != null && message.hasOwnProperty("headers"))
+                object.headers = $root.shared.Headers.toObject(message.headers, options);
+            return object;
+        };
+
+        /**
+         * Converts this GetUnconfirmedTransactionsResponse to JSON.
+         * @function toJSON
+         * @memberof transactions.GetUnconfirmedTransactionsResponse
+         * @instance
+         * @returns {Object.<string,*>} JSON object
+         */
+        GetUnconfirmedTransactionsResponse.prototype.toJSON = function toJSON() {
+            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+        };
+
+        return GetUnconfirmedTransactionsResponse;
+    })();
+
     transactions.PostTransactionsRequest = (function() {
 
         /**

--- a/packages/core-p2p/src/socket-server/codecs/proto/transactions.proto
+++ b/packages/core-p2p/src/socket-server/codecs/proto/transactions.proto
@@ -2,6 +2,17 @@ syntax = "proto3";
 
 package transactions;
 
+message GetUnconfirmedTransactionsRequest {
+    bool countOnly = 1;
+    shared.Headers headers = 2;
+}
+
+message GetUnconfirmedTransactionsResponse {
+    uint32 poolSize = 1;
+    bytes transactions = 2;
+    shared.Headers headers = 3;
+}
+
 message PostTransactionsRequest {
     bytes transactions = 1;
     shared.Headers headers = 2;

--- a/packages/core-p2p/src/socket-server/codecs/transactions.ts
+++ b/packages/core-p2p/src/socket-server/codecs/transactions.ts
@@ -3,43 +3,63 @@ import { transactions } from "./proto/protos";
 // actual max transactions is enforced by schema but we set a hard limit for deserializing (way higher than in schema)
 const hardLimitNumberOfTransactions = 1000;
 
+const serialiseTransactions = (
+    encode: Function,
+    obj: transactions.IPostTransactionsRequest | transactions.IGetUnconfirmedTransactionsResponse,
+): Buffer => {
+    const size = (obj.transactions as unknown as Buffer[]).reduce((sum: number, tx: Buffer) => sum + 4 + tx.length, 0);
+    const result = Buffer.alloc(size);
+
+    let offset = 0;
+    for (const tx of obj.transactions as unknown as Buffer[]) {
+        offset = result.writeUInt32BE(tx.length, offset);
+        offset += tx.copy(result, offset);
+    }
+
+    obj = { ...obj, transactions: result };
+
+    return Buffer.from(encode(obj).finish());
+};
+
+const deserialiseTransactions = (decode: Function, payload: Buffer): object => {
+    const decoded = decode(payload);
+    const txsBuffer = Buffer.from(decoded.transactions);
+    const txs: Buffer[] = [];
+    for (let offset = 0; offset < txsBuffer.byteLength - 4; ) {
+        const txLength = txsBuffer.readUInt32BE(offset);
+        txs.push(txsBuffer.slice(offset + 4, offset + 4 + txLength));
+        offset += 4 + txLength;
+        if (txs.length > hardLimitNumberOfTransactions) {
+            break;
+        }
+    }
+
+    return {
+        ...decoded,
+        transactions: txs,
+    };
+};
+
+export const getUnconfirmedTransactions = {
+    request: {
+        serialise: (obj: transactions.GetUnconfirmedTransactionsRequest): Buffer =>
+            Buffer.from(transactions.GetUnconfirmedTransactionsRequest.encode(obj).finish()),
+        deserialise: (payload: Buffer): {} => transactions.GetUnconfirmedTransactionsRequest.decode(payload),
+    },
+    response: {
+        serialise: (obj: transactions.IGetUnconfirmedTransactionsResponse): Buffer =>
+            serialiseTransactions(transactions.GetUnconfirmedTransactionsResponse.encode, obj),
+        deserialise: (payload: Buffer): object =>
+            deserialiseTransactions(transactions.GetUnconfirmedTransactionsResponse.decode, payload),
+    },
+};
+
 export const postTransactions = {
     request: {
-        serialise: (obj: transactions.IPostTransactionsRequest): Buffer => {
-            const size = (obj.transactions as unknown as Buffer[]).reduce(
-                (sum: number, tx: Buffer) => sum + 4 + tx.length,
-                0,
-            );
-            const result = Buffer.alloc(size);
-
-            let offset = 0;
-            for (const tx of obj.transactions as unknown as Buffer[]) {
-                offset = result.writeUInt32BE(tx.length, offset);
-                offset += tx.copy(result, offset);
-            }
-
-            obj = { ...obj, transactions: result };
-
-            return Buffer.from(transactions.PostTransactionsRequest.encode(obj).finish());
-        },
-        deserialise: (payload: Buffer): object => {
-            const decoded = transactions.PostTransactionsRequest.decode(payload);
-            const txsBuffer = Buffer.from(decoded.transactions);
-            const txs: Buffer[] = [];
-            for (let offset = 0; offset < txsBuffer.byteLength - 4; ) {
-                const txLength = txsBuffer.readUInt32BE(offset);
-                txs.push(txsBuffer.slice(offset + 4, offset + 4 + txLength));
-                offset += 4 + txLength;
-                if (txs.length > hardLimitNumberOfTransactions) {
-                    break;
-                }
-            }
-
-            return {
-                ...decoded,
-                transactions: txs,
-            };
-        },
+        serialise: (obj: transactions.IPostTransactionsRequest): Buffer =>
+            serialiseTransactions(transactions.PostTransactionsRequest.encode, obj),
+        deserialise: (payload: Buffer): object =>
+            deserialiseTransactions(transactions.PostTransactionsRequest.decode, payload),
     },
     response: {
         serialise: (accept: string[]): Buffer =>

--- a/packages/core-p2p/src/socket-server/controllers/internal.ts
+++ b/packages/core-p2p/src/socket-server/controllers/internal.ts
@@ -1,6 +1,6 @@
 import Hapi from "@hapi/hapi";
 import { Container, Contracts, Services, Utils } from "@solar-network/core-kernel";
-import { Crypto, Interfaces, Managers } from "@solar-network/crypto";
+import { Crypto, Managers } from "@solar-network/crypto";
 
 import { Controller } from "./controller";
 
@@ -13,12 +13,6 @@ export class InternalController extends Controller {
 
     @Container.inject(Container.Identifiers.BlockchainService)
     private readonly blockchain!: Contracts.Blockchain.Blockchain;
-
-    @Container.inject(Container.Identifiers.TransactionPoolService)
-    private readonly transactionPool!: Contracts.TransactionPool.Service;
-
-    @Container.inject(Container.Identifiers.TransactionPoolCollator)
-    private readonly collator!: Contracts.TransactionPool.Collator;
 
     @Container.inject(Container.Identifiers.RoundState)
     private readonly roundState!: Contracts.State.RoundState;
@@ -33,18 +27,6 @@ export class InternalController extends Controller {
     public emitEvent(request: Hapi.Request, h: Hapi.ResponseToolkit): boolean {
         this.events.dispatch((request.payload as any).event, (request.payload as any).body);
         return true;
-    }
-
-    public async getUnconfirmedTransactions(
-        request: Hapi.Request,
-        h: Hapi.ResponseToolkit,
-    ): Promise<Contracts.P2P.UnconfirmedTransactions> {
-        const transactions: Interfaces.ITransaction[] = await this.collator.getBlockCandidateTransactions();
-
-        return {
-            poolSize: this.transactionPool.getPoolSize(),
-            transactions: transactions.map((t) => t.serialised.toString("hex")),
-        };
     }
 
     public async getCurrentRound(request: Hapi.Request, h: Hapi.ResponseToolkit): Promise<Contracts.P2P.CurrentRound> {

--- a/packages/core-p2p/src/socket-server/controllers/transactions.ts
+++ b/packages/core-p2p/src/socket-server/controllers/transactions.ts
@@ -1,11 +1,32 @@
 import Hapi from "@hapi/hapi";
 import { Container, Contracts } from "@solar-network/core-kernel";
+import { Interfaces } from "@solar-network/crypto";
 
 import { Controller } from "./controller";
 
 export class TransactionsController extends Controller {
+    @Container.inject(Container.Identifiers.TransactionPoolCollator)
+    private readonly collator!: Contracts.TransactionPool.Collator;
+
     @Container.inject(Container.Identifiers.TransactionPoolProcessor)
     private readonly processor!: Contracts.TransactionPool.Processor;
+
+    @Container.inject(Container.Identifiers.TransactionPoolService)
+    private readonly transactionPool!: Contracts.TransactionPool.Service;
+
+    public async getUnconfirmedTransactions(
+        request: Hapi.Request,
+        h: Hapi.ResponseToolkit,
+    ): Promise<Contracts.P2P.UnconfirmedTransactions> {
+        const transactions: Interfaces.ITransaction[] = (request.payload as any).countOnly
+            ? []
+            : await this.collator.getBlockCandidateTransactions();
+
+        return {
+            poolSize: this.transactionPool.getPoolSize(),
+            transactions: transactions.map((t) => t.serialised),
+        };
+    }
 
     public async postTransactions(request: Hapi.Request, h: Hapi.ResponseToolkit): Promise<string[]> {
         const result = await this.processor.process((request.payload as any).transactions as Buffer[]);

--- a/packages/core-p2p/src/socket-server/routes/internal.ts
+++ b/packages/core-p2p/src/socket-server/routes/internal.ts
@@ -1,11 +1,4 @@
-import {
-    emitEvent,
-    getCurrentRound,
-    getNetworkState,
-    getSlotNumber,
-    getUnconfirmedTransactions,
-    syncBlockchain,
-} from "../codecs/internal";
+import { emitEvent, getCurrentRound, getNetworkState, getSlotNumber, syncBlockchain } from "../codecs/internal";
 import { InternalController } from "../controllers/internal";
 import { internalSchemas } from "../schemas/internal";
 import { Route, RouteConfig } from "./route";
@@ -19,11 +12,6 @@ export class InternalRoute extends Route {
                 handler: controller.emitEvent,
                 validation: internalSchemas.emitEvent,
                 codec: emitEvent,
-            },
-            "/p2p/internal/getUnconfirmedTransactions": {
-                id: "p2p.internal.getUnconfirmedTransactions",
-                handler: controller.getUnconfirmedTransactions,
-                codec: getUnconfirmedTransactions,
             },
             "/p2p/internal/getCurrentRound": {
                 id: "p2p.internal.getCurrentRound",

--- a/packages/core-p2p/src/socket-server/routes/transactions.ts
+++ b/packages/core-p2p/src/socket-server/routes/transactions.ts
@@ -1,5 +1,5 @@
 import { constants } from "../../constants";
-import { postTransactions } from "../codecs/transactions";
+import { getUnconfirmedTransactions, postTransactions } from "../codecs/transactions";
 import { TransactionsController } from "../controllers/transactions";
 import { transactionsSchemas } from "../schemas/transactions";
 import { Route, RouteConfig } from "./route";
@@ -8,6 +8,12 @@ export class TransactionsRoute extends Route {
     public getRoutesConfigByPath(): { [path: string]: RouteConfig } {
         const controller = this.getController();
         return {
+            "/p2p/transactions/getUnconfirmedTransactions": {
+                id: "p2p.transactions.getUnconfirmedTransactions",
+                handler: controller.getUnconfirmedTransactions,
+                codec: getUnconfirmedTransactions,
+                maxBytes: 1024,
+            },
             "/p2p/transactions/postTransactions": {
                 id: "p2p.transactions.postTransactions",
                 handler: controller.postTransactions,

--- a/packages/core-p2p/src/utils/build-rate-limiter.ts
+++ b/packages/core-p2p/src/utils/build-rate-limiter.ts
@@ -39,7 +39,7 @@ export const buildRateLimiter = (options: {
                 {
                     rateLimit: options.isOutgoing ? 1 : 2,
                     duration: options.isOutgoing ? 2 : 1,
-                    endpoint: "p2p.peer.getUnconfirmedTransactions",
+                    endpoint: "p2p.transactions.getUnconfirmedTransactions",
                 },
                 {
                     rateLimit: options.rateLimitPostTransactions || 25,

--- a/packages/core-p2p/src/utils/build-rate-limiter.ts
+++ b/packages/core-p2p/src/utils/build-rate-limiter.ts
@@ -37,6 +37,11 @@ export const buildRateLimiter = (options: {
                     endpoint: "p2p.peer.getCommonBlocks",
                 },
                 {
+                    rateLimit: options.isOutgoing ? 1 : 2,
+                    duration: options.isOutgoing ? 2 : 1,
+                    endpoint: "p2p.peer.getUnconfirmedTransactions",
+                },
+                {
                     rateLimit: options.rateLimitPostTransactions || 25,
                     endpoint: "p2p.transactions.postTransactions",
                 },

--- a/packages/core-transaction-pool/package.json
+++ b/packages/core-transaction-pool/package.json
@@ -19,6 +19,7 @@
         "compile": "node ../../node_modules/typescript/bin/tsc"
     },
     "dependencies": {
+        "@solar-network/core-database": "workspace:*",
         "@solar-network/core-kernel": "workspace:*",
         "@solar-network/core-transactions": "workspace:*",
         "@solar-network/crypto": "workspace:*",

--- a/packages/core-transaction-pool/src/errors.ts
+++ b/packages/core-transaction-pool/src/errors.ts
@@ -1,6 +1,12 @@
 import { Contracts, Utils as AppUtils } from "@solar-network/core-kernel";
 import { Interfaces, Utils } from "@solar-network/crypto";
 
+export class AlreadyForgedTransactionError extends Contracts.TransactionPool.PoolError {
+    public constructor(transaction: Interfaces.ITransaction) {
+        super(`${transaction} was already forged`, "ERR_FORGED");
+    }
+}
+
 export class RetryTransactionError extends Contracts.TransactionPool.PoolError {
     public constructor(transaction: Interfaces.ITransaction) {
         super(`${transaction} cannot be added to pool, please retry`, "ERR_RETRY");


### PR DESCRIPTION
Our security goal for forging delegate nodes is for them to eventually fully operate behind a firewall with their p2p port closed. Although we're not there yet, this PR brings us one step closer to achieving it by polling the network for unconfirmed transactions and downloading them from other peers that receive them via their `postTransactions` endpoint or api. This is accomplished by opening up the existing `getUnconfirmedTransactions` endpoint by moving it from the `internal` route to the public `transactions` route and defining an appropriate protobuf codec and rate limit.

It also fixes some issues with the transaction broadcaster which could lead to validation errors causing a sudden loss of all peers.