### PR TITLE
refactor(crypto): use bip32 implementation compatible with node v17+

### DIFF
--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -23,10 +23,10 @@
         "rollup": "rollup -c"
     },
     "dependencies": {
+        "@scure/bip32": "1.1.0",
         "ajv": "6.12.6",
         "ajv-keywords": "3.4.1",
         "bcrypto": "5.4.0",
-        "bip32": "2.0.6",
         "bip39": "3.0.4",
         "browserify-aes": "1.2.0",
         "bstring": "0.3.9",

--- a/packages/crypto/src/crypto/hdwallet.ts
+++ b/packages/crypto/src/crypto/hdwallet.ts
@@ -1,56 +1,45 @@
-import { BIP32Interface, fromPrivateKey, fromSeed } from "bip32";
+import { HDKey } from "@scure/bip32";
 import { mnemonicToSeedSync } from "bip39";
 
 import { IKeyPair } from "../interfaces";
 import { configManager } from "../managers";
 
 export class HDWallet {
-    public static readonly slip44 = 3333;
-
     /**
      * Get root node from the given mnemonic with an optional passphrase.
      */
-    public static fromMnemonic(mnemonic: string, passphrase?: string): BIP32Interface {
-        return fromSeed(mnemonicToSeedSync(mnemonic, passphrase), configManager.get("network"));
+    public static fromMnemonic(mnemonic: string, account: number, passphrase?: string): HDKey {
+        return HDKey.fromMasterSeed(mnemonicToSeedSync(mnemonic, passphrase)).derive(
+            `m/44'/${configManager.get("network.slip44")}'/${account}'/0`,
+        );
     }
 
     /**
-     * Get bip32 node from keys.
+     * Get key pair from the given root, optionally at the specified index.
      */
-    public static fromKeys(keys: IKeyPair, chainCode: Buffer): BIP32Interface {
-        if (!keys.compressed) {
-            throw new TypeError("BIP32 only allows compressed keys");
+    public static getKeys(root: HDKey, index?: number): IKeyPair {
+        let node: HDKey = root;
+
+        if (index !== undefined) {
+            node = root.deriveChild(index);
         }
 
-        return fromPrivateKey(Buffer.from(keys.privateKey, "hex"), chainCode, configManager.get("network"));
-    }
-
-    /**
-     * Get key pair from the given node.
-     */
-    public static getKeys(node: BIP32Interface): IKeyPair {
-        if (!node.privateKey) {
+        if (!node.privateKey || !node.publicKey) {
             throw new Error();
         }
 
         return {
-            publicKey: node.publicKey.toString("hex"),
-            privateKey: node.privateKey.toString("hex"),
+            publicKey: Buffer.from(
+                node.publicKey.buffer,
+                node.publicKey.byteOffset,
+                node.publicKey.byteLength,
+            ).toString("hex"),
+            privateKey: Buffer.from(
+                node.privateKey.buffer,
+                node.privateKey.byteOffset,
+                node.privateKey.byteLength,
+            ).toString("hex"),
             compressed: true,
         };
-    }
-
-    /**
-     * Derives a node from the coin type as specified by slip44.
-     */
-    public static deriveSlip44(root: BIP32Interface, hardened = true): BIP32Interface {
-        return root.derivePath(`m/44'/${this.slip44}${hardened ? "'" : ""}`);
-    }
-
-    /**
-     * Derives a node from the network as specified by AIP20.
-     */
-    public static deriveNetwork(root: BIP32Interface): BIP32Interface {
-        return this.deriveSlip44(root).deriveHardened(configManager.get("network.aip20") || 1);
     }
 }

--- a/packages/crypto/src/crypto/hdwallet.ts
+++ b/packages/crypto/src/crypto/hdwallet.ts
@@ -8,10 +8,11 @@ export class HDWallet {
     /**
      * Get root node from the given mnemonic with an optional passphrase.
      */
-    public static fromMnemonic(mnemonic: string, account: number, passphrase?: string): HDKey {
-        return HDKey.fromMasterSeed(mnemonicToSeedSync(mnemonic, passphrase)).derive(
-            `m/44'/${configManager.get("network.slip44")}'/${account}'/0`,
-        );
+    public static fromMnemonic(mnemonic: string, account: number, slip44?: number, passphrase?: string): HDKey {
+        if (slip44 === undefined) {
+            slip44 = configManager.get("network.slip44");
+        }
+        return HDKey.fromMasterSeed(mnemonicToSeedSync(mnemonic, passphrase)).derive(`m/44'/${slip44}'/${account}'/0`);
     }
 
     /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -333,6 +333,7 @@ importers:
       '@rollup/plugin-inject': 4.0.2
       '@rollup/plugin-json': 4.1.0
       '@rollup/plugin-node-resolve': 8.4.0
+      '@scure/bip32': 1.1.0
       '@types/bip39': 2.4.2
       '@types/buffer-xor': 2.0.0
       '@types/lodash.get': 4.4.6
@@ -342,7 +343,6 @@ importers:
       ajv: 6.12.6
       ajv-keywords: 3.4.1
       bcrypto: 5.4.0
-      bip32: 2.0.6
       bip39: 3.0.4
       browserify-aes: 1.2.0
       bstring: 0.3.9
@@ -361,10 +361,10 @@ importers:
       util: 0.12.4
       wif: 2.0.6
     dependencies:
+      '@scure/bip32': 1.1.0
       ajv: 6.12.6
       ajv-keywords: 3.4.1_ajv@6.12.6
       bcrypto: 5.4.0
-      bip32: 2.0.6
       bip39: 3.0.4
       browserify-aes: 1.2.0
       bstring: 0.3.9
@@ -3833,6 +3833,14 @@ packages:
     resolution: {integrity: sha512-n2RC9d6XatVbWFdHLimzzUJxJ1KY8LdjqrW6YvGPiRmsHkhOUx74/Ct10x5Yo7bC/Jvqx7cDEW8IMPv/+vwEzA==}
     dev: true
 
+  /@noble/hashes/1.1.2:
+    resolution: {integrity: sha512-KYRCASVTv6aeUi1tsF8/vpyR7zpfs3FUzy2Jqm+MU+LmUKhQ0y2FpfwqkCcxSg2ua4GALJd8k2R76WxwZGbQpA==}
+    dev: false
+
+  /@noble/secp256k1/1.6.3:
+    resolution: {integrity: sha512-T04e4iTurVy7I8Sw4+c5OSN9/RkPlo1uKxAomtxQNLq8j1uPAqnsqG1bqvY3Jv7c13gyr6dui0zmh/I3+f/JaQ==}
+    dev: false
+
   /@nodelib/fs.scandir/2.1.5:
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -4305,6 +4313,18 @@ packages:
       - zenObservable
     dev: false
 
+  /@scure/base/1.1.1:
+    resolution: {integrity: sha512-ZxOhsSyxYwLJj3pLZCefNitxsj093tb2vq90mp2txoYeBqbcjDjqFhyM8eUjq/uFm6zJ+mUuqxlS2FkuSY1MTA==}
+    dev: false
+
+  /@scure/bip32/1.1.0:
+    resolution: {integrity: sha512-ftTW3kKX54YXLCxH6BB7oEEoJfoE2pIgw7MINKAs5PsS6nqKPuKk1haTF/EuHmYqG330t5GSrdmtRuHaY1a62Q==}
+    dependencies:
+      '@noble/hashes': 1.1.2
+      '@noble/secp256k1': 1.6.3
+      '@scure/base': 1.1.1
+    dev: false
+
   /@sideway/address/4.1.3:
     resolution: {integrity: sha512-8ncEUtmnTsMmL7z1YPB47kPUq7LpKWJNFPsRzHiIajGC5uXlWGn+AmkYPcHNl8S4tcEGx+cnORnNYaw2wvL+LQ==}
     dependencies:
@@ -4653,10 +4673,6 @@ packages:
     dependencies:
       '@types/node': 17.0.21
     dev: true
-
-  /@types/node/10.12.18:
-    resolution: {integrity: sha512-fh+pAqt4xRzPfqA6eh3Z2y6fyZavRIumvjhaCL753+TVkGKGhpPeyrJG2JftD0T9q4GF00KjefsQ+PQNDdWQaQ==}
-    dev: false
 
   /@types/node/11.11.6:
     resolution: {integrity: sha512-Exw4yUWMBXM3X+8oqzJNRqZSwUAaS4+7NdvHqQuFi/d+synz++xmX3QIf+BFqneW8N31R8Ky+sikfZUXq07ggQ==}
@@ -5761,19 +5777,6 @@ packages:
     resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
     dependencies:
       file-uri-to-path: 1.0.0
-    dev: false
-
-  /bip32/2.0.6:
-    resolution: {integrity: sha512-HpV5OMLLGTjSVblmrtYRfFFKuQB+GArM0+XP8HGWfJ5vxYBqo+DesvJwOdC2WJ3bCkZShGf0QIfoIpeomVzVdA==}
-    engines: {node: '>=6.0.0'}
-    dependencies:
-      '@types/node': 10.12.18
-      bs58check: 2.1.2
-      create-hash: 1.2.0
-      create-hmac: 1.1.7
-      tiny-secp256k1: 1.1.6
-      typeforce: 1.18.0
-      wif: 2.0.6
     dev: false
 
   /bip39/3.0.4:
@@ -12253,18 +12256,6 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: false
 
-  /tiny-secp256k1/1.1.6:
-    resolution: {integrity: sha512-FmqJZGduTyvsr2cF3375fqGHUovSwDi/QytexX1Se4BPuPZpTE5Ftp5fg+EFSuEf3lhZqgCRjEG3ydUQ/aNiwA==}
-    engines: {node: '>=6.0.0'}
-    requiresBuild: true
-    dependencies:
-      bindings: 1.5.0
-      bn.js: 4.12.0
-      create-hmac: 1.1.7
-      elliptic: 6.5.4
-      nan: 2.15.0
-    dev: false
-
   /tmp/0.1.0:
     resolution: {integrity: sha512-J7Z2K08jbGcdA1kkQpJSqLF6T0tdQqpR2pnSUXsIchbPdTI9v3e85cLW0d6WDhwuAleOV71j2xWs8qMPfK7nKw==}
     engines: {node: '>=6'}
@@ -12471,10 +12462,6 @@ packages:
       shiki: 0.10.1
       typescript: 4.4.4
     dev: true
-
-  /typeforce/1.18.0:
-    resolution: {integrity: sha512-7uc1O8h1M1g0rArakJdf0uLRSSgFcYexrVoKo+bzJd32gd4gDy2L/Z+8/FjPnU9ydY3pEnVPtr9FyscYY60K1g==}
-    dev: false
 
   /typeorm/0.2.25:
     resolution: {integrity: sha512-yzQ995fyDy5wolSLK9cmjUNcmQdixaeEm2TnXB5HN++uKbs9TiR6Y7eYAHpDlAE8s9J1uniDBgytecCZVFergQ==}


### PR DESCRIPTION
Unfortunately the `bip32` package used in the `HDWallet` crypto class is not compatible with Node.js 17 onwards (https://github.com/bitcoinjs/bip32/issues/59) and since we now use Node.js 18 in production, this was a breaking change for us. With no fix in sight, we have switched from that package to `@scure/bip32` instead.

Also, it seems like the upstream implementation of the `HDWallet` crypto class is overly complicated for our needs, so it was pared down as part of this PR.