### PR TITLE
refactor: remove irrelevant transaction properties

### DIFF
--- a/packages/core-api/src/resources/transaction-with-block.ts
+++ b/packages/core-api/src/resources/transaction-with-block.ts
@@ -22,7 +22,6 @@ export class TransactionWithBlockResource implements Resource {
         AppUtils.assert.defined<string>(transactionData.senderPublicKey);
 
         const sender: string = this.walletRepository.findByPublicKey(transactionData.senderPublicKey).getAddress();
-        const recipient: string | undefined = transactionData.recipientId ?? undefined;
         const signSignature: string | undefined = transactionData.signSignature ?? transactionData.secondSignature;
         const confirmations: number = this.stateStore.getLastHeight() - blockData.height + 1;
 
@@ -41,7 +40,7 @@ export class TransactionWithBlockResource implements Resource {
                 typeof transactionData.burnedFee !== "undefined" ? transactionData.burnedFee.toFixed() : undefined,
             sender,
             senderPublicKey: transactionData.senderPublicKey,
-            recipient,
+            recipient: transactionData.recipientId,
             signature: transactionData.signature,
             signSignature,
             signatures: transactionData.signatures,

--- a/packages/core-api/src/resources/transaction-with-block.ts
+++ b/packages/core-api/src/resources/transaction-with-block.ts
@@ -22,7 +22,7 @@ export class TransactionWithBlockResource implements Resource {
         AppUtils.assert.defined<string>(transactionData.senderPublicKey);
 
         const sender: string = this.walletRepository.findByPublicKey(transactionData.senderPublicKey).getAddress();
-        const recipient: string = transactionData.recipientId ?? sender;
+        const recipient: string | undefined = transactionData.recipientId ?? undefined;
         const signSignature: string | undefined = transactionData.signSignature ?? transactionData.secondSignature;
         const confirmations: number = this.stateStore.getLastHeight() - blockData.height + 1;
 
@@ -32,7 +32,10 @@ export class TransactionWithBlockResource implements Resource {
             version: transactionData.version,
             type: transactionData.type,
             typeGroup: transactionData.typeGroup,
-            amount: transactionData.amount.toFixed(),
+            amount:
+                typeof transactionData.amount !== "undefined" && !transactionData.amount.isZero()
+                    ? transactionData.amount.toFixed()
+                    : undefined,
             fee: transactionData.fee.toFixed(),
             burnedFee:
                 typeof transactionData.burnedFee !== "undefined" ? transactionData.burnedFee.toFixed() : undefined,

--- a/packages/core-api/src/resources/transaction.ts
+++ b/packages/core-api/src/resources/transaction.ts
@@ -43,18 +43,21 @@ export class TransactionResource implements Resource {
             version: resource.version,
             type: resource.type,
             typeGroup: resource.typeGroup,
-            amount: resource.amount.toFixed(),
+            amount:
+                typeof resource.amount !== "undefined" && !resource.amount.isZero()
+                    ? resource.amount.toFixed()
+                    : undefined,
             fee: resource.fee.toFixed(),
             burnedFee: typeof resource.burnedFee !== "undefined" ? resource.burnedFee.toFixed() : undefined,
             sender,
             senderPublicKey: resource.senderPublicKey,
-            recipient: resource.recipientId || sender,
+            recipient: resource.recipientId,
             signature: resource.signature,
             signSignature: resource.signSignature || resource.secondSignature,
             signatures: resource.signatures,
             vendorField: resource.vendorField,
             asset: resource.asset,
-            confirmations: 0, // ! resource.block ? lastBlock.data.height - resource.block.height + 1 : 0
+            confirmations: 0,
             timestamp:
                 typeof resource.timestamp !== "undefined" ? AppUtils.formatTimestamp(resource.timestamp) : undefined,
             nonce: resource.nonce?.toFixed(),

--- a/packages/core-database/src/migrations/20220615100000-null-recipient-ids-in-transactions-table.ts
+++ b/packages/core-database/src/migrations/20220615100000-null-recipient-ids-in-transactions-table.ts
@@ -1,0 +1,14 @@
+import { Enums } from "@solar-network/crypto";
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class NullRecipientIdsInTransactionsTable20220615100000 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<any> {
+        await queryRunner.query(`
+            UPDATE transactions SET recipient_id = NULL WHERE type_group <> ${Enums.TransactionTypeGroup.Core} OR (type_group = ${Enums.TransactionTypeGroup.Core} AND type <> ${Enums.TransactionType.Core.Transfer} AND type <> ${Enums.TransactionType.HtlcLock});
+        `);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<any> {
+        //
+    }
+}

--- a/packages/core-database/src/migrations/20220615200000-null-amounts-in-transactions-table.ts
+++ b/packages/core-database/src/migrations/20220615200000-null-amounts-in-transactions-table.ts
@@ -1,0 +1,17 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class NullAmountsInTransactionsTable20220615200000 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<any> {
+        await queryRunner.query(`
+            ALTER TABLE transactions ALTER COLUMN amount DROP NOT NULL;
+            UPDATE transactions SET amount = NULL WHERE amount = 0;
+        `);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<any> {
+        await queryRunner.query(`
+            UPDATE transactions SET amount = 0 WHERE amount IS NULL;
+            ALTER TABLE transactions ALTER COLUMN amount SET NOT NULL;
+        `);
+    }
+}

--- a/packages/core-database/src/utils/transform.ts
+++ b/packages/core-database/src/utils/transform.ts
@@ -4,7 +4,7 @@ import { FindOperator } from "typeorm";
 export const transformBigInt = {
     from(value: string | undefined): BigNumber | undefined {
         if (value !== undefined) {
-            return BigNumber.make(value);
+            return BigNumber.make(value || 0);
         }
 
         return undefined;

--- a/packages/core-database/src/utils/transform.ts
+++ b/packages/core-database/src/utils/transform.ts
@@ -4,7 +4,7 @@ import { FindOperator } from "typeorm";
 export const transformBigInt = {
     from(value: string | undefined): BigNumber | undefined {
         if (value !== undefined) {
-            return BigNumber.make(value || 0);
+            return value ? BigNumber.make(value) : BigNumber.ZERO;
         }
 
         return undefined;

--- a/packages/core-state/src/state-builder.ts
+++ b/packages/core-state/src/state-builder.ts
@@ -102,7 +102,9 @@ export class StateBuilder {
         for (const transaction of transactions) {
             const wallet = this.walletRepository.findByPublicKey(transaction.senderPublicKey);
             wallet.setNonce(Utils.BigNumber.make(transaction.nonce));
-            wallet.decreaseBalance(Utils.BigNumber.make(transaction.amount || 0).plus(transaction.fee));
+            wallet.decreaseBalance(
+                Utils.BigNumber.make(transaction.amount || Utils.BigNumber.ZERO).plus(transaction.fee),
+            );
         }
     }
 

--- a/packages/core-state/src/state-builder.ts
+++ b/packages/core-state/src/state-builder.ts
@@ -102,7 +102,7 @@ export class StateBuilder {
         for (const transaction of transactions) {
             const wallet = this.walletRepository.findByPublicKey(transaction.senderPublicKey);
             wallet.setNonce(Utils.BigNumber.make(transaction.nonce));
-            wallet.decreaseBalance(Utils.BigNumber.make(transaction.amount).plus(transaction.fee));
+            wallet.decreaseBalance(Utils.BigNumber.make(transaction.amount || 0).plus(transaction.fee));
         }
     }
 

--- a/packages/core-transactions/src/handlers/transaction.ts
+++ b/packages/core-transactions/src/handlers/transaction.ts
@@ -141,7 +141,8 @@ export abstract class TransactionHandler {
 
         sender.setNonce(data.nonce);
 
-        const newBalance: Utils.BigNumber = sender.getBalance().minus(data.amount).minus(data.fee);
+        const amount: Utils.BigNumber = Utils.BigNumber.make(data.amount || 0);
+        const newBalance: Utils.BigNumber = sender.getBalance().minus(amount).minus(data.fee);
 
         assert(Utils.isException(transaction.data) || !newBalance.isNegative());
 
@@ -173,7 +174,8 @@ export abstract class TransactionHandler {
 
         const data: Interfaces.ITransactionData = transaction.data;
 
-        sender.increaseBalance(data.amount.plus(data.fee));
+        const amount: Utils.BigNumber = Utils.BigNumber.make(data.amount || 0);
+        sender.increaseBalance(amount.plus(data.fee));
 
         this.verifyTransactionNonceRevert(sender, transaction);
 
@@ -220,8 +222,10 @@ export abstract class TransactionHandler {
 
         this.verifyTransactionNonceApply(sender, transaction);
 
-        if (sender.getBalance().minus(data.amount).minus(data.fee).isNegative()) {
-            throw new InsufficientBalanceError(data.amount.plus(data.fee), sender.getBalance());
+        const amount: Utils.BigNumber = Utils.BigNumber.make(data.amount || 0);
+
+        if (sender.getBalance().minus(amount).minus(data.fee).isNegative()) {
+            throw new InsufficientBalanceError(amount.plus(data.fee), sender.getBalance());
         }
 
         if (data.senderPublicKey !== sender.getPublicKey()) {

--- a/packages/core-transactions/src/handlers/transaction.ts
+++ b/packages/core-transactions/src/handlers/transaction.ts
@@ -137,32 +137,16 @@ export abstract class TransactionHandler {
 
         this.verifyTransactionNonceApply(sender, transaction);
 
-        AppUtils.assert.defined<AppUtils.BigNumber>(data.nonce);
+        AppUtils.assert.defined<Utils.BigNumber>(data.nonce);
 
         sender.setNonce(data.nonce);
 
-        const amount: Utils.BigNumber = Utils.BigNumber.make(data.amount || 0);
-        const newBalance: Utils.BigNumber = sender.getBalance().minus(amount).minus(data.fee);
+        const newBalance: Utils.BigNumber = sender
+            .getBalance()
+            .minus(data.amount || Utils.BigNumber.ZERO)
+            .minus(data.fee);
 
         assert(Utils.isException(transaction.data) || !newBalance.isNegative());
-
-        // negativeBalanceExceptions check is never executed, because performGenericWalletChecks already checks balance
-        // if (process.env.CORE_ENV === "test") {
-        //     assert(Utils.isException(transaction.data.id) || !newBalance.isNegative());
-        // } else {
-        //     if (newBalance.isNegative()) {
-        //         const negativeBalanceExceptions: Record<string, Record<string, string>> =
-        //             Managers.configManager.get("exceptions.negativeBalances") || {};
-        //
-        //         AppUtils.assert.defined<string>(sender.publicKey);
-        //
-        //         const negativeBalances: Record<string, string> = negativeBalanceExceptions[sender.publicKey] || {};
-        //
-        //         if (!newBalance.isEqualTo(negativeBalances[sender.nonce.toString()] || 0)) {
-        //             throw new InsufficientBalanceError();
-        //         }
-        //     }
-        // }
 
         sender.setBalance(newBalance);
     }
@@ -174,7 +158,7 @@ export abstract class TransactionHandler {
 
         const data: Interfaces.ITransactionData = transaction.data;
 
-        const amount: Utils.BigNumber = Utils.BigNumber.make(data.amount || 0);
+        const amount: Utils.BigNumber = data.amount || Utils.BigNumber.ZERO;
         sender.increaseBalance(amount.plus(data.fee));
 
         this.verifyTransactionNonceRevert(sender, transaction);
@@ -222,7 +206,7 @@ export abstract class TransactionHandler {
 
         this.verifyTransactionNonceApply(sender, transaction);
 
-        const amount: Utils.BigNumber = Utils.BigNumber.make(data.amount || 0);
+        const amount: Utils.BigNumber = data.amount || Utils.BigNumber.ZERO;
 
         if (sender.getBalance().minus(amount).minus(data.fee).isNegative()) {
             throw new InsufficientBalanceError(amount.plus(data.fee), sender.getBalance());
@@ -277,7 +261,7 @@ export abstract class TransactionHandler {
      * @memberof Wallet
      */
     protected verifyTransactionNonceApply(wallet: Contracts.State.Wallet, transaction: Interfaces.ITransaction): void {
-        const nonce: AppUtils.BigNumber = transaction.data.nonce || AppUtils.BigNumber.ZERO;
+        const nonce: Utils.BigNumber = transaction.data.nonce || Utils.BigNumber.ZERO;
 
         if (!wallet.getNonce().plus(1).isEqualTo(nonce)) {
             throw new UnexpectedNonceError(nonce, wallet, false);
@@ -293,7 +277,7 @@ export abstract class TransactionHandler {
      * @memberof Wallet
      */
     protected verifyTransactionNonceRevert(wallet: Contracts.State.Wallet, transaction: Interfaces.ITransaction): void {
-        const nonce: AppUtils.BigNumber = transaction.data.nonce || AppUtils.BigNumber.ZERO;
+        const nonce: Utils.BigNumber = transaction.data.nonce || Utils.BigNumber.ZERO;
 
         if (!wallet.getNonce().isEqualTo(nonce)) {
             throw new UnexpectedNonceError(nonce, wallet, true);

--- a/packages/crypto/src/blocks/block.ts
+++ b/packages/crypto/src/blocks/block.ts
@@ -237,7 +237,7 @@ export class Block implements IBlock {
 
                 appliedTransactions[transaction.data.id] = transaction.data;
 
-                totalAmount = totalAmount.plus(transaction.data.amount || 0);
+                totalAmount = totalAmount.plus(transaction.data.amount || BigNumber.ZERO);
                 totalFee = totalFee.plus(transaction.data.fee);
 
                 payloadBuffers.push(bytes);

--- a/packages/crypto/src/blocks/block.ts
+++ b/packages/crypto/src/blocks/block.ts
@@ -237,7 +237,7 @@ export class Block implements IBlock {
 
                 appliedTransactions[transaction.data.id] = transaction.data;
 
-                totalAmount = totalAmount.plus(transaction.data.amount);
+                totalAmount = totalAmount.plus(transaction.data.amount || 0);
                 totalFee = totalFee.plus(transaction.data.fee);
 
                 payloadBuffers.push(bytes);

--- a/packages/crypto/src/blocks/factory.ts
+++ b/packages/crypto/src/blocks/factory.ts
@@ -38,7 +38,9 @@ export class BlockFactory {
 
         if (data.transactions) {
             for (const transaction of data.transactions) {
-                transaction.amount = BigNumber.make(transaction.amount || 0);
+                if (transaction.amount) {
+                    transaction.amount = BigNumber.make(transaction.amount);
+                }
                 transaction.fee = BigNumber.make(transaction.fee);
             }
         }

--- a/packages/crypto/src/blocks/factory.ts
+++ b/packages/crypto/src/blocks/factory.ts
@@ -38,7 +38,7 @@ export class BlockFactory {
 
         if (data.transactions) {
             for (const transaction of data.transactions) {
-                transaction.amount = BigNumber.make(transaction.amount);
+                transaction.amount = BigNumber.make(transaction.amount || 0);
                 transaction.fee = BigNumber.make(transaction.fee);
             }
         }

--- a/packages/crypto/src/transactions/builders/transactions/core/delegate-registration.ts
+++ b/packages/crypto/src/transactions/builders/transactions/core/delegate-registration.ts
@@ -1,5 +1,4 @@
 import { ITransactionAsset, ITransactionData } from "../../../../interfaces";
-import { BigNumber } from "../../../../utils";
 import { Core } from "../../../types";
 import { TransactionBuilder } from "../transaction";
 
@@ -10,8 +9,6 @@ export class DelegateRegistrationBuilder extends TransactionBuilder<DelegateRegi
         this.data.type = Core.DelegateRegistrationTransaction.type;
         this.data.typeGroup = Core.DelegateRegistrationTransaction.typeGroup;
         this.data.fee = Core.DelegateRegistrationTransaction.staticFee();
-        this.data.amount = BigNumber.ZERO;
-        this.data.recipientId = undefined;
         this.data.senderPublicKey = undefined;
         this.data.asset = { delegate: {} } as ITransactionAsset;
     }
@@ -26,8 +23,6 @@ export class DelegateRegistrationBuilder extends TransactionBuilder<DelegateRegi
 
     public getStruct(): ITransactionData {
         const struct: ITransactionData = super.getStruct();
-        struct.amount = this.data.amount;
-        struct.recipientId = this.data.recipientId;
         struct.asset = this.data.asset;
 
         super.validate(struct);

--- a/packages/crypto/src/transactions/builders/transactions/core/delegate-resignation.ts
+++ b/packages/crypto/src/transactions/builders/transactions/core/delegate-resignation.ts
@@ -1,5 +1,4 @@
 import { ITransactionData } from "../../../../interfaces";
-import { BigNumber } from "../../../../utils";
 import { Core } from "../../../types";
 import { TransactionBuilder } from "../transaction";
 
@@ -10,13 +9,11 @@ export class DelegateResignationBuilder extends TransactionBuilder<DelegateResig
         this.data.type = Core.DelegateResignationTransaction.type;
         this.data.typeGroup = Core.DelegateResignationTransaction.typeGroup;
         this.data.fee = Core.DelegateResignationTransaction.staticFee();
-        this.data.amount = BigNumber.ZERO;
         this.data.senderPublicKey = undefined;
     }
 
     public getStruct(): ITransactionData {
         const struct: ITransactionData = super.getStruct();
-        struct.amount = this.data.amount;
 
         super.validate(struct);
         return struct;

--- a/packages/crypto/src/transactions/builders/transactions/core/htlc-claim.ts
+++ b/packages/crypto/src/transactions/builders/transactions/core/htlc-claim.ts
@@ -1,5 +1,4 @@
 import { IHtlcClaimAsset, ITransactionData } from "../../../../interfaces";
-import { BigNumber } from "../../../../utils";
 import { Core } from "../../../types";
 import { TransactionBuilder } from "../transaction";
 
@@ -10,7 +9,6 @@ export class HtlcClaimBuilder extends TransactionBuilder<HtlcClaimBuilder> {
         this.data.type = Core.HtlcClaimTransaction.type;
         this.data.typeGroup = Core.HtlcClaimTransaction.typeGroup;
         this.data.fee = Core.HtlcClaimTransaction.staticFee();
-        this.data.amount = BigNumber.ZERO;
         this.data.asset = {};
     }
 
@@ -24,7 +22,6 @@ export class HtlcClaimBuilder extends TransactionBuilder<HtlcClaimBuilder> {
 
     public getStruct(): ITransactionData {
         const struct: ITransactionData = super.getStruct();
-        struct.amount = this.data.amount;
         struct.asset = this.data.asset;
 
         super.validate(struct);

--- a/packages/crypto/src/transactions/builders/transactions/core/htlc-lock.ts
+++ b/packages/crypto/src/transactions/builders/transactions/core/htlc-lock.ts
@@ -24,6 +24,18 @@ export class HtlcLockBuilder extends TransactionBuilder<HtlcLockBuilder> {
         return this;
     }
 
+    public amount(amount: string): HtlcLockBuilder {
+        this.data.amount = BigNumber.make(amount);
+
+        return this.instance();
+    }
+
+    public recipientId(recipientId: string): HtlcLockBuilder {
+        this.data.recipientId = recipientId;
+
+        return this.instance();
+    }
+
     public getStruct(): ITransactionData {
         const struct: ITransactionData = super.getStruct();
         struct.recipientId = this.data.recipientId;

--- a/packages/crypto/src/transactions/builders/transactions/core/htlc-refund.ts
+++ b/packages/crypto/src/transactions/builders/transactions/core/htlc-refund.ts
@@ -1,5 +1,4 @@
 import { IHtlcRefundAsset, ITransactionData } from "../../../../interfaces";
-import { BigNumber } from "../../../../utils";
 import { Core } from "../../../types";
 import { TransactionBuilder } from "../transaction";
 
@@ -10,7 +9,6 @@ export class HtlcRefundBuilder extends TransactionBuilder<HtlcRefundBuilder> {
         this.data.type = Core.HtlcRefundTransaction.type;
         this.data.typeGroup = Core.HtlcRefundTransaction.typeGroup;
         this.data.fee = Core.HtlcRefundTransaction.staticFee();
-        this.data.amount = BigNumber.ZERO;
         this.data.asset = {};
     }
 
@@ -24,7 +22,6 @@ export class HtlcRefundBuilder extends TransactionBuilder<HtlcRefundBuilder> {
 
     public getStruct(): ITransactionData {
         const struct: ITransactionData = super.getStruct();
-        struct.amount = this.data.amount;
         struct.asset = this.data.asset;
 
         super.validate(struct);

--- a/packages/crypto/src/transactions/builders/transactions/core/ipfs.ts
+++ b/packages/crypto/src/transactions/builders/transactions/core/ipfs.ts
@@ -1,5 +1,4 @@
 import { ITransactionData } from "../../../../interfaces";
-import { BigNumber } from "../../../../utils";
 import { Core } from "../../../types";
 import { TransactionBuilder } from "../transaction";
 
@@ -11,7 +10,6 @@ export class IPFSBuilder extends TransactionBuilder<IPFSBuilder> {
         this.data.typeGroup = Core.IpfsTransaction.typeGroup;
         this.data.fee = Core.IpfsTransaction.staticFee();
         this.data.vendorField = undefined;
-        this.data.amount = BigNumber.ZERO;
         this.data.asset = {};
     }
 
@@ -25,7 +23,6 @@ export class IPFSBuilder extends TransactionBuilder<IPFSBuilder> {
 
     public getStruct(): ITransactionData {
         const struct: ITransactionData = super.getStruct();
-        struct.amount = this.data.amount;
         struct.asset = this.data.asset;
 
         super.validate(struct);

--- a/packages/crypto/src/transactions/builders/transactions/core/multi-payment.ts
+++ b/packages/crypto/src/transactions/builders/transactions/core/multi-payment.ts
@@ -16,7 +16,6 @@ export class MultiPaymentBuilder extends TransactionBuilder<MultiPaymentBuilder>
         this.data.asset = {
             payments: [],
         };
-        this.data.amount = BigNumber.make(0);
     }
 
     public addPayment(recipientId: string, amount: string): MultiPaymentBuilder {
@@ -38,7 +37,6 @@ export class MultiPaymentBuilder extends TransactionBuilder<MultiPaymentBuilder>
     public getStruct(): ITransactionData {
         const struct: ITransactionData = super.getStruct();
         struct.senderPublicKey = this.data.senderPublicKey;
-        struct.amount = this.data.amount;
         struct.asset = this.data.asset;
 
         super.validate(struct);

--- a/packages/crypto/src/transactions/builders/transactions/core/multi-signature.ts
+++ b/packages/crypto/src/transactions/builders/transactions/core/multi-signature.ts
@@ -1,5 +1,4 @@
 import { IMultiSignatureAsset, ITransactionData } from "../../../../interfaces";
-import { BigNumber } from "../../../../utils";
 import { Core } from "../../../types";
 import { TransactionBuilder } from "../transaction";
 
@@ -9,9 +8,7 @@ export class MultiSignatureBuilder extends TransactionBuilder<MultiSignatureBuil
 
         this.data.type = Core.MultiSignatureRegistrationTransaction.type;
         this.data.typeGroup = Core.MultiSignatureRegistrationTransaction.typeGroup;
-        this.data.fee = BigNumber.ZERO;
-        this.data.amount = BigNumber.ZERO;
-        this.data.recipientId = undefined;
+        this.data.fee = Core.MultiSignatureRegistrationTransaction.staticFee();
         this.data.senderPublicKey = undefined;
         this.data.asset = { multiSignature: { min: 0, publicKeys: [] } };
     }
@@ -48,8 +45,6 @@ export class MultiSignatureBuilder extends TransactionBuilder<MultiSignatureBuil
 
     public getStruct(): ITransactionData {
         const struct: ITransactionData = super.getStruct();
-        struct.amount = this.data.amount;
-        struct.recipientId = this.data.recipientId;
         struct.asset = this.data.asset;
 
         super.validate(struct);

--- a/packages/crypto/src/transactions/builders/transactions/core/second-signature.ts
+++ b/packages/crypto/src/transactions/builders/transactions/core/second-signature.ts
@@ -1,6 +1,5 @@
 import { Keys } from "../../../../identities";
 import { ITransactionAsset, ITransactionData } from "../../../../interfaces";
-import { BigNumber } from "../../../../utils";
 import { Core } from "../../../types";
 import { TransactionBuilder } from "../transaction";
 
@@ -11,8 +10,6 @@ export class SecondSignatureBuilder extends TransactionBuilder<SecondSignatureBu
         this.data.type = Core.SecondSignatureRegistrationTransaction.type;
         this.data.typeGroup = Core.SecondSignatureRegistrationTransaction.typeGroup;
         this.data.fee = Core.SecondSignatureRegistrationTransaction.staticFee();
-        this.data.amount = BigNumber.ZERO;
-        this.data.recipientId = undefined;
         this.data.senderPublicKey = undefined;
         this.data.asset = { signature: {} } as ITransactionAsset;
     }
@@ -27,8 +24,6 @@ export class SecondSignatureBuilder extends TransactionBuilder<SecondSignatureBu
 
     public getStruct(): ITransactionData {
         const struct: ITransactionData = super.getStruct();
-        struct.amount = this.data.amount;
-        struct.recipientId = this.data.recipientId;
         struct.asset = this.data.asset;
 
         super.validate(struct);

--- a/packages/crypto/src/transactions/builders/transactions/core/transfer.ts
+++ b/packages/crypto/src/transactions/builders/transactions/core/transfer.ts
@@ -22,6 +22,18 @@ export class TransferBuilder extends TransactionBuilder<TransferBuilder> {
         return this.instance();
     }
 
+    public amount(amount: string): TransferBuilder {
+        this.data.amount = BigNumber.make(amount);
+
+        return this.instance();
+    }
+
+    public recipientId(recipientId: string): TransferBuilder {
+        this.data.recipientId = recipientId;
+
+        return this.instance();
+    }
+
     public getStruct(): ITransactionData {
         const struct: ITransactionData = super.getStruct();
         struct.amount = this.data.amount;

--- a/packages/crypto/src/transactions/builders/transactions/core/vote.ts
+++ b/packages/crypto/src/transactions/builders/transactions/core/vote.ts
@@ -1,5 +1,4 @@
 import { ITransactionData } from "../../../../interfaces";
-import { BigNumber } from "../../../../utils";
 import { Core } from "../../../types";
 import { TransactionBuilder } from "../transaction";
 
@@ -10,12 +9,8 @@ export class VoteBuilder extends TransactionBuilder<VoteBuilder> {
         this.data.type = Core.LegacyVoteTransaction.type;
         this.data.typeGroup = Core.LegacyVoteTransaction.typeGroup;
         this.data.fee = Core.LegacyVoteTransaction.staticFee();
-        this.data.amount = BigNumber.ZERO;
-        this.data.recipientId = undefined;
         this.data.senderPublicKey = undefined;
         this.data.asset = { votes: [] };
-
-        this.signWithSenderAsRecipient = true;
     }
 
     public votesAsset(votes: string[]): VoteBuilder {
@@ -28,8 +23,6 @@ export class VoteBuilder extends TransactionBuilder<VoteBuilder> {
 
     public getStruct(): ITransactionData {
         const struct: ITransactionData = super.getStruct();
-        struct.amount = this.data.amount;
-        struct.recipientId = this.data.recipientId;
         struct.asset = this.data.asset;
 
         super.validate(struct);

--- a/packages/crypto/src/transactions/builders/transactions/solar/vote.ts
+++ b/packages/crypto/src/transactions/builders/transactions/solar/vote.ts
@@ -1,5 +1,5 @@
 import { ITransactionData } from "../../../../interfaces";
-import { BigNumber, sortVotes } from "../../../../utils";
+import { sortVotes } from "../../../../utils";
 import { Solar } from "../../../types";
 import { TransactionBuilder } from "../transaction";
 
@@ -10,12 +10,8 @@ export class VoteBuilder extends TransactionBuilder<VoteBuilder> {
         this.data.type = Solar.VoteTransaction.type;
         this.data.typeGroup = Solar.VoteTransaction.typeGroup;
         this.data.fee = Solar.VoteTransaction.staticFee();
-        this.data.amount = BigNumber.ZERO;
-        this.data.recipientId = undefined;
         this.data.senderPublicKey = undefined;
         this.data.asset = { votes: {} };
-
-        this.signWithSenderAsRecipient = true;
     }
 
     public votesAsset(votes: { [vote: string]: number }): VoteBuilder {
@@ -60,8 +56,6 @@ export class VoteBuilder extends TransactionBuilder<VoteBuilder> {
 
     public getStruct(): ITransactionData {
         const struct: ITransactionData = super.getStruct();
-        struct.amount = this.data.amount;
-        struct.recipientId = this.data.recipientId;
         struct.asset = this.data.asset;
 
         super.validate(struct);

--- a/packages/crypto/src/transactions/builders/transactions/transaction.ts
+++ b/packages/crypto/src/transactions/builders/transactions/transaction.ts
@@ -4,7 +4,7 @@ import {
     TransactionSchemaError,
     VendorFieldLengthExceededError,
 } from "../../../errors";
-import { Address, Keys } from "../../../identities";
+import { Keys } from "../../../identities";
 import { IKeyPair, ITransaction, ITransactionData } from "../../../interfaces";
 import { configManager } from "../../../managers/config";
 import { NetworkType } from "../../../types";
@@ -15,8 +15,6 @@ import { Verifier } from "../../verifier";
 
 export abstract class TransactionBuilder<TBuilder extends TransactionBuilder<TBuilder>> {
     public data: ITransactionData;
-
-    protected signWithSenderAsRecipient = false;
 
     private disableVersionCheck = true;
 
@@ -66,18 +64,6 @@ export abstract class TransactionBuilder<TBuilder extends TransactionBuilder<TBu
         if (fee) {
             this.data.fee = BigNumber.make(fee);
         }
-
-        return this.instance();
-    }
-
-    public amount(amount: string): TBuilder {
-        this.data.amount = BigNumber.make(amount);
-
-        return this.instance();
-    }
-
-    public recipientId(recipientId: string): TBuilder {
-        this.data.recipientId = recipientId;
 
         return this.instance();
     }
@@ -181,10 +167,6 @@ export abstract class TransactionBuilder<TBuilder extends TransactionBuilder<TBu
 
     private signWithKeyPair(keys: IKeyPair): TBuilder {
         this.data.senderPublicKey = keys.publicKey;
-
-        if (this.signWithSenderAsRecipient) {
-            this.data.recipientId = Address.fromPublicKey(keys.publicKey, this.data.network);
-        }
 
         this.data.signature = Signer.sign(this.getSigningObject(), keys, {
             disableVersionCheck: this.disableVersionCheck,

--- a/packages/crypto/src/transactions/deserialiser.ts
+++ b/packages/crypto/src/transactions/deserialiser.ts
@@ -50,7 +50,6 @@ export class Deserialiser {
 
         transaction.senderPublicKey = buf.readBuffer(33).toString("hex");
         transaction.fee = BigNumber.make(buf.readBigUInt64LE().toString());
-        transaction.amount = BigNumber.ZERO;
     }
 
     private static deserialiseVendorField(transaction: ITransaction, buf: ByteBuffer): void {

--- a/packages/crypto/src/transactions/factory.ts
+++ b/packages/crypto/src/transactions/factory.ts
@@ -49,7 +49,9 @@ export class TransactionFactory {
 
     public static fromJson(json: ITransactionJson): ITransaction {
         const data: ITransactionData = { ...json } as unknown as ITransactionData;
-        data.amount = BigNumber.make(data.amount);
+        if (data.amount) {
+            data.amount = BigNumber.make(data.amount);
+        }
         data.fee = BigNumber.make(data.fee);
 
         return this.fromData(data);

--- a/packages/crypto/src/transactions/types/core/multi-payment.ts
+++ b/packages/crypto/src/transactions/types/core/multi-payment.ts
@@ -50,7 +50,6 @@ export abstract class MultiPaymentTransaction extends Transaction {
             });
         }
 
-        data.amount = BigNumber.ZERO;
         data.asset = { payments };
     }
 }

--- a/packages/crypto/src/transactions/types/schemas.ts
+++ b/packages/crypto/src/transactions/types/schemas.ts
@@ -17,14 +17,13 @@ const strictTransaction = {
 export const transactionBaseSchema: Record<string, any> = {
     $id: undefined,
     type: "object",
-    required: ["type", "senderPublicKey", "fee", "amount", "nonce"],
+    required: ["type", "senderPublicKey", "fee", "nonce"],
     properties: {
         id: { anyOf: [{ $ref: "transactionId" }, { type: "null" }] },
         version: { enum: [2, 3] },
         network: { $ref: "networkByte" },
         nonce: { bignumber: { minimum: 0 } },
         typeGroup: { type: "integer", minimum: 0 },
-        amount: { bignumber: { minimum: 1, bypassGenesis: true } },
         fee: { bignumber: { minimum: 0, bypassGenesis: true } },
         burnedFee: { bignumber: { minimum: 0 } },
         senderPublicKey: { $ref: "publicKey" },
@@ -62,9 +61,10 @@ export const strictSchema = (schema: TransactionSchema): TransactionSchema => {
 
 export const transfer = extend(transactionBaseSchema, {
     $id: "transfer",
-    required: ["recipientId"],
+    required: ["recipientId", "amount"],
     properties: {
         type: { transactionType: TransactionType.Core.Transfer },
+        amount: { bignumber: { minimum: 1, bypassGenesis: true } },
         fee: { bignumber: { minimum: 1, bypassGenesis: true } },
         recipientId: { $ref: "address" },
         expiration: { type: "integer", minimum: 0 },
@@ -76,7 +76,6 @@ export const secondSignature = extend(transactionBaseSchema, {
     required: ["asset"],
     properties: {
         type: { transactionType: TransactionType.Core.SecondSignature },
-        amount: { bignumber: { minimum: 0, maximum: 0 } },
         fee: { bignumber: { minimum: 1 } },
         secondSignature: { type: "null" },
         asset: {
@@ -102,7 +101,6 @@ export const delegateRegistration = extend(transactionBaseSchema, {
     required: ["asset"],
     properties: {
         type: { transactionType: TransactionType.Core.DelegateRegistration },
-        amount: { bignumber: { minimum: 0, maximum: 0 } },
         fee: { bignumber: { minimum: 1, bypassGenesis: true } },
         asset: {
             type: "object",
@@ -140,9 +138,7 @@ export const legacyVote = extend(transactionBaseSchema, {
     },
     properties: {
         type: { transactionType: TransactionType.Core.Vote },
-        amount: { bignumber: { minimum: 0, maximum: 0 } },
         fee: { bignumber: { minimum: 1 } },
-        recipientId: { $ref: "address" },
         asset: {
             type: "object",
             required: ["votes"],
@@ -163,7 +159,6 @@ export const vote = extend(transactionBaseSchema, {
     required: ["typeGroup", "asset"],
     properties: {
         type: { transactionType: TransactionType.Solar.Vote },
-        amount: { bignumber: { minimum: 0, maximum: 0 } },
         fee: { bignumber: { minimum: 1 } },
         asset: {
             type: "object",
@@ -192,7 +187,6 @@ export const multiSignature = extend(transactionBaseSchema, {
     required: ["asset"],
     properties: {
         type: { transactionType: TransactionType.Core.MultiSignature },
-        amount: { bignumber: { minimum: 0, maximum: 0 } },
         fee: { bignumber: { minimum: 1 } },
         asset: {
             type: "object",
@@ -226,7 +220,6 @@ export const ipfs = extend(transactionBaseSchema, {
     $id: "ipfs",
     properties: {
         type: { transactionType: TransactionType.Core.Ipfs },
-        amount: { bignumber: { minimum: 0, maximum: 0 } },
         fee: { bignumber: { minimum: 1 } },
         asset: {
             type: "object",
@@ -243,7 +236,7 @@ export const ipfs = extend(transactionBaseSchema, {
 
 export const htlcLock = extend(transactionBaseSchema, {
     $id: "htlcLock",
-    required: ["recipientId"],
+    required: ["recipientId", "amount"],
     properties: {
         type: { transactionType: TransactionType.Core.HtlcLock },
         amount: { bignumber: { minimum: 1 } },
@@ -283,7 +276,6 @@ export const htlcClaim = extend(transactionBaseSchema, {
     $id: "htlcClaim",
     properties: {
         type: { transactionType: TransactionType.Core.HtlcClaim },
-        amount: { bignumber: { minimum: 0, maximum: 0 } },
         fee: { bignumber: { minimum: 0 } },
         asset: {
             type: "object",
@@ -313,7 +305,6 @@ export const htlcRefund = extend(transactionBaseSchema, {
     $id: "htlcRefund",
     properties: {
         type: { transactionType: TransactionType.Core.HtlcRefund },
-        amount: { bignumber: { minimum: 0, maximum: 0 } },
         fee: { bignumber: { minimum: 0 } },
         asset: {
             type: "object",
@@ -335,7 +326,6 @@ export const multiPayment = extend(transactionBaseSchema, {
     $id: "multiPayment",
     properties: {
         type: { transactionType: TransactionType.Core.MultiPayment },
-        amount: { bignumber: { minimum: 0, maximum: 0 } },
         fee: { bignumber: { minimum: 1 } },
         asset: {
             type: "object",
@@ -364,7 +354,6 @@ export const delegateResignation = extend(transactionBaseSchema, {
     $id: "delegateResignation",
     properties: {
         type: { transactionType: TransactionType.Core.DelegateResignation },
-        amount: { bignumber: { minimum: 0, maximum: 0 } },
         fee: { bignumber: { minimum: 0 } },
     },
 });


### PR DESCRIPTION
Currently, every transaction stores a `recipientId` and `amount` value even when they are not needed. In such cases, the `amount` is 0 and the `recipientId` is the address of the sender. This takes up disk space and memory and would only get worse with time, so this PR removes irrelevant `recipientId` and `amount` properties from transactions that do not require them, and nullifies them in the database which reduces the memory footprint.

That is to say, in the case of `recipientId`, only types 0 and 8 from typegroup 1 now store the `recipientId` since no other transaction types use it, and in the case of `amount`, only types 0 and 8 from typegroup 1 and type 0 from typegroup 2 will store the value.

