### PR TITLE
fix: prevent wallet repository pollution

### DIFF
--- a/packages/api/src/services/delegate-search-service.ts
+++ b/packages/api/src/services/delegate-search-service.ts
@@ -19,6 +19,10 @@ export class DelegateSearchService {
     private readonly paginationService!: Services.Search.PaginationService;
 
     public getDelegate(walletAddress: string): DelegateResource | undefined {
+        if (!this.walletRepository.hasByAddress(walletAddress)) {
+            return undefined;
+        }
+
         const wallet = this.walletRepository.findByAddress(walletAddress);
         const supply: string = AppUtils.supplyCalculator.calculate(this.walletRepository.allByAddress());
         const ourKeys: string[] = AppUtils.getForgerDelegates();

--- a/packages/api/src/services/lock-search-service.ts
+++ b/packages/api/src/services/lock-search-service.ts
@@ -87,6 +87,10 @@ export class LockSearchService {
     }
 
     private *getWalletLocks(walletAddress: string, ...criterias: LockCriteria[]): Iterable<LockResource> {
+        if (!this.walletRepository.hasByAddress(walletAddress)) {
+            return undefined;
+        }
+
         const wallet = this.walletRepository.findByAddress(walletAddress);
         const locksAttribute = wallet.getAttribute<Interfaces.IHtlcLocks>("htlc.locks", {});
 

--- a/packages/blockchain/src/processor/block-processor.ts
+++ b/packages/blockchain/src/processor/block-processor.ts
@@ -205,6 +205,25 @@ export class BlockProcessor {
     }
 
     private async validateGenerator(block: Interfaces.IBlock): Promise<boolean> {
+        const walletRepository = this.app.getTagged<Contracts.State.WalletRepository>(
+            Container.Identifiers.WalletRepository,
+            "state",
+            "blockchain",
+        );
+
+        if (!walletRepository.hasByPublicKey(block.data.generatorPublicKey)) {
+            return false;
+        }
+
+        const generatorWallet: Contracts.State.Wallet = walletRepository.findByPublicKey(block.data.generatorPublicKey);
+
+        let generatorUsername: string;
+        try {
+            generatorUsername = generatorWallet.getAttribute("delegate.username");
+        } catch {
+            return false;
+        }
+
         const blockTimeLookup = await AppUtils.forgingInfoCalculator.getBlockTimeLookup(this.app, block.data.height);
 
         const roundInfo: Contracts.Shared.RoundInfo = AppUtils.roundCalculator.calculateRound(block.data.height);
@@ -219,20 +238,6 @@ export class BlockProcessor {
         );
 
         const forgingDelegate: Contracts.State.Wallet = delegates[forgingInfo.currentForger];
-
-        const walletRepository = this.app.getTagged<Contracts.State.WalletRepository>(
-            Container.Identifiers.WalletRepository,
-            "state",
-            "blockchain",
-        );
-        const generatorWallet: Contracts.State.Wallet = walletRepository.findByPublicKey(block.data.generatorPublicKey);
-
-        let generatorUsername: string;
-        try {
-            generatorUsername = generatorWallet.getAttribute("delegate.username");
-        } catch {
-            return false;
-        }
 
         if (!forgingDelegate) {
             this.logger.debug(

--- a/packages/blockchain/src/state-machine/actions/check-later.ts
+++ b/packages/blockchain/src/state-machine/actions/check-later.ts
@@ -97,7 +97,10 @@ export class CheckLater implements Action {
                             .getLastBlock();
                         blocks = blocks.filter((block) => block.height > lastBlock.data.height);
                         if (blocks.length) {
-                            if (blocks.length === 1) {
+                            if (
+                                blocks.length === 1 &&
+                                this.walletRepository.hasByPublicKey(blocks[0].generatorPublicKey)
+                            ) {
                                 const generatorWallet: Contracts.State.Wallet = this.walletRepository.findByPublicKey(
                                     blocks[0].generatorPublicKey,
                                 );

--- a/packages/database/src/transaction-filter.ts
+++ b/packages/database/src/transaction-filter.ts
@@ -113,13 +113,15 @@ export class TransactionFilter implements Contracts.Database.TransactionFilter {
     private async handleSenderIdCriteria(
         criteria: Contracts.Search.EqualCriteria<string>,
     ): Promise<Contracts.Search.Expression<Transaction>> {
-        const senderWallet = this.walletRepository.findByAddress(criteria);
+        if (this.walletRepository.hasByAddress(criteria)) {
+            const senderWallet = this.walletRepository.findByAddress(criteria);
 
-        if (senderWallet && senderWallet.getPublicKey()) {
-            return { op: "equal", property: "senderPublicKey", value: senderWallet.getPublicKey() };
-        } else {
-            return { op: "false" };
+            if (senderWallet && senderWallet.getPublicKey()) {
+                return { op: "equal", property: "senderPublicKey", value: senderWallet.getPublicKey() };
+            }
         }
+
+        return { op: "false" };
     }
 
     private async handleRecipientIdCriteria(
@@ -140,27 +142,28 @@ export class TransactionFilter implements Contracts.Database.TransactionFilter {
             ],
         };
 
-        const recipientWallet = this.walletRepository.findByAddress(criteria);
-        if (recipientWallet && recipientWallet.getPublicKey()) {
-            const delegateRegistrationExpression: Contracts.Search.AndExpression<Transaction> = {
-                op: "and",
-                expressions: [
-                    { op: "equal", property: "typeGroup", value: Enums.TransactionTypeGroup.Core },
-                    { op: "equal", property: "type", value: Enums.TransactionType.Core.DelegateRegistration },
-                    { op: "equal", property: "senderPublicKey", value: recipientWallet.getPublicKey() },
-                ],
-            };
+        if (this.walletRepository.hasByAddress(criteria)) {
+            const recipientWallet = this.walletRepository.findByAddress(criteria);
+            if (recipientWallet && recipientWallet.getPublicKey()) {
+                const delegateRegistrationExpression: Contracts.Search.AndExpression<Transaction> = {
+                    op: "and",
+                    expressions: [
+                        { op: "equal", property: "typeGroup", value: Enums.TransactionTypeGroup.Core },
+                        { op: "equal", property: "type", value: Enums.TransactionType.Core.DelegateRegistration },
+                        { op: "equal", property: "senderPublicKey", value: recipientWallet.getPublicKey() },
+                    ],
+                };
 
-            return {
-                op: "or",
-                expressions: [recipientIdExpression, transferRecipientIdExpression, delegateRegistrationExpression],
-            };
-        } else {
-            return {
-                op: "or",
-                expressions: [recipientIdExpression, transferRecipientIdExpression],
-            };
+                return {
+                    op: "or",
+                    expressions: [recipientIdExpression, transferRecipientIdExpression, delegateRegistrationExpression],
+                };
+            }
         }
+        return {
+            op: "or",
+            expressions: [recipientIdExpression, transferRecipientIdExpression],
+        };
     }
 
     private async handleAssetCriteria(

--- a/packages/kernel/src/contracts/p2p/network-monitor.ts
+++ b/packages/kernel/src/contracts/p2p/network-monitor.ts
@@ -32,7 +32,7 @@ export interface NetworkMonitor {
     }): Promise<void>;
     discoverPeers(pingAll?: boolean, addAll?: boolean, silent?: boolean): Promise<boolean>;
     getAllDelegates(): Promise<string[]>;
-    getDelegateName(publicKey: string): string;
+    getDelegateName(publicKey: string): string | undefined;
     getNetworkHeight(): number;
     getNetworkState(log?: boolean): Promise<NetworkState>;
     refreshPeersAfterFork(): Promise<void>;

--- a/packages/p2p/src/network-monitor.ts
+++ b/packages/p2p/src/network-monitor.ts
@@ -456,8 +456,11 @@ export class NetworkMonitor implements Contracts.P2P.NetworkMonitor {
         ).map((wallet) => wallet.getAttribute("delegate.username"));
     }
 
-    public getDelegateName(publicKey: string): string {
-        return this.walletRepository.findByPublicKey(publicKey).getAttribute("delegate.username");
+    public getDelegateName(publicKey: string): string | undefined {
+        if (this.walletRepository.hasByPublicKey(publicKey)) {
+            return this.walletRepository.findByPublicKey(publicKey).getAttribute("delegate.username");
+        }
+        return undefined;
     }
 
     public async checkForFork(): Promise<number> {

--- a/packages/p2p/src/network-state.ts
+++ b/packages/p2p/src/network-state.ts
@@ -264,7 +264,7 @@ export class NetworkState implements Contracts.P2P.NetworkState {
 
     private addToList(hasQuorum: boolean, peer: Contracts.P2P.Peer, monitor: Contracts.P2P.NetworkMonitor): void {
         this.quorumDetails.delegates[hasQuorum ? "hasQuorum" : "noQuorum"].push(
-            ...peer.publicKeys.map((publicKey) => monitor.getDelegateName(publicKey)),
+            ...peer.publicKeys.map((publicKey) => monitor.getDelegateName(publicKey)!),
         );
     }
 

--- a/packages/p2p/src/peer-communicator.ts
+++ b/packages/p2p/src/peer-communicator.ts
@@ -224,26 +224,28 @@ export class PeerCommunicator implements Contracts.P2P.PeerCommunicator {
                         ) {
                             break;
                         }
-                        const delegateWallet = this.walletRepository.findByPublicKey(publicKey);
-
-                        if (!delegatePeer) {
-                            peer.publicKeys.push(publicKey);
-                            delegateWallet.setAttribute("delegate.version", pingResponse.config.version);
-                        } else if (!peer.isForked()) {
-                            if (
-                                delegatePeer.isForked() ||
-                                (peer.state.header.height === lastBlock.data.height &&
-                                    peer.state.header.id === lastBlock.data.id) ||
-                                (peer.state.header.height >= delegatePeer.state.header.height &&
-                                    delegatePeer.state.header.id !== lastBlock.data.id)
-                            ) {
+                        if (this.walletRepository.hasByPublicKey(publicKey)) {
+                            const delegateWallet = this.walletRepository.findByPublicKey(publicKey);
+                            if (!delegatePeer) {
                                 peer.publicKeys.push(publicKey);
                                 delegateWallet.setAttribute("delegate.version", pingResponse.config.version);
-                                delegatePeer.publicKeys = delegatePeer.publicKeys.filter(
-                                    (peerPublicKey) => peerPublicKey !== publicKey,
-                                );
+                            } else if (!peer.isForked()) {
+                                if (
+                                    delegatePeer.isForked() ||
+                                    (peer.state.header.height === lastBlock.data.height &&
+                                        peer.state.header.id === lastBlock.data.id) ||
+                                    (peer.state.header.height >= delegatePeer.state.header.height &&
+                                        delegatePeer.state.header.id !== lastBlock.data.id)
+                                ) {
+                                    peer.publicKeys.push(publicKey);
+                                    delegateWallet.setAttribute("delegate.version", pingResponse.config.version);
+                                    delegatePeer.publicKeys = delegatePeer.publicKeys.filter(
+                                        (peerPublicKey) => peerPublicKey !== publicKey,
+                                    );
+                                }
                             }
                         }
+
                         alreadyCheckedSignatures.push(publicKey + signature);
                     }
                 }

--- a/packages/p2p/src/socket-server/controllers/blocks.ts
+++ b/packages/p2p/src/socket-server/controllers/blocks.ts
@@ -78,6 +78,10 @@ export class BlocksController extends Controller {
             transactions: deserialised.transactions.map((tx) => tx.data),
         };
 
+        if (!this.walletRepository.hasByPublicKey(block.generatorPublicKey)) {
+            return { status: false, height: this.blockchain.getLastHeight() };
+        }
+
         const generatorWallet: Contracts.State.Wallet = this.walletRepository.findByPublicKey(block.generatorPublicKey);
 
         let generator: string;

--- a/packages/p2p/src/socket-server/controllers/internal.ts
+++ b/packages/p2p/src/socket-server/controllers/internal.ts
@@ -56,12 +56,14 @@ export class InternalController extends Controller {
         const timestamp: number = Crypto.Slots.getTime();
         const forgingInfo = Utils.forgingInfoCalculator.calculateForgingInfo(timestamp, height, blockTimeLookup);
 
-        const { reward } = delegates[forgingInfo.currentForger]
-            ? await this.roundState.getRewardForBlockInRound(
-                  height,
-                  this.walletRepository.findByPublicKey(delegates[forgingInfo.currentForger].publicKey!),
-              )
-            : Managers.configManager.getMilestone();
+        const { reward } =
+            delegates[forgingInfo.currentForger] &&
+            this.walletRepository.hasByPublicKey(delegates[forgingInfo.currentForger].publicKey!)
+                ? await this.roundState.getRewardForBlockInRound(
+                      height,
+                      this.walletRepository.findByPublicKey(delegates[forgingInfo.currentForger].publicKey!),
+                  )
+                : Managers.configManager.getMilestone();
 
         return {
             allDelegates,


### PR DESCRIPTION
This PR fixes an upstream bug that can cause wallet repository pollution, potentially triggering out of memory conditions on a node. By any other yardstick, this would be considered a security vulnerability, but upstream explicitly does not consider issues affecting API to be security vulnerabilities.

Nodes can access various API endpoints such as `/api/wallets/<address>/transactions` or `/api/transactions?recipientId=<address>` where `address` is a non-existent wallet address. This will create a new empty wallet which is perpetually stored in the wallet repository, taking up memory. This is particularly bad in the case of the latter endpoint since aside from requiring a 34 character alphanumeric string, there is no validation on `recipientId` (or the equally affected `senderId`) so anyone can effectively write digital graffiti which will be returned by `/api/wallets` for everybody to see since it does not have to be a valid address. With enough time and resources, enough empty wallets can be added to use up all memory of the node since this is a free attack vector as no transactions are required.

Several other endpoints are affected too, and there is also a more complicated method of exploitation using p2p requests as well. It occurs because the upstream code does not call `hasByAddress` or `hasByPublicKey` before calling `findByAddress` or `findByPublicKey` in the above scenarios. This is a problem because whenever `findByAddress`/`findByPublicKey` does not find a new wallet, it creates an empty one and stores it in the wallet repository and returns that. This PR resolves the issue by calling `hasByAddress` or `hasByPublicKey` first, and only attempts to find the wallet if this returns `true`.

It also has an innocuous trigger: the desktop wallet software will query the public API of a node for existing transactions when creating a new address or importing an existing one. If that wallet is empty, Core will again create a new wallet and hold it in memory forever.

This already plagues the upstream production blockchain as can be seen here at the time of writing: https://api.ark.io/api/wallets?nonce=0&balance=0
