### PR TITLE
feat(transactions): emit event when delegate vote state changes

### DIFF
--- a/packages/kernel/src/enums/events.ts
+++ b/packages/kernel/src/enums/events.ts
@@ -74,7 +74,6 @@ export enum DelegateEvent {
 
 export enum VoteEvent {
     Vote = "wallet.vote",
-    Unvote = "wallet.unvote",
 }
 
 /**


### PR DESCRIPTION
This enhances the `wallet.vote` event to also include details of the previous vote from the wallet so that delegates can use it to track whenever a wallet starts voting for them, cancels their vote for them or revises their vote allocation for them.