### PR TITLE
refactor: unify delegate vote data in api

### DIFF
--- a/packages/core-api/src/resources-new/delegate.ts
+++ b/packages/core-api/src/resources-new/delegate.ts
@@ -12,17 +12,17 @@ export type DelegateResource = {
     username: string;
     address: string;
     publicKey: string;
-    votes: Utils.BigNumber;
-    voters: number;
+    votesReceived: {
+        percent: number;
+        votes: Utils.BigNumber;
+        voters: number;
+    };
     rank: number;
     isResigned: boolean;
     resignationType: string | undefined;
     blocks: {
         produced: number;
         last: string | undefined;
-    };
-    production: {
-        approval: number;
     };
     forged: {
         fees: Utils.BigNumber;
@@ -38,8 +38,11 @@ export const delegateCriteriaSchemaObject = {
     username: Joi.string().pattern(/^[a-z0-9!@$&_.]{1,20}$/),
     address: walletCriteriaSchemaObject.address,
     publicKey: walletCriteriaSchemaObject.publicKey,
-    votes: Schemas.createRangeCriteriaSchema(Schemas.nonNegativeBigNumber),
-    voters: Schemas.createRangeCriteriaSchema(Joi.number().integer().min(0)),
+    votesReceived: {
+        percent: Schemas.createRangeCriteriaSchema(Joi.number().min(0)),
+        votes: Schemas.createRangeCriteriaSchema(Schemas.nonNegativeBigNumber),
+        voters: Schemas.createRangeCriteriaSchema(Joi.number().integer().min(0)),
+    },
     rank: Schemas.createRangeCriteriaSchema(Joi.number().integer().min(1)),
     isResigned: Joi.boolean(),
     resignationType: Joi.string().valid("permanent", "temporary"),
@@ -54,9 +57,6 @@ export const delegateCriteriaSchemaObject = {
                 human: Joi.string(),
             },
         },
-    },
-    production: {
-        approval: Schemas.createRangeCriteriaSchema(Joi.number().min(0)),
     },
     forged: {
         burnedFees: Schemas.createRangeCriteriaSchema(Schemas.nonNegativeBigNumber),

--- a/packages/core-api/src/services/delegate-search-service.ts
+++ b/packages/core-api/src/services/delegate-search-service.ts
@@ -68,17 +68,17 @@ export class DelegateSearchService {
             username: delegateAttribute.username,
             address: wallet.getAddress(),
             publicKey: publicKey!,
-            votes: delegateAttribute.voteBalance,
-            voters: delegateAttribute.voters,
+            votesReceived: {
+                percent: AppUtils.delegateCalculator.calculateVotePercent(wallet, supply),
+                votes: delegateAttribute.voteBalance,
+                voters: delegateAttribute.voters,
+            },
             rank: delegateAttribute.rank,
             isResigned: delegateAttribute.resigned !== undefined,
             resignationType,
             blocks: {
                 produced: delegateAttribute.producedBlocks,
                 last: delegateAttribute.lastBlock,
-            },
-            production: {
-                approval: AppUtils.delegateCalculator.calculateApproval(wallet, supply),
             },
             forged: {
                 fees: delegateAttribute.forgedFees,

--- a/packages/core-api/src/www/api.json
+++ b/packages/core-api/src/www/api.json
@@ -655,36 +655,6 @@
                         }
                     },
                     {
-                        "name": "production.approval",
-                        "in": "query",
-                        "description": "Exact production approval rate of the delegate(s) to be returned",
-                        "schema": {
-                            "type": "number",
-                            "minimum": 0,
-                            "maximum": 1
-                        }
-                    },
-                    {
-                        "name": "production.approval.from",
-                        "in": "query",
-                        "description": "Lowest production approval rate of the delegate(s) to be returned",
-                        "schema": {
-                            "type": "number",
-                            "minimum": 0,
-                            "maximum": 1
-                        }
-                    },
-                    {
-                        "name": "production.approval.to",
-                        "in": "query",
-                        "description": "Highest production approval rate of the delegate(s) to be returned",
-                        "schema": {
-                            "type": "number",
-                            "minimum": 0,
-                            "maximum": 1
-                        }
-                    },
-                    {
                         "name": "forged.fees",
                         "in": "query",
                         "description": "Exact amount, in satoshis, of all fees forged by the delegate(s) to be returned",
@@ -804,7 +774,37 @@
                         }
                     },
                     {
-                        "name": "votes",
+                        "name": "votesReceived.percent",
+                        "in": "query",
+                        "description": "Exact total vote percentage of the delegate(s) to be returned",
+                        "schema": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 1
+                        }
+                    },
+                    {
+                        "name": "votesReceived.percent.from",
+                        "in": "query",
+                        "description": "Minimum total vote percentage of the delegate(s) to be returned",
+                        "schema": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 1
+                        }
+                    },
+                    {
+                        "name": "votesReceived.percent.to",
+                        "in": "query",
+                        "description": "Maximum total vote percentage rate of the delegate(s) to be returned",
+                        "schema": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 1
+                        }
+                    },
+                    {
+                        "name": "votesReceived.votes",
                         "in": "query",
                         "description": "Exact amount of vote weight for the delegate(s) to be returned",
                         "schema": {
@@ -812,7 +812,7 @@
                         }
                     },
                     {
-                        "name": "votes.from",
+                        "name": "votesReceived.votes.from",
                         "in": "query",
                         "description": "Minimum amount of vote weight for the delegate(s) to be returned",
                         "schema": {
@@ -820,7 +820,7 @@
                         }
                     },
                     {
-                        "name": "votes.to",
+                        "name": "votesReceived.votes.to",
                         "in": "query",
                         "description": "Maximum amount of vote weight for the delegate(s) to be returned",
                         "schema": {
@@ -828,7 +828,7 @@
                         }
                     },
                     {
-                        "name": "voters",
+                        "name": "votesReceived.voters",
                         "in": "query",
                         "description": "Exact number of voters for the delegate(s) to be returned",
                         "schema": {
@@ -836,7 +836,7 @@
                         }
                     },
                     {
-                        "name": "voters.from",
+                        "name": "votesReceived.voters.from",
                         "in": "query",
                         "description": "Minimum number of voters for the delegate(s) to be returned",
                         "schema": {
@@ -844,7 +844,7 @@
                         }
                     },
                     {
-                        "name": "voters.to",
+                        "name": "votesReceived.voters.to",
                         "in": "query",
                         "description": "Maximum number of voters for the delegate(s) to be returned",
                         "schema": {
@@ -946,18 +946,18 @@
                                 "forged.total:desc",
                                 "isResigned:asc",
                                 "isResigned:desc",
-                                "production.approval:asc",
-                                "production.approval:desc",
                                 "publicKey:asc",
                                 "publicKey:desc",
                                 "rank:asc",
                                 "rank:desc",
                                 "version:asc",
                                 "version:desc",
-                                "votes:asc",
-                                "votes:desc",
-                                "voters:asc",
-                                "voters:desc"
+                                "votesReceived.percent:asc",
+                                "votesReceived.percent:desc",
+                                "votesReceived.votes:asc",
+                                "votesReceived.votes:desc",
+                                "votesReceived.voters:asc",
+                                "votesReceived.voters:desc"
                             ]
                         }
                     }

--- a/packages/core-kernel/src/utils/delegate-calculator.ts
+++ b/packages/core-kernel/src/utils/delegate-calculator.ts
@@ -12,7 +12,7 @@ const toDecimal = (voteBalance: Utils.BigNumber, totalSupply: Utils.BigNumber): 
     return +div.toFixed(2);
 };
 
-export const calculateApproval = (delegate: Wallet, supply: string): number => {
+export const calculateVotePercent = (delegate: Wallet, supply: string): number => {
     const totalSupply: Utils.BigNumber = Utils.BigNumber.make(supply);
     const voteBalance: Utils.BigNumber = delegate.getAttribute("delegate.voteBalance");
 

--- a/packages/core-kernel/src/utils/index.ts
+++ b/packages/core-kernel/src/utils/index.ts
@@ -1,5 +1,5 @@
 import { calculateForgingInfo } from "./calculate-forging-info";
-import { calculateApproval, calculateForgedTotal } from "./delegate-calculator";
+import { calculateForgedTotal, calculateVotePercent } from "./delegate-calculator";
 import { calculateLockExpirationStatus } from "./expiration-calculator";
 import { formatSeconds } from "./format-seconds";
 import { formatTimestamp } from "./format-timestamp";
@@ -209,7 +209,7 @@ export * from "./words";
 export * from "./zip-object";
 export { immutable };
 
-export const delegateCalculator = { calculateApproval, calculateForgedTotal };
+export const delegateCalculator = { calculateForgedTotal, calculateVotePercent };
 export const expirationCalculator = { calculateLockExpirationStatus };
 export const roundCalculator = { calculateRound, isNewRound };
 export const supplyCalculator = { calculate };

--- a/packages/core-transactions/src/handlers/core/delegate-registration.ts
+++ b/packages/core-transactions/src/handlers/core/delegate-registration.ts
@@ -22,7 +22,6 @@ export class DelegateRegistrationTransactionHandler extends TransactionHandler {
 
     public walletAttributes(): ReadonlyArray<string> {
         return [
-            "delegate.approval", // Used by the API
             "delegate.forgedFees", // Used by the API
             "delegate.burnedFees", // Used by the API
             "delegate.forgedRewards", // Used by the API


### PR DESCRIPTION
Previously, the vote statistics on the `/delegates` and `/delegates/{id}` API endpoints were fragmented across separate top-level and nested properties (`votes`, `voters` and `production.approval`). The latter was especially not very obvious what the information actually meant, and could give rise to confusion from users perhaps thinking that it reflected the number of blocks a delegate had produced that the network had somehow approved. In fact, it is just the percentage of total available votes the delegate has received.

This PR changes this so there is a single property, `votesReceived` with the following properties inside it: `votesReceived.percent`, `votesReceived.votes` and `votesReceived.voters`.

Previously (some irrelevant properties removed for brevity):

```
{"username":"gym","address":"DGymbo8YN2RJoa72ZJTkLfZTrh7LCTwFnx","votes":"161657381994390","voters":9,"rank":1,"production":{"approval":0.3}}
```

Now (with the same irrelevant properties removed for brevity):

```
{"username":"gym","address":"DGymbo8YN2RJoa72ZJTkLfZTrh7LCTwFnx","votesReceived":{"percent":0.3,"votes":"161658066291265","voters":9},"rank":1}
```