### PR TITLE
fix: prevent adding empty wallets to repository

### DIFF
--- a/packages/blockchain/src/processor/block-processor.ts
+++ b/packages/blockchain/src/processor/block-processor.ts
@@ -205,17 +205,13 @@ export class BlockProcessor {
     }
 
     private async validateGenerator(block: Interfaces.IBlock): Promise<boolean> {
-        const walletRepository = this.app.getTagged<Contracts.State.WalletRepository>(
-            Container.Identifiers.WalletRepository,
-            "state",
-            "blockchain",
-        );
-
-        if (!walletRepository.hasByPublicKey(block.data.generatorPublicKey)) {
+        if (!this.walletRepository.hasByPublicKey(block.data.generatorPublicKey)) {
             return false;
         }
 
-        const generatorWallet: Contracts.State.Wallet = walletRepository.findByPublicKey(block.data.generatorPublicKey);
+        const generatorWallet: Contracts.State.Wallet = this.walletRepository.findByPublicKey(
+            block.data.generatorPublicKey,
+        );
 
         let generatorUsername: string;
         try {
@@ -246,7 +242,7 @@ export class BlockProcessor {
         } else if (forgingDelegate.getPublicKey() !== block.data.generatorPublicKey) {
             AppUtils.assert.defined<string>(forgingDelegate.getPublicKey());
 
-            const forgingWallet: Contracts.State.Wallet = walletRepository.findByPublicKey(
+            const forgingWallet: Contracts.State.Wallet = this.walletRepository.findByPublicKey(
                 forgingDelegate.getPublicKey()!,
             );
             const forgingUsername: string = forgingWallet.getAttribute("delegate.username");

--- a/packages/state/src/wallets/indexers/indexers.ts
+++ b/packages/state/src/wallets/indexers/indexers.ts
@@ -1,31 +1,40 @@
 import { Contracts } from "@solar-network/kernel";
 
+const isIndexable = (wallet: Contracts.State.Wallet): boolean => {
+    return (
+        !wallet.getNonce().isZero() ||
+        !wallet.getBalance().isZero() ||
+        wallet.hasMultiSignature() ||
+        Object.keys(wallet.getAttributes()).length > 1
+    );
+};
+
 export const addressesIndexer = (index: Contracts.State.WalletIndex, wallet: Contracts.State.Wallet): void => {
-    if (wallet.getAddress()) {
+    if (wallet.getAddress() && isIndexable(wallet)) {
         index.set(wallet.getAddress(), wallet);
     }
 };
 
 export const publicKeysIndexer = (index: Contracts.State.WalletIndex, wallet: Contracts.State.Wallet): void => {
-    if (wallet.getPublicKey()) {
+    if (wallet.getPublicKey() && isIndexable(wallet)) {
         index.set(wallet.getPublicKey()!, wallet);
     }
 };
 
 export const usernamesIndexer = (index: Contracts.State.WalletIndex, wallet: Contracts.State.Wallet): void => {
-    if (wallet.isDelegate()) {
+    if (wallet.isDelegate() && isIndexable(wallet)) {
         index.set(wallet.getAttribute("delegate.username"), wallet);
     }
 };
 
 export const resignationsIndexer = (index: Contracts.State.WalletIndex, wallet: Contracts.State.Wallet): void => {
-    if (wallet.isDelegate() && wallet.hasAttribute("delegate.resigned")) {
+    if (wallet.isDelegate() && wallet.hasAttribute("delegate.resigned") && isIndexable(wallet)) {
         index.set(wallet.getAttribute("delegate.username"), wallet);
     }
 };
 
 export const locksIndexer = (index: Contracts.State.WalletIndex, wallet: Contracts.State.Wallet): void => {
-    if (wallet.hasAttribute("htlc.locks")) {
+    if (wallet.hasAttribute("htlc.locks") && isIndexable(wallet)) {
         const locks: object = wallet.getAttribute("htlc.locks");
 
         for (const lockId of Object.keys(locks)) {
@@ -35,7 +44,7 @@ export const locksIndexer = (index: Contracts.State.WalletIndex, wallet: Contrac
 };
 
 export const ipfsIndexer = (index: Contracts.State.WalletIndex, wallet: Contracts.State.Wallet): void => {
-    if (wallet.hasAttribute("ipfs.hashes")) {
+    if (wallet.hasAttribute("ipfs.hashes") && isIndexable(wallet)) {
         const hashes: object = wallet.getAttribute("ipfs.hashes");
 
         for (const hash of Object.keys(hashes)) {

--- a/packages/transactions/src/handlers/transaction.ts
+++ b/packages/transactions/src/handlers/transaction.ts
@@ -1,4 +1,4 @@
-import { Interfaces, Managers, Transactions, Utils } from "@solar-network/crypto";
+import { Enums, Identities, Interfaces, Managers, Transactions, Utils } from "@solar-network/crypto";
 import { Repositories } from "@solar-network/database";
 import { Container, Contracts, Utils as AppUtils } from "@solar-network/kernel";
 import assert from "assert";
@@ -30,18 +30,24 @@ export abstract class TransactionHandler {
     @Container.inject(Container.Identifiers.WalletRepository)
     protected readonly walletRepository!: Contracts.State.WalletRepository;
 
+    @Container.inject(Container.Identifiers.WalletRepository)
+    @Container.tagged("state", "blockchain")
+    protected readonly stateWalletRepository!: Contracts.State.WalletRepository;
+
     @Container.inject(Container.Identifiers.LogService)
     protected readonly logger!: Contracts.Kernel.Logger;
 
     public async verify(transaction: Interfaces.ITransaction): Promise<boolean> {
         AppUtils.assert.defined<string>(transaction.data.senderPublicKey);
 
-        const senderWallet: Contracts.State.Wallet = this.walletRepository.findByPublicKey(
-            transaction.data.senderPublicKey,
-        );
+        if (this.walletRepository.hasByPublicKey(transaction.data.senderPublicKey)) {
+            const senderWallet: Contracts.State.Wallet = this.walletRepository.findByPublicKey(
+                transaction.data.senderPublicKey,
+            );
 
-        if (senderWallet.hasMultiSignature()) {
-            transaction.isVerified = this.verifySignatures(senderWallet, transaction.data);
+            if (senderWallet.hasMultiSignature()) {
+                transaction.isVerified = this.verifySignatures(senderWallet, transaction.data);
+            }
         }
 
         return transaction.isVerified;
@@ -112,25 +118,33 @@ export abstract class TransactionHandler {
     }
 
     public async apply(transaction: Interfaces.ITransaction): Promise<void> {
-        await this.applyToSender(transaction);
-        await this.applyToRecipient(transaction);
+        try {
+            await this.applyToSender(transaction);
+            await this.applyToRecipient(transaction);
+        } finally {
+            await this.index(transaction);
+        }
     }
 
     public async revert(transaction: Interfaces.ITransaction): Promise<void> {
-        await this.revertForSender(transaction);
-        await this.revertForRecipient(transaction);
+        try {
+            await this.revertForSender(transaction);
+            await this.revertForRecipient(transaction);
+        } finally {
+            await this.index(transaction);
+        }
     }
 
     public async applyToSender(transaction: Interfaces.ITransaction): Promise<void> {
         AppUtils.assert.defined<string>(transaction.data.senderPublicKey);
-
-        const sender: Contracts.State.Wallet = this.walletRepository.findByPublicKey(transaction.data.senderPublicKey);
 
         const data: Interfaces.ITransactionData = transaction.data;
 
         if (Utils.isException(data)) {
             this.logger.warning(`Transaction forcibly applied as an exception: ${transaction.id}`);
         }
+
+        const sender: Contracts.State.Wallet = this.walletRepository.findByPublicKey(transaction.data.senderPublicKey);
 
         await this.throwIfCannotBeApplied(transaction, sender);
 
@@ -281,6 +295,80 @@ export abstract class TransactionHandler {
         if (!wallet.getNonce().isEqualTo(nonce)) {
             throw new UnexpectedNonceError(nonce, wallet, true);
         }
+    }
+
+    private indexRepositories(repositories: Contracts.State.WalletRepository[], addresses: string[]) {
+        for (const address of addresses) {
+            for (const repository of repositories) {
+                if (repository.hasByAddress(address)) {
+                    repository.index(repository.findByAddress(address));
+                }
+            }
+        }
+    }
+
+    private async index(transaction: Interfaces.ITransaction): Promise<void> {
+        AppUtils.assert.defined<string>(transaction.data.senderPublicKey);
+
+        const senderId = Identities.Address.fromPublicKey(transaction.data.senderPublicKey);
+
+        const repositories = [this.stateWalletRepository];
+        const addresses = [senderId];
+
+        if (this.stateWalletRepository !== this.walletRepository) {
+            repositories.push(this.walletRepository);
+        }
+
+        if (transaction.data.recipientId) {
+            AppUtils.assert.defined<string>(transaction.data.recipientId);
+
+            addresses.push(transaction.data.recipientId);
+        }
+
+        if (transaction.data.typeGroup === Enums.TransactionTypeGroup.Core) {
+            if (transaction.data.type === Enums.TransactionType.Core.Transfer) {
+                AppUtils.assert.defined<Interfaces.ITransferItem[]>(transaction.data.asset?.transfers);
+
+                for (const { recipientId } of transaction.data.asset.transfers) {
+                    addresses.push(recipientId);
+                }
+            }
+
+            if (transaction.data.type === Enums.TransactionType.Core.HtlcClaim) {
+                try {
+                    AppUtils.assert.defined<Interfaces.IHtlcClaimAsset>(transaction.data.asset?.claim);
+
+                    const lockId = transaction.data.asset.claim.lockTransactionId;
+                    const lockSenderWallet = this.walletRepository.findByIndex(
+                        Contracts.State.WalletIndexes.Locks,
+                        lockId,
+                    );
+                    const locks: Interfaces.IHtlcLocks = lockSenderWallet.getAttribute("htlc.locks", {});
+
+                    let lockRecipientId: string | undefined;
+
+                    if (locks[lockId] && locks[lockId].recipientId) {
+                        lockRecipientId = locks[lockId].recipientId;
+                    } else {
+                        const lockTransaction: Interfaces.ITransactionData = (
+                            await this.transactionRepository.findByIds([lockId])
+                        )[0];
+
+                        lockRecipientId = lockTransaction.recipientId;
+                    }
+
+                    AppUtils.assert.defined<Interfaces.ITransactionData>(lockRecipientId);
+
+                    const lockSenderId = lockSenderWallet.getAddress();
+
+                    addresses.push(...[lockSenderId, lockRecipientId]);
+                } catch {
+                    //
+                }
+            }
+        }
+
+        this.indexRepositories(repositories, addresses);
     }
 
     public abstract getConstructor(): Transactions.TransactionConstructor;

--- a/plugins/sxp-swap/src/sxp-swap.ts
+++ b/plugins/sxp-swap/src/sxp-swap.ts
@@ -143,6 +143,7 @@ export class SXPSwap {
         ): Promise<void> {
             await (this as any).applyToSender(transaction, status);
             await this.applyToRecipient(transaction);
+            await (this as any).index(transaction);
         };
 
         Handlers.TransactionHandler.prototype.applyToSender = async function (
@@ -151,14 +152,15 @@ export class SXPSwap {
         ): Promise<void> {
             AppUtils.assert.defined<string>(transaction.data.senderPublicKey);
 
-            const sender: Contracts.State.Wallet = (this as any).walletRepository.findByPublicKey(
-                transaction.data.senderPublicKey,
-            );
             const data: Interfaces.ITransactionData = transaction.data;
 
             if (Utils.isException(data)) {
                 self.log.warning(`Transaction forcibly applied as an exception: ${transaction.id}`);
             }
+
+            const sender: Contracts.State.Wallet = (this as any).walletRepository.findByPublicKey(
+                transaction.data.senderPublicKey,
+            );
 
             await (this as any).throwIfCannotBeApplied(transaction, sender, status);
 


### PR DESCRIPTION
This adds extra guards to prevent empty wallets being added to the wallet repository going forward by re-indexing any wallet involved in a transaction after attempting to apply or revert it. It also prevents any non-empty wallets that become empty after reverting a transaction from lingering in the wallet repository.