### PR TITLE
feat: temporary and permanent delegate resignation

### DIFF
--- a/packages/core-api/src/resources-new/delegate.ts
+++ b/packages/core-api/src/resources-new/delegate.ts
@@ -17,6 +17,7 @@ export type DelegateResource = {
     voters: number;
     rank: number;
     isResigned: boolean;
+    resignationType: string | undefined;
     blocks: {
         produced: number;
         last: string | undefined;
@@ -42,6 +43,7 @@ export const delegateCriteriaSchemaObject = {
     voters: Schemas.createRangeCriteriaSchema(Joi.number().integer().min(0)),
     rank: Schemas.createRangeCriteriaSchema(Joi.number().integer().min(1)),
     isResigned: Joi.boolean(),
+    resignationType: Joi.string().valid("permanent", "temporary"),
     blocks: {
         produced: Schemas.createRangeCriteriaSchema(Joi.number().integer().min(0)),
         last: {

--- a/packages/core-api/src/services/delegate-search-service.ts
+++ b/packages/core-api/src/services/delegate-search-service.ts
@@ -1,5 +1,5 @@
 import { Container, Contracts, Services, Utils as AppUtils } from "@solar-network/core-kernel";
-import { Managers } from "@solar-network/crypto";
+import { Enums, Managers } from "@solar-network/crypto";
 import { Semver } from "@solar-network/utils";
 
 import { DelegateCriteria, DelegateResource } from "../resources-new";
@@ -57,6 +57,14 @@ export class DelegateSearchService {
             wallet.setAttribute("delegate.version", this.app.version());
         }
 
+        let resignationType: string | undefined = undefined;
+
+        if (delegateAttribute.resigned === Enums.DelegateStatus.PermanentResign) {
+            resignationType = "permanent";
+        } else if (delegateAttribute.resigned === Enums.DelegateStatus.TemporaryResign) {
+            resignationType = "temporary";
+        }
+
         return {
             username: delegateAttribute.username,
             address: wallet.getAddress(),
@@ -64,7 +72,8 @@ export class DelegateSearchService {
             votes: delegateAttribute.voteBalance,
             voters: delegateAttribute.voters,
             rank: delegateAttribute.rank,
-            isResigned: !!delegateAttribute.resigned,
+            isResigned: delegateAttribute.resigned !== undefined,
+            resignationType,
             blocks: {
                 produced: delegateAttribute.producedBlocks,
                 last: delegateAttribute.lastBlock,

--- a/packages/core-api/src/services/wallet-search-service.ts
+++ b/packages/core-api/src/services/wallet-search-service.ts
@@ -1,5 +1,5 @@
-import { Container, Contracts, Services } from "@solar-network/core-kernel";
-import { Identities } from "@solar-network/crypto";
+import { Container, Contracts, Services, Utils } from "@solar-network/core-kernel";
+import { Enums, Identities } from "@solar-network/crypto";
 
 import { WalletCriteria, WalletResource } from "../resources-new";
 
@@ -62,12 +62,29 @@ export class WalletSearchService {
     }
 
     private getWalletResourceFromWallet(wallet: Contracts.State.Wallet): WalletResource {
+        const attributes: Record<string, any> = Utils.cloneDeep(wallet.getAttributes());
+
+        let resigned: string | undefined = undefined;
+        if (wallet.hasAttribute("delegate.resigned")) {
+            switch (wallet.getAttribute("delegate.resigned")) {
+                case Enums.DelegateStatus.PermanentResign: {
+                    resigned = "permanent";
+                    break;
+                }
+                case Enums.DelegateStatus.TemporaryResign: {
+                    resigned = "temporary";
+                    break;
+                }
+            }
+            attributes.delegate.resigned = resigned;
+        }
+
         return {
             address: wallet.getAddress(),
             publicKey: wallet.getPublicKey(),
             balance: wallet.getBalance(),
             nonce: wallet.getNonce(),
-            attributes: { ...wallet.getAttributes(), votes: undefined },
+            attributes: { ...attributes, votes: undefined },
             votingFor: wallet.getVoteDistribution(),
         };
     }

--- a/packages/core-api/src/www/api.json
+++ b/packages/core-api/src/www/api.json
@@ -644,6 +644,17 @@
                         }
                     },
                     {
+                        "name": "resignationType",
+                        "in": "query",
+                        "description": "Whether the delegate(s) to be returned have resigned permanently or temporarily",
+                        "schema": {
+                            "enum": [
+                                "permanent",
+                                "temporary"
+                            ]
+                        }
+                    },
+                    {
                         "name": "production.approval",
                         "in": "query",
                         "description": "Exact production approval rate of the delegate(s) to be returned",

--- a/packages/core-transactions/src/errors.ts
+++ b/packages/core-transactions/src/errors.ts
@@ -117,15 +117,21 @@ export class InvalidSecondSignatureError extends TransactionError {
     }
 }
 
+export class IrrevocableResignationError extends TransactionError {
+    public constructor() {
+        super("Failed to apply transaction, because the wallet permanently resigned as a delegate");
+    }
+}
+
 export class WalletAlreadyPermanentlyResignedError extends TransactionError {
     public constructor() {
-        super("Failed to apply transaction, because the wallet already permanently resigned as delegate");
+        super("Failed to apply transaction, because the wallet already permanently resigned as a delegate");
     }
 }
 
 export class WalletAlreadyTemporarilyResignedError extends TransactionError {
     public constructor() {
-        super("Failed to apply transaction, because the wallet already temporarily resigned as delegate");
+        super("Failed to apply transaction, because the wallet already temporarily resigned as a delegate");
     }
 }
 
@@ -137,7 +143,7 @@ export class WalletNotADelegateError extends TransactionError {
 
 export class WalletNotResignedError extends TransactionError {
     public constructor() {
-        super(`Failed to apply transaction, because the wallet has not resigned as delegate`);
+        super(`Failed to apply transaction, because the wallet has not resigned as a delegate`);
     }
 }
 

--- a/packages/core-transactions/src/errors.ts
+++ b/packages/core-transactions/src/errors.ts
@@ -1,4 +1,4 @@
-import { Contracts } from "@solar-network/core-kernel";
+import { Contracts, Utils as AppUtils } from "@solar-network/core-kernel";
 import { Transactions, Utils } from "@solar-network/crypto";
 
 export class TransactionError extends Error {
@@ -117,15 +117,27 @@ export class InvalidSecondSignatureError extends TransactionError {
     }
 }
 
-export class WalletAlreadyResignedError extends TransactionError {
+export class WalletAlreadyPermanentlyResignedError extends TransactionError {
     public constructor() {
-        super("Failed to apply transaction, because the wallet already resigned as a delegate");
+        super("Failed to apply transaction, because the wallet already permanently resigned as delegate");
+    }
+}
+
+export class WalletAlreadyTemporarilyResignedError extends TransactionError {
+    public constructor() {
+        super("Failed to apply transaction, because the wallet already temporarily resigned as delegate");
     }
 }
 
 export class WalletNotADelegateError extends TransactionError {
     public constructor() {
         super("Failed to apply transaction, because the wallet is not a delegate");
+    }
+}
+
+export class WalletNotResignedError extends TransactionError {
+    public constructor() {
+        super(`Failed to apply transaction, because the wallet has not resigned as delegate`);
     }
 }
 
@@ -239,5 +251,23 @@ export class HtlcLockNotExpiredError extends TransactionError {
 export class HtlcLockExpiredError extends TransactionError {
     public constructor() {
         super("Failed to apply transaction, because the associated HTLC lock transaction expired");
+    }
+}
+
+export class NotEnoughTimeSinceResignationError extends TransactionError {
+    public constructor(blocks: number) {
+        super(
+            `Failed to apply transaction, because ${AppUtils.pluralise(
+                "more block",
+                blocks,
+                true,
+            )} must be produced before the resignation can be revoked`,
+        );
+    }
+}
+
+export class ResignationTypeAssetMilestoneNotActiveError extends TransactionError {
+    public constructor() {
+        super("Failed to apply transaction, because different delegate resignation types are not enabled");
     }
 }

--- a/packages/core-transactions/src/handlers/core/delegate-registration.ts
+++ b/packages/core-transactions/src/handlers/core/delegate-registration.ts
@@ -1,5 +1,5 @@
 import { Container, Contracts, Enums as AppEnums, Utils as AppUtils } from "@solar-network/core-kernel";
-import { Identities, Interfaces, Transactions, Utils } from "@solar-network/crypto";
+import { Enums, Identities, Interfaces, Transactions, Utils } from "@solar-network/crypto";
 
 import {
     NotSupportedForMultiSignatureWalletError,
@@ -68,6 +68,11 @@ export class DelegateRegistrationTransactionHandler extends TransactionHandler {
                 voters: 0,
             });
 
+            wallet.initialiseStateHistory("delegateStatus");
+            wallet.addStateHistory("delegateStatus", {
+                height: transaction.blockHeight,
+                type: Enums.DelegateStatus.NotResigned,
+            });
             this.walletRepository.index(wallet);
         }
 
@@ -192,6 +197,12 @@ export class DelegateRegistrationTransactionHandler extends TransactionHandler {
             voters: 0,
         });
 
+        sender.initialiseStateHistory("delegateStatus");
+        sender.addStateHistory("delegateStatus", {
+            height: transaction.data.blockHeight,
+            type: Enums.DelegateStatus.NotResigned,
+        });
+
         this.walletRepository.index(sender);
     }
 
@@ -203,6 +214,7 @@ export class DelegateRegistrationTransactionHandler extends TransactionHandler {
         const sender: Contracts.State.Wallet = this.walletRepository.findByPublicKey(transaction.data.senderPublicKey);
 
         sender.forgetAttribute("delegate");
+        sender.forgetStateHistory("delegateStatus");
 
         this.walletRepository.index(sender);
     }

--- a/packages/core-transactions/src/handlers/core/delegate-resignation.ts
+++ b/packages/core-transactions/src/handlers/core/delegate-resignation.ts
@@ -113,7 +113,7 @@ export class DelegateResignationTransactionHandler extends TransactionHandler {
             .allByUsername()
             .filter((w) => !w.hasAttribute("delegate.resigned")).length;
 
-        if (type !== Enums.DelegateStatus.NotResigned && currentDelegatesCount - 1 < requiredDelegatesCount) {
+        if (!wallet.hasAttribute("delegate.resigned") && currentDelegatesCount - 1 < requiredDelegatesCount) {
             throw new NotEnoughDelegatesError();
         }
 

--- a/packages/core-transactions/src/handlers/core/delegate-resignation.ts
+++ b/packages/core-transactions/src/handlers/core/delegate-resignation.ts
@@ -2,6 +2,7 @@ import { Container, Contracts, Enums as AppEnums, Utils as AppUtils } from "@sol
 import { Enums, Interfaces, Managers, Transactions, Utils } from "@solar-network/crypto";
 
 import {
+    IrrevocableResignationError,
     NotEnoughDelegatesError,
     NotEnoughTimeSinceResignationError,
     ResignationTypeAssetMilestoneNotActiveError,
@@ -88,7 +89,11 @@ export class DelegateResignationTransactionHandler extends TransactionHandler {
 
         if (wallet.hasAttribute("delegate.resigned")) {
             if (wallet.getAttribute("delegate.resigned") === Enums.DelegateStatus.PermanentResign) {
-                throw new WalletAlreadyPermanentlyResignedError();
+                if (type === Enums.DelegateStatus.PermanentResign) {
+                    throw new WalletAlreadyPermanentlyResignedError();
+                }
+
+                throw new IrrevocableResignationError();
             } else if (type === Enums.DelegateStatus.TemporaryResign) {
                 throw new WalletAlreadyTemporarilyResignedError();
             } else if (type === Enums.DelegateStatus.NotResigned) {

--- a/packages/core-transactions/src/handlers/core/delegate-resignation.ts
+++ b/packages/core-transactions/src/handlers/core/delegate-resignation.ts
@@ -113,7 +113,7 @@ export class DelegateResignationTransactionHandler extends TransactionHandler {
             .allByUsername()
             .filter((w) => !w.hasAttribute("delegate.resigned")).length;
 
-        if (currentDelegatesCount - 1 < requiredDelegatesCount) {
+        if (type !== Enums.DelegateStatus.NotResigned && currentDelegatesCount - 1 < requiredDelegatesCount) {
             throw new NotEnoughDelegatesError();
         }
 

--- a/packages/crypto/src/enums.ts
+++ b/packages/crypto/src/enums.ts
@@ -32,6 +32,12 @@ export enum TransactionTypeGroup {
     Reserved = 1000,
 }
 
+export enum DelegateStatus {
+    TemporaryResign = 0,
+    PermanentResign = 1,
+    NotResigned = 2,
+}
+
 export enum HtlcLockExpirationType {
     EpochTimestamp = 1,
     BlockHeight = 2,

--- a/packages/crypto/src/transactions/builders/transactions/core/delegate-resignation.ts
+++ b/packages/crypto/src/transactions/builders/transactions/core/delegate-resignation.ts
@@ -10,10 +10,20 @@ export class DelegateResignationBuilder extends TransactionBuilder<DelegateResig
         this.data.typeGroup = Core.DelegateResignationTransaction.typeGroup;
         this.data.fee = Core.DelegateResignationTransaction.staticFee();
         this.data.senderPublicKey = undefined;
+        this.data.asset = {};
+    }
+
+    public resignationTypeAsset(resignationTypeAsset: number): DelegateResignationBuilder {
+        this.data.asset = {
+            resignationType: resignationTypeAsset,
+        };
+
+        return this;
     }
 
     public getStruct(): ITransactionData {
         const struct: ITransactionData = super.getStruct();
+        struct.asset = this.data.asset;
 
         super.validate(struct);
         return struct;

--- a/packages/crypto/src/transactions/types/core/delegate-resignation.ts
+++ b/packages/crypto/src/transactions/types/core/delegate-resignation.ts
@@ -33,7 +33,7 @@ export abstract class DelegateResignationTransaction extends Transaction {
         const remainderLength: number = buf.getRemainderLength();
         if (
             (remainderLength <= 128 && remainderLength % 64 === 0) ||
-            (remainderLength >= 128 && remainderLength % 65 === 0)
+            (remainderLength >= 130 && remainderLength % 65 === 0)
         ) {
             return;
         }

--- a/packages/crypto/src/transactions/types/schemas.ts
+++ b/packages/crypto/src/transactions/types/schemas.ts
@@ -359,6 +359,13 @@ export const delegateResignation = extend(transactionBaseSchema, {
     properties: {
         type: { transactionType: TransactionType.Core.DelegateResignation },
         fee: { bignumber: { minimum: 0 } },
+        asset: {
+            type: "object",
+            required: ["resignationType"],
+            properties: {
+                resignationType: { enum: [0, 1, 2] },
+            },
+        },
     },
 });
 


### PR DESCRIPTION
This PR adds a `resignationType` asset to the existing delegate resignation transaction type to specify whether the resignation is temporary (0 or omitted; default), permanent (1) or being revoked (2).

Where no asset has been specified, it will default to temporary, which means - by intentional design - all existing resignations that occurred prior to the implementation of this PR will automatically become temporary, ergo potentially revocable. Delegates wishing to make them permanent can resubmit a (free) resignation transaction with the `resignationType` asset set to 1.

As the name suggests, only temporary resignations may be revoked, and revocation can only occur after a fixed period of blocks have been produced since the resignation transaction was sent. This is to reduce the potential for spam, to prevent delegates from temporarily resigning and immediately revoking the resignation in a loop.

The rationale behind temporary resignation is for cases where a delegate's server has exploded and they don't have a backup, so instead of being red for a bit they do the right thing and temporarily resign until they're up and running again. Of course in cases such as the leakage of a private key, the only sensible and reasonable course of action is permanent resignation.