### PR TITLE
refactor(blockchain): discard blocks with conflicting transactions

### DIFF
--- a/packages/blockchain/src/processor/handlers/conflicting-transactions-handler.ts
+++ b/packages/blockchain/src/processor/handlers/conflicting-transactions-handler.ts
@@ -1,0 +1,20 @@
+import { Interfaces } from "@solar-network/crypto";
+import { Container, Contracts } from "@solar-network/kernel";
+
+import { BlockProcessorResult } from "../block-processor";
+import { BlockHandler } from "../contracts";
+
+@Container.injectable()
+export class ConflictingTransactionsHandler implements BlockHandler {
+    @Container.inject(Container.Identifiers.Application)
+    protected readonly app!: Contracts.Kernel.Application;
+
+    @Container.inject(Container.Identifiers.BlockchainService)
+    protected readonly blockchain!: Contracts.Blockchain.Blockchain;
+
+    public async execute(block?: Interfaces.IBlock): Promise<BlockProcessorResult> {
+        this.blockchain.resetLastDownloadedBlock();
+
+        return BlockProcessorResult.Rejected;
+    }
+}

--- a/packages/blockchain/src/processor/handlers/index.ts
+++ b/packages/blockchain/src/processor/handlers/index.ts
@@ -1,5 +1,6 @@
 export * from "./accept-block-handler";
 export * from "./already-forged-handler";
+export * from "./conflicting-transactions-handler";
 export * from "./exception-handler";
 export * from "./invalid-generator-handler";
 export * from "./invalid-reward-handler";

--- a/packages/crypto/src/transactions/types/core/delegate-registration.ts
+++ b/packages/crypto/src/transactions/types/core/delegate-registration.ts
@@ -7,6 +7,7 @@ export abstract class DelegateRegistrationTransaction extends Transaction {
     public static typeGroup: number = TransactionTypeGroup.Core;
     public static type: number = TransactionType.Core.DelegateRegistration;
     public static key = "delegateRegistration";
+    public static unique: boolean = true;
 
     protected static defaultStaticFee: BigNumber = BigNumber.make("2500000000");
 

--- a/packages/crypto/src/transactions/types/core/delegate-resignation.ts
+++ b/packages/crypto/src/transactions/types/core/delegate-resignation.ts
@@ -8,6 +8,7 @@ export abstract class DelegateResignationTransaction extends Transaction {
     public static typeGroup: number = TransactionTypeGroup.Core;
     public static type: number = TransactionType.Core.DelegateResignation;
     public static key = "delegateResignation";
+    public static unique: boolean = true;
 
     protected static defaultStaticFee: BigNumber = BigNumber.make("2500000000");
 

--- a/packages/crypto/src/transactions/types/core/second-signature-registration.ts
+++ b/packages/crypto/src/transactions/types/core/second-signature-registration.ts
@@ -7,6 +7,7 @@ export abstract class SecondSignatureRegistrationTransaction extends Transaction
     public static typeGroup: number = TransactionTypeGroup.Core;
     public static type: number = TransactionType.Core.SecondSignature;
     public static key = "secondSignature";
+    public static unique: boolean = true;
 
     protected static defaultStaticFee: BigNumber = BigNumber.make("500000000");
 

--- a/packages/crypto/src/transactions/types/core/vote.ts
+++ b/packages/crypto/src/transactions/types/core/vote.ts
@@ -7,6 +7,7 @@ export class LegacyVoteTransaction extends Transaction {
     public static typeGroup: number = TransactionTypeGroup.Core;
     public static type: number = TransactionType.Core.Vote;
     public static key = "legacyVote";
+    public static unique: boolean = true;
 
     protected static defaultStaticFee: BigNumber = BigNumber.make("100000000");
 

--- a/packages/crypto/src/transactions/types/solar/vote.ts
+++ b/packages/crypto/src/transactions/types/solar/vote.ts
@@ -8,6 +8,7 @@ export class VoteTransaction extends Transaction {
     public static typeGroup: number = TransactionTypeGroup.Solar;
     public static type: number = TransactionType.Solar.Vote;
     public static key: string = "vote";
+    public static unique: boolean = true;
 
     protected static defaultStaticFee: BigNumber = BigNumber.make("100000000");
 

--- a/packages/crypto/src/transactions/types/transaction.ts
+++ b/packages/crypto/src/transactions/types/transaction.ts
@@ -17,6 +17,7 @@ export abstract class Transaction implements ITransaction {
     public static type: number | undefined = undefined;
     public static typeGroup: number | undefined = undefined;
     public static key: string | undefined = undefined;
+    public static unique: boolean = false;
 
     protected static defaultStaticFee: BigNumber = BigNumber.ZERO;
 


### PR DESCRIPTION
This PR introduces a new `unique` property for each transaction handler, which, if `true`, prohibits multiple transactions of that type from the same sender appearing in the same block. If this constraint is violated, the block is rejected to prevent a conflict.

In ordinary honest use, the pool already stops multiple instances of certain transaction types from the same sender being collated into the same block, but there was nothing previously on the protocol level to prevent it in scenarios where a malicious delegate removed certain pool checks.