### PR TITLE
refactor: rename vendorfield to memo

### DIFF
--- a/packages/core-api/src/resources-new/lock.ts
+++ b/packages/core-api/src/resources-new/lock.ts
@@ -22,7 +22,7 @@ export type LockResource = {
     };
     expirationType: Enums.HtlcLockExpirationType;
     expirationValue: number;
-    vendorField: string;
+    memo: string;
 };
 
 export const lockCriteriaSchemaObject = {
@@ -47,7 +47,7 @@ export const lockCriteriaSchemaObject = {
         Enums.HtlcLockExpirationType.EpochTimestamp,
     ),
     expirationValue: Joi.alternatives(blockCriteriaSchemaObject.height, blockCriteriaSchemaObject.timestamp),
-    vendorField: transactionCriteriaSchemaObject.vendorField,
+    memo: transactionCriteriaSchemaObject.memo,
 };
 
 export const lockParamSchema = transactionIdSchema;

--- a/packages/core-api/src/resources-new/transaction.ts
+++ b/packages/core-api/src/resources-new/transaction.ts
@@ -14,7 +14,7 @@ export const transactionCriteriaSchemaObject = {
     ),
     senderPublicKey: walletCriteriaSchemaObject.publicKey,
     recipientId: walletCriteriaSchemaObject.address,
-    vendorField: Joi.string().max(255),
+    memo: Joi.string().max(255),
 };
 
 export const transactionParamSchema = transactionIdSchema;

--- a/packages/core-api/src/resources/transaction-with-block.ts
+++ b/packages/core-api/src/resources/transaction-with-block.ts
@@ -56,7 +56,7 @@ export class TransactionWithBlockResource implements Resource {
             signature: transactionData.signature,
             signSignature,
             signatures: transactionData.signatures,
-            vendorField: transactionData.vendorField,
+            memo: transactionData.memo,
             asset: transactionData.asset,
             confirmations,
             timestamp: AppUtils.formatTimestamp(blockData.timestamp),

--- a/packages/core-api/src/resources/transaction.ts
+++ b/packages/core-api/src/resources/transaction.ts
@@ -64,7 +64,7 @@ export class TransactionResource implements Resource {
             signature: resource.signature,
             signSignature: resource.signSignature || resource.secondSignature,
             signatures: resource.signatures,
-            vendorField: resource.vendorField,
+            memo: resource.memo,
             asset: resource.asset,
             confirmations: 0,
             timestamp:

--- a/packages/core-api/src/schemas.ts
+++ b/packages/core-api/src/schemas.ts
@@ -213,7 +213,7 @@ export const transactionCriteriaSchemas = {
     senderPublicKey: orEqualCriteria(Joi.string().hex().length(66)),
     type: orEqualCriteria(Joi.number().integer().min(0)),
     typeGroup: orEqualCriteria(Joi.number().integer().min(0)),
-    vendorField: orLikeCriteria(Joi.string().max(255, "utf8")),
+    memo: orLikeCriteria(Joi.string().max(255, "utf8")),
     amount: orNumericCriteria(Joi.number().integer().min(0)),
     fee: orNumericCriteria(Joi.number().integer().min(0)),
     burnedFee: orNumericCriteria(Joi.number().integer().min(0)),

--- a/packages/core-api/src/services/lock-search-service.ts
+++ b/packages/core-api/src/services/lock-search-service.ts
@@ -73,7 +73,7 @@ export class LockSearchService {
             timestamp: AppUtils.formatTimestamp(lockAttribute.timestamp),
             expirationType: lockAttribute.expiration.type,
             expirationValue: lockAttribute.expiration.value,
-            vendorField: lockAttribute.vendorField!,
+            memo: lockAttribute.memo!,
         };
     }
 

--- a/packages/core-api/src/www/api.json
+++ b/packages/core-api/src/www/api.json
@@ -1139,9 +1139,9 @@
                         }
                     },
                     {
-                        "name": "vendorField",
+                        "name": "memo",
                         "in": "query",
-                        "description": "Vendor field string of the lock transaction(s) to be returned",
+                        "description": "Memo string of the lock transaction(s) to be returned",
                         "schema": {
                             "type": "string",
                             "maxLength": 255
@@ -1288,6 +1288,8 @@
                                 "isExpired:desc",
                                 "lockId:asc",
                                 "lockId:desc",
+                                "memo:asc",
+                                "memo:desc",
                                 "recipientId:asc",
                                 "recipientId:desc",
                                 "secretHash:asc",
@@ -1299,9 +1301,7 @@
                                 "timestamp.human:asc",
                                 "timestamp.human:desc",
                                 "timestamp.unix:asc",
-                                "timestamp.unix:desc",
-                                "vendorField:asc",
-                                "vendorField:desc"
+                                "timestamp.unix:desc"
                             ]
                         }
                     }
@@ -1370,6 +1370,8 @@
                                 "fee.epoch:desc",
                                 "id:asc",
                                 "id:desc",
+                                "memo:asc",
+                                "memo:desc",
                                 "nonce:asc",
                                 "nonce:desc",
                                 "recipientId:asc",
@@ -1380,8 +1382,6 @@
                                 "senderPublicKey:desc",
                                 "timestamp:asc",
                                 "timestamp:desc",
-                                "vendorField:asc",
-                                "vendorField:desc",
                                 "version:asc",
                                 "version:desc"
                             ]
@@ -1527,9 +1527,9 @@
                         }
                     },
                     {
-                        "name": "vendorField",
+                        "name": "memo",
                         "in": "query",
-                        "description": "Vendor field string of the transaction(s) to be returned",
+                        "description": "Memo string of the transaction(s) to be returned",
                         "schema": {
                             "type": "string",
                             "maxLength": 255
@@ -1686,8 +1686,8 @@
                                 "type:desc",
                                 "typeGroup:asc",
                                 "typeGroup:desc",
-                                "vendorField:asc",
-                                "vendorField:desc",
+                                "memo:asc",
+                                "memo:desc",
                                 "version:asc",
                                 "version:desc"
                             ]
@@ -2507,7 +2507,7 @@
                     "nonce",
                     "amount",
                     "recipientId",
-                    "vendorField",
+                    "memo",
                     "expiration"
                 ],
                 "properties": {
@@ -2549,7 +2549,7 @@
                         "type": "string",
                         "example": "022bcee076006120b24f145d495686d2afc880079daf2eb20d8be9bf0e434ca3e1"
                     },
-                    "vendorField": {
+                    "memo": {
                         "type": "string",
                         "example": "Welcome to Solar!"
                     },

--- a/packages/core-database/src/migrations/20220618000000-rename-vendor-field-to-memo-in-transactions-table.ts
+++ b/packages/core-database/src/migrations/20220618000000-rename-vendor-field-to-memo-in-transactions-table.ts
@@ -1,0 +1,21 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class RenameMemoToMemoInTransactionsTable20220618000000 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<any> {
+        await queryRunner.query(`
+            ALTER TABLE transactions RENAME vendor_field TO memo;
+            ALTER INDEX transactions_vendor_field RENAME TO transactions_memo;
+            ALTER INDEX transactions_vendor_field_asc_sequence RENAME TO transactions_memo_asc_sequence;
+            ALTER INDEX transactions_vendor_field_sequence RENAME TO transactions_memo_sequence;
+        `);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<any> {
+        await queryRunner.query(`
+            ALTER TABLE transactions RENAME memo TO vendor_field;
+            ALTER INDEX transactions_memo RENAME TO transactions_vendor_field;
+            ALTER INDEX transactions_memo_asc_sequence RENAME TO transactions_vendor_field_asc_sequence;
+            ALTER INDEX transactions_memo_sequence RENAME TO transactions_vendor_field_sequence;
+        `);
+    }
+}

--- a/packages/core-database/src/models/transaction.ts
+++ b/packages/core-database/src/models/transaction.ts
@@ -2,7 +2,7 @@ import { Contracts } from "@solar-network/core-kernel";
 import { Utils } from "@solar-network/crypto";
 import { Column, Entity, Index } from "typeorm";
 
-import { transformBigInt, transformVendorField } from "../utils/transform";
+import { transformBigInt, transformMemo } from "../utils/transform";
 
 // TODO: Fix model to have undefined type on nullable fields
 @Entity({
@@ -87,9 +87,9 @@ export class Transaction implements Contracts.Database.TransactionModel {
     @Column({
         type: "bytea",
         default: undefined,
-        transformer: transformVendorField,
+        transformer: transformMemo,
     })
-    public vendorField: string | undefined;
+    public memo: string | undefined;
 
     @Column({
         type: "bigint",

--- a/packages/core-database/src/repositories/abstract-repository.ts
+++ b/packages/core-database/src/repositories/abstract-repository.ts
@@ -120,7 +120,7 @@ export abstract class AbstractRepository<TEntity extends ObjectLiteral> extends 
                     propertyValue = undefined;
                 } else if (columnMetadata.type === "bigint") {
                     propertyValue = Utils.BigNumber.make(value);
-                } else if (columnMetadata.propertyName === "vendorField") {
+                } else if (columnMetadata.propertyName === "memo") {
                     propertyValue = value.toString("utf8");
                 } else {
                     propertyValue = value;

--- a/packages/core-database/src/transaction-filter.ts
+++ b/packages/core-database/src/transaction-filter.ts
@@ -75,9 +75,9 @@ export class TransactionFilter implements Contracts.Database.TransactionFilter {
                     return handleOrCriteria(criteria.typeGroup!, async (c) => {
                         return { property: "typeGroup", op: "equal", value: c };
                     });
-                case "vendorField":
-                    return handleOrCriteria(criteria.vendorField!, async (c) => {
-                        return { property: "vendorField", op: "like", pattern: Buffer.from(c, "utf-8") };
+                case "memo":
+                    return handleOrCriteria(criteria.memo!, async (c) => {
+                        return { property: "memo", op: "like", pattern: Buffer.from(c, "utf-8") };
                     });
                 case "amount":
                     return handleOrCriteria(criteria.amount!, async (c) => {

--- a/packages/core-database/src/utils/transform.ts
+++ b/packages/core-database/src/utils/transform.ts
@@ -18,7 +18,7 @@ export const transformBigInt = {
     },
 };
 
-export const transformVendorField = {
+export const transformMemo = {
     from: (value: Buffer | undefined | null): string | undefined => {
         if (value !== undefined && value !== null) {
             return value.toString("utf8");

--- a/packages/core-kernel/src/contracts/database/models.ts
+++ b/packages/core-kernel/src/contracts/database/models.ts
@@ -30,7 +30,7 @@ export interface TransactionModel {
     recipientId: string;
     type: number;
     typeGroup: number;
-    vendorField: string | undefined;
+    memo: string | undefined;
     amount: Utils.BigNumber;
     fee: Utils.BigNumber;
     burnedFee: Utils.BigNumber;

--- a/packages/core-kernel/src/contracts/shared/transaction-history-service.ts
+++ b/packages/core-kernel/src/contracts/shared/transaction-history-service.ts
@@ -25,7 +25,7 @@ export type TransactionCriteria = {
     senderPublicKey?: OrEqualCriteria<string>;
     type?: OrEqualCriteria<number>;
     typeGroup?: OrEqualCriteria<number>;
-    vendorField?: OrLikeCriteria<string>;
+    memo?: OrLikeCriteria<string>;
     amount?: OrNumericCriteria<Utils.BigNumber>;
     fee?: OrNumericCriteria<Utils.BigNumber>;
     asset?: OrContainsCriteria<Record<string, any>>;

--- a/packages/core-kernel/src/contracts/state/wallets.ts
+++ b/packages/core-kernel/src/contracts/state/wallets.ts
@@ -286,5 +286,5 @@ export interface UnwrappedHtlcLock {
     expirationType: number;
     expirationValue: number;
     isExpired: boolean;
-    vendorField: string;
+    memo: string;
 }

--- a/packages/core-snapshots/src/codecs/message-pack-codec.ts
+++ b/packages/core-snapshots/src/codecs/message-pack-codec.ts
@@ -96,7 +96,7 @@ export class MessagePackCodec implements Codec {
                 // @ts-ignore
                 recipientId: transaction.data.recipientId,
                 type: transaction.data.type,
-                vendorField: transaction.data.vendorField,
+                memo: transaction.data.memo,
                 amount: transaction.data.amount,
                 fee: transaction.data.fee,
                 burnedFee: burnedFee,

--- a/packages/core-transactions/src/handlers/core/htlc-claim.ts
+++ b/packages/core-transactions/src/handlers/core/htlc-claim.ts
@@ -249,9 +249,7 @@ export class HtlcClaimTransactionHandler extends TransactionHandler {
             amount: lockTransaction.amount,
             recipientId: lockTransaction.recipientId,
             timestamp: lockTransaction.timestamp,
-            vendorField: lockTransaction.vendorField
-                ? Buffer.from(lockTransaction.vendorField, "hex").toString("utf8")
-                : undefined,
+            memo: lockTransaction.memo ? Buffer.from(lockTransaction.memo, "hex").toString("utf8") : undefined,
             ...lockTransaction.asset.lock,
         };
         lockWallet.setAttribute("htlc.locks", locks);

--- a/packages/core-transactions/src/handlers/core/htlc-lock.ts
+++ b/packages/core-transactions/src/handlers/core/htlc-lock.ts
@@ -31,9 +31,7 @@ export class HtlcLockTransactionHandler extends TransactionHandler {
                 amount: Utils.BigNumber.make(transaction.amount),
                 recipientId: transaction.recipientId,
                 timestamp: transaction.timestamp,
-                vendorField: transaction.vendorField
-                    ? Buffer.from(transaction.vendorField, "hex").toString("utf8")
-                    : undefined,
+                memo: transaction.memo ? Buffer.from(transaction.memo, "hex").toString("utf8") : undefined,
                 ...transaction.asset.lock,
             };
 
@@ -129,7 +127,7 @@ export class HtlcLockTransactionHandler extends TransactionHandler {
             amount: transaction.data.amount,
             recipientId: transaction.data.recipientId,
             timestamp: transaction.timestamp,
-            vendorField: transaction.data.vendorField,
+            memo: transaction.data.memo,
             ...transaction.data.asset.lock,
         };
         sender.setAttribute("htlc.locks", locks);

--- a/packages/core-transactions/src/handlers/core/htlc-refund.ts
+++ b/packages/core-transactions/src/handlers/core/htlc-refund.ts
@@ -185,9 +185,7 @@ export class HtlcRefundTransactionHandler extends TransactionHandler {
             amount: lockTransaction.amount,
             recipientId: lockTransaction.recipientId,
             timestamp: lockTransaction.timestamp,
-            vendorField: lockTransaction.vendorField
-                ? Buffer.from(lockTransaction.vendorField, "hex").toString("utf8")
-                : undefined,
+            memo: lockTransaction.memo ? Buffer.from(lockTransaction.memo, "hex").toString("utf8") : undefined,
             ...lockTransaction.asset.lock,
         };
         lockWallet.setAttribute("htlc.locks", locks);

--- a/packages/core-transactions/src/handlers/core/legacy-transfer.ts
+++ b/packages/core-transactions/src/handlers/core/legacy-transfer.ts
@@ -39,10 +39,6 @@ export class LegacyTransferTransactionHandler extends TransactionHandler {
         return super.throwIfCannotBeApplied(transaction, sender);
     }
 
-    public hasVendorField(): boolean {
-        return true;
-    }
-
     public async throwIfCannotEnterPool(transaction: Interfaces.ITransaction): Promise<void> {
         Utils.assert.defined<string>(transaction.data.recipientId);
         const recipientId: string = transaction.data.recipientId;

--- a/packages/crypto/src/errors.ts
+++ b/packages/crypto/src/errors.ts
@@ -106,9 +106,9 @@ export class MaximumTransferCountExceededError extends CryptoError {
     }
 }
 
-export class VendorFieldLengthExceededError extends CryptoError {
+export class MemoLengthExceededError extends CryptoError {
     public constructor(limit: number) {
-        super(`Length of vendor field exceeded the allowed maximum ${limit}`);
+        super(`Length of memo exceeded the allowed maximum ${limit}`);
     }
 }
 

--- a/packages/crypto/src/interfaces/transactions.ts
+++ b/packages/crypto/src/interfaces/transactions.ts
@@ -65,6 +65,7 @@ export interface ITransactionData {
     recipientId?: string;
 
     asset?: ITransactionAsset;
+    memo?: string;
     vendorField?: string;
 
     id?: string;
@@ -97,7 +98,7 @@ export interface ITransactionJson {
     recipientId?: string;
 
     asset?: ITransactionAsset;
-    vendorField?: string | undefined;
+    memo?: string | undefined;
 
     id?: string;
     signature?: string;
@@ -155,7 +156,7 @@ export interface IHtlcLock extends IHtlcLockAsset {
     amount: BigNumber;
     recipientId: string | undefined;
     timestamp: number;
-    vendorField: string | undefined;
+    memo: string | undefined;
 }
 
 export type IHtlcLocks = Record<string, IHtlcLock>;

--- a/packages/crypto/src/networks/testnet/milestones.json
+++ b/packages/crypto/src/networks/testnet/milestones.json
@@ -55,8 +55,7 @@
             "maximum": 256,
             "minimum": 2
         },
-        "reward": 0,
-        "vendorFieldLength": 255
+        "reward": 0
     },
     {
         "height": 478,

--- a/packages/crypto/src/transactions/builders/transactions/core/htlc-lock.ts
+++ b/packages/crypto/src/transactions/builders/transactions/core/htlc-lock.ts
@@ -12,7 +12,7 @@ export class HtlcLockBuilder extends TransactionBuilder<HtlcLockBuilder> {
         this.data.recipientId = undefined;
         this.data.amount = BigNumber.ZERO;
         this.data.fee = Core.HtlcLockTransaction.staticFee();
-        this.data.vendorField = undefined;
+        this.data.memo = undefined;
         this.data.asset = {};
     }
 

--- a/packages/crypto/src/transactions/builders/transactions/core/ipfs.ts
+++ b/packages/crypto/src/transactions/builders/transactions/core/ipfs.ts
@@ -9,7 +9,7 @@ export class IPFSBuilder extends TransactionBuilder<IPFSBuilder> {
         this.data.type = Core.IpfsTransaction.type;
         this.data.typeGroup = Core.IpfsTransaction.typeGroup;
         this.data.fee = Core.IpfsTransaction.staticFee();
-        this.data.vendorField = undefined;
+        this.data.memo = undefined;
         this.data.asset = {};
     }
 

--- a/packages/crypto/src/transactions/builders/transactions/core/transfer.ts
+++ b/packages/crypto/src/transactions/builders/transactions/core/transfer.ts
@@ -12,7 +12,7 @@ export class TransferBuilder extends TransactionBuilder<TransferBuilder> {
         this.data.type = Core.TransferTransaction.type;
         this.data.typeGroup = Core.TransferTransaction.typeGroup;
         this.data.fee = Core.TransferTransaction.staticFee();
-        this.data.vendorField = undefined;
+        this.data.memo = undefined;
         this.data.asset = {
             transfers: [],
         };

--- a/packages/crypto/src/transactions/deserialiser.ts
+++ b/packages/crypto/src/transactions/deserialiser.ts
@@ -15,7 +15,7 @@ export class Deserialiser {
         this.deserialiseCommon(data, buff);
 
         const instance: ITransaction = TransactionTypeFactory.create(data);
-        this.deserialiseVendorField(instance, buff);
+        this.deserialiseMemo(instance, buff);
 
         // Deserialise type specific parts
         instance.deserialise(buff);
@@ -52,11 +52,11 @@ export class Deserialiser {
         transaction.fee = BigNumber.make(buf.readBigUInt64LE().toString());
     }
 
-    private static deserialiseVendorField(transaction: ITransaction, buf: ByteBuffer): void {
-        const vendorFieldLength: number = buf.readUInt8();
-        if (vendorFieldLength > 0) {
-            const vendorFieldBuffer: Buffer = buf.readBuffer(vendorFieldLength);
-            transaction.data.vendorField = vendorFieldBuffer.toString("utf8");
+    private static deserialiseMemo(transaction: ITransaction, buf: ByteBuffer): void {
+        const memoLength: number = buf.readUInt8();
+        if (memoLength > 0) {
+            const memoBuffer: Buffer = buf.readBuffer(memoLength);
+            transaction.data.memo = memoBuffer.toString("utf8");
         }
     }
 

--- a/packages/crypto/src/transactions/factory.ts
+++ b/packages/crypto/src/transactions/factory.ts
@@ -64,6 +64,11 @@ export class TransactionFactory {
                 data.asset.transfers = data.asset.payments;
                 delete data.asset.payments;
             }
+
+            if (data.vendorField) {
+                data.memo = data.vendorField;
+                delete data.vendorField;
+            }
         }
 
         const { value, error } = Verifier.verifySchema(data, strict);

--- a/packages/crypto/src/transactions/serialiser.ts
+++ b/packages/crypto/src/transactions/serialiser.ts
@@ -32,7 +32,7 @@ export class Serialiser {
         const buff: ByteBuffer = new ByteBuffer(Buffer.alloc(size));
 
         this.serialiseCommon(transaction.data, buff);
-        this.serialiseVendorField(transaction, buff);
+        this.serialiseMemo(transaction, buff);
 
         const serialised: ByteBuffer | undefined = transaction.serialise(options);
 
@@ -73,13 +73,13 @@ export class Serialiser {
         buff.writeBigInt64LE(transaction.fee.toBigInt());
     }
 
-    private static serialiseVendorField(transaction: ITransaction, buff: ByteBuffer): void {
+    private static serialiseMemo(transaction: ITransaction, buff: ByteBuffer): void {
         const { data }: ITransaction = transaction;
 
-        if (data.vendorField) {
-            const vf: Buffer = Buffer.from(data.vendorField, "utf8");
-            buff.writeUInt8(vf.length);
-            buff.writeBuffer(vf);
+        if (data.memo) {
+            const memo: Buffer = Buffer.from(data.memo, "utf8");
+            buff.writeUInt8(memo.length);
+            buff.writeBuffer(memo);
         } else {
             buff.writeUInt8(0x00);
         }

--- a/packages/crypto/src/transactions/types/schemas.ts
+++ b/packages/crypto/src/transactions/types/schemas.ts
@@ -27,7 +27,7 @@ export const transactionBaseSchema: Record<string, any> = {
         fee: { bignumber: { minimum: 0, bypassGenesis: true } },
         burnedFee: { bignumber: { minimum: 0 } },
         senderPublicKey: { $ref: "publicKey" },
-        vendorField: { anyOf: [{ type: "null" }, { type: "string", format: "vendorField" }] },
+        memo: { anyOf: [{ type: "null" }, { type: "string", format: "memo" }] },
         signature: { allOf: [{ minLength: 128, maxLength: 128 }, { $ref: "hex" }] },
         secondSignature: { allOf: [{ minLength: 128, maxLength: 128 }, { $ref: "hex" }] },
         signSignature: { allOf: [{ minLength: 128, maxLength: 128 }, { $ref: "hex" }] },

--- a/packages/crypto/src/utils/index.ts
+++ b/packages/crypto/src/utils/index.ts
@@ -95,8 +95,6 @@ export const numberToHex = (num: number, padding = 2): string => {
     return "0".repeat(padding - indexHex.length) + indexHex;
 };
 
-export const maxVendorFieldLength = (height?: number): number => configManager.getMilestone(height).vendorFieldLength;
-
 export const isSupportedTransactionVersion = (version: number): boolean => {
     const { acceptLegacySchnorrTransactions, bip340 } = configManager.getMilestone();
 

--- a/packages/crypto/src/validation/formats.ts
+++ b/packages/crypto/src/validation/formats.ts
@@ -1,11 +1,11 @@
 import { Ajv } from "ajv";
 
-import { isValidPeer, maxVendorFieldLength } from "../utils";
+import { isValidPeer } from "../utils";
 
-const vendorField = (ajv: Ajv): void => {
-    ajv.addFormat("vendorField", (data) => {
+const memo = (ajv: Ajv): void => {
+    ajv.addFormat("memo", (data) => {
         try {
-            return Buffer.from(data, "utf8").length <= maxVendorFieldLength();
+            return Buffer.from(data, "utf8").length <= 255;
         } catch {
             return false;
         }
@@ -22,4 +22,4 @@ const validPeer = (ajv: Ajv): void => {
     });
 };
 
-export const formats = [vendorField, validPeer];
+export const formats = [memo, validPeer];

--- a/plugins/sxp-swap/src/errors.ts
+++ b/plugins/sxp-swap/src/errors.ts
@@ -7,6 +7,12 @@ export class ApiCommunicationError extends Error {
     }
 }
 
+export class MemoIncorrectError extends Error {
+    public constructor() {
+        super("The memo of the transaction from the swap source wallet must adhere to the correct format");
+    }
+}
+
 export class InvalidSignatureError extends Error {
     public constructor() {
         super("The swap transaction signature is invalid");
@@ -74,12 +80,6 @@ export class UnknownSwapNetworkError extends Error {
         super(
             `The network of this swap transaction (${network}) does not correspond to any recognised network (${supportedNetworks.join(", ")})`
         );
-    }
-}
-
-export class VendorFieldIncorrectError extends Error {
-    public constructor() {
-        super("The vendor field of the transaction from the swap source wallet must adhere to the correct format");
     }
 }
 


### PR DESCRIPTION
This PR renames `vendorField` to `memo` throughout Core and changes `vendor_field` to `memo` in the database too.

This is because the terms "vendorfield" and "smartbridge" were seemingly confusing for a lot of people who thought they were buzzwords without any real meaning. We are therefore going to go forward with the term `memo` which has already been adopted in the industry.

The transaction builders have also been updated to use `memo()` to set a memo, but will continue to accept `vendorField()` for the time being to assist with script and tool migration, although it is now deprecated and will be dropped in a later version of Core.