### PR TITLE
refactor: nearly instantaneous fork recovery

### DIFF
--- a/packages/core-blockchain/src/blockchain.ts
+++ b/packages/core-blockchain/src/blockchain.ts
@@ -533,7 +533,6 @@ export class Blockchain implements Contracts.Blockchain.Blockchain {
             this.logger.info(
                 `Removed ${rollbackBlocks.toLocaleString()} ${Utils.pluralise("block", rollbackBlocks)} :wastebasket:`,
             );
-            await this.networkMonitor.refreshPeersAfterFork();
             await this.getQueue().resume();
             try {
                 if (blocks[0].ip) {

--- a/packages/core-blockchain/src/blockchain.ts
+++ b/packages/core-blockchain/src/blockchain.ts
@@ -524,6 +524,34 @@ export class Blockchain implements Contracts.Blockchain.Blockchain {
         }
     }
 
+    public async checkForFork(blocks: Interfaces.IBlockData[]): Promise<boolean> {
+        const rollbackBlocks: number = await this.networkMonitor.checkForFork();
+        if (rollbackBlocks > 0) {
+            this.clearAndStopQueue();
+            await this.removeBlocks(rollbackBlocks);
+            this.stateStore.setNumberOfBlocksToRollback(0);
+            this.logger.info(
+                `Removed ${rollbackBlocks.toLocaleString()} ${Utils.pluralise("block", rollbackBlocks)} :wastebasket:`,
+            );
+            await this.networkMonitor.refreshPeersAfterFork();
+            await this.getQueue().resume();
+            try {
+                if (blocks[0].ip) {
+                    const forkedBlock: Interfaces.IBlockData | undefined =
+                        await this.networkMonitor.downloadBlockAtHeight(blocks[0].ip, blocks[0].height - 1);
+                    if (forkedBlock) {
+                        this.enqueueBlocks([forkedBlock, ...blocks]);
+                    }
+                }
+            } catch {
+                //
+            }
+            return true;
+        }
+
+        return false;
+    }
+
     private resetMissedBlocks(): void {
         this.missedBlocks = 0;
     }

--- a/packages/core-blockchain/src/process-blocks-job.ts
+++ b/packages/core-blockchain/src/process-blocks-job.ts
@@ -73,16 +73,19 @@ export class ProcessBlocksJob implements Contracts.Kernel.QueueJob {
             !Utils.isBlockChained(this.blockchain.getLastBlock().data, this.blocks[0], blockTimeLookup) &&
             !CryptoUtils.isException(this.blocks[0])
         ) {
-            this.logger.warning(
-                Utils.getBlockNotChainedErrorMessage(
-                    this.blockchain.getLastBlock().data,
-                    this.blocks[0],
-                    blockTimeLookup,
-                ),
-            );
-            // Discard remaining blocks as it won't go anywhere anyway.
             this.blockchain.clearQueue();
             this.blockchain.resetLastDownloadedBlock();
+
+            if (!(await this.blockchain.checkForFork(this.blocks))) {
+                this.logger.warning(
+                    Utils.getBlockNotChainedErrorMessage(
+                        this.blockchain.getLastBlock().data,
+                        this.blocks[0],
+                        blockTimeLookup,
+                    ),
+                );
+            }
+
             return;
         }
 

--- a/packages/core-blockchain/src/state-machine/actions/download-blocks.ts
+++ b/packages/core-blockchain/src/state-machine/actions/download-blocks.ts
@@ -78,12 +78,14 @@ export class DownloadBlocks implements Action {
                     ).toLocaleString()} :warning:`,
                 );
             } else {
-                this.logger.warning("Downloaded block not accepted :warning: :warning: :warning:");
-                this.logger.warning(JSON.stringify(blocks[0]));
-
-                this.logger.warning(`Last downloaded block: ${JSON.stringify(lastDownloadedBlock)}`);
-
                 this.blockchain.clearQueue();
+
+                if (!(await this.blockchain.checkForFork(blocks))) {
+                    this.logger.warning("Downloaded block not accepted :warning: :warning: :warning:");
+                    this.logger.warning(JSON.stringify(blocks[0]));
+
+                    this.logger.warning(`Last downloaded block: ${JSON.stringify(lastDownloadedBlock)}`);
+                }
             }
 
             /* istanbul ignore else */

--- a/packages/core-blockchain/src/state-machine/actions/start-fork-recovery.ts
+++ b/packages/core-blockchain/src/state-machine/actions/start-fork-recovery.ts
@@ -28,7 +28,9 @@ export class StartForkRecovery implements Action {
 
         this.stateStore.setNumberOfBlocksToRollback(0);
 
-        this.logger.info(`Removed ${AppUtils.pluralise("block", blocksToRemove, true)} :wastebasket:`);
+        this.logger.info(
+            `Removed ${blocksToRemove.toLocaleString()} ${AppUtils.pluralise("block", blocksToRemove)} :wastebasket:`,
+        );
 
         await this.networkMonitor.refreshPeersAfterFork();
 

--- a/packages/core-kernel/src/contracts/blockchain/blockchain.ts
+++ b/packages/core-kernel/src/contracts/blockchain/blockchain.ts
@@ -121,5 +121,7 @@ export interface Blockchain {
     /**
      * Push ping block.
      */
-    pushPingBlock(block: Interfaces.IBlockData, fromForger): void;
+    pushPingBlock(block: Interfaces.IBlockData, fromForger: boolean): void;
+
+    checkForFork(blocks: Interfaces.IBlockData[]): Promise<boolean>;
 }

--- a/packages/core-kernel/src/contracts/p2p/network-monitor.ts
+++ b/packages/core-kernel/src/contracts/p2p/network-monitor.ts
@@ -32,7 +32,7 @@ export interface NetworkMonitor {
     getNetworkHeight(): number;
     getNetworkState(log?: boolean): Promise<NetworkState>;
     refreshPeersAfterFork(): Promise<void>;
-    checkNetworkHealth(): Promise<NetworkStatus>;
+    checkNetworkHealth(fast?: boolean): Promise<NetworkStatus>;
     downloadBlockAtHeight(ip: string, height: number): Promise<Interfaces.IBlockData | undefined>;
     downloadBlocksFromHeight(
         fromBlockHeight: number,

--- a/packages/core-kernel/src/contracts/p2p/network-monitor.ts
+++ b/packages/core-kernel/src/contracts/p2p/network-monitor.ts
@@ -33,6 +33,7 @@ export interface NetworkMonitor {
     getNetworkState(log?: boolean): Promise<NetworkState>;
     refreshPeersAfterFork(): Promise<void>;
     checkNetworkHealth(): Promise<NetworkStatus>;
+    downloadBlockAtHeight(ip: string, height: number): Promise<Interfaces.IBlockData | undefined>;
     downloadBlocksFromHeight(
         fromBlockHeight: number,
         maxParallelDownloads?: number,
@@ -46,4 +47,5 @@ export interface NetworkMonitor {
     completeColdStart(): void;
     hasMinimumPeers(silent?: boolean): boolean;
     populateSeedPeers(): Promise<void>;
+    checkForFork(): Promise<number>;
 }

--- a/packages/core-p2p/src/network-monitor.ts
+++ b/packages/core-p2p/src/network-monitor.ts
@@ -412,9 +412,7 @@ export class NetworkMonitor implements Contracts.P2P.NetworkMonitor {
 
                 if (blocksToRollback > 5000) {
                     this.logger.warning(
-                        `Fork detected! Rolling back ${(5000).toLocaleString()}/${
-                            blocksToRollback.toLocaleString
-                        } blocks to fork at height ${forkHeight.toLocaleString()} (${ourPeerCount} vs ${forkPeerCount}) :repeat:`,
+                        `Fork detected! Rolling back ${(5000).toLocaleString()}/${blocksToRollback.toLocaleString()} blocks to fork at height ${forkHeight.toLocaleString()} (${ourPeerCount} vs ${forkPeerCount}) :repeat:`,
                     );
 
                     return { forked: true, blocksToRollback: 5000 };

--- a/packages/core-p2p/src/network-monitor.ts
+++ b/packages/core-p2p/src/network-monitor.ts
@@ -412,7 +412,7 @@ export class NetworkMonitor implements Contracts.P2P.NetworkMonitor {
 
                 if (blocksToRollback > 5000) {
                     this.logger.warning(
-                        `Fork detected! Rolling back ${(5000).toLocaleString()}/${blocksToRollback.toLocaleString()} blocks to fork at height ${forkHeight.toLocaleString()} (${ourPeerCount} vs ${forkPeerCount}) :repeat:`,
+                        `Fork detected! Rolling back ${(5000).toLocaleString()}/${blocksToRollback.toLocaleString()} blocks to fork at height ${forkHeight.toLocaleString()} (${ourPeerCount.toLocaleString()} vs ${forkPeerCount.toLocaleString()}) :repeat:`,
                     );
 
                     return { forked: true, blocksToRollback: 5000 };
@@ -421,7 +421,7 @@ export class NetworkMonitor implements Contracts.P2P.NetworkMonitor {
                         `Fork detected! Rolling back ${blocksToRollback.toLocaleString()} ${Utils.pluralise(
                             "block",
                             blocksToRollback,
-                        )} to fork at height ${forkHeight.toLocaleString()} (${ourPeerCount} vs ${forkPeerCount}) :repeat:`,
+                        )} to fork at height ${forkHeight.toLocaleString()} (${ourPeerCount.toLocaleString()} vs ${forkPeerCount.toLocaleString()}) :repeat:`,
                     );
 
                     return { forked: true, blocksToRollback };

--- a/packages/core-p2p/src/network-monitor.ts
+++ b/packages/core-p2p/src/network-monitor.ts
@@ -464,8 +464,8 @@ export class NetworkMonitor implements Contracts.P2P.NetworkMonitor {
         if (timeNow - this.lastForkCheck > milestone.blocktime) {
             this.lastForkCheck = timeNow;
             const networkStatus = await this.checkNetworkHealth();
-            if (networkStatus.forked && networkStatus.blocksToRollback && networkStatus.blocksToRollback > 0) {
-                return networkStatus.blocksToRollback;
+            if (networkStatus.forked && networkStatus.blocksToRollback! > 0) {
+                return networkStatus.blocksToRollback!;
             }
         }
         return 0;


### PR DESCRIPTION
This PR enhances our fork recovery system to automatically detect a fork when we are on the minority chain as soon as it happens. This is possible because we regularly scan the network for blocks and we only include delegates in consensus decisions, so as soon as a block cannot be chained, we poll all the delegate nodes to check if we are on a fork.

If 50%+1 delegates confirm that we are on a fork, recovery starts immediately and the forked block is downloaded from the node that triggered the recovery algorithm, thus removing the roulette of potentially redownloading a bad block from the wrong fork over and over again, and the node should be back on the majority chain within 30 seconds or so from the moment it is detected.