### PR TITLE
refactor: use transaction history service instead of generic state history

### DIFF
--- a/packages/kernel/src/contracts/state/wallets.ts
+++ b/packages/kernel/src/contracts/state/wallets.ts
@@ -130,65 +130,6 @@ export interface Wallet {
     hasVoted(): boolean;
 
     /**
-     * @returns {Record<string, any[]>}
-     * @memberof Wallet
-     */
-    getAllStateHistory(): Record<string, any[]>;
-
-    /**
-     * @param {string} key
-     * @returns {any}
-     * @memberof Wallet
-     */
-    getCurrentStateHistory(key: string): any;
-
-    /**
-     * @param {string} key
-     * @returns {any}
-     * @memberof Wallet
-     */
-    getPreviousStateHistory(key: string): any;
-
-    /**
-     * @param {string} key
-     * @returns {any}
-     * @memberof Wallet
-     */
-    getStateHistory(key: string): any;
-
-    /**
-     * @param {Record<string, any[]>} stateHistory
-     * @memberof Wallet
-     */
-    setAllStateHistory(stateHistory: Record<string, any[]>): void;
-
-    /**
-     * @param {string} key
-     * @memberof Wallet
-     */
-    initialiseStateHistory(key: string): void;
-
-    /**
-     * @param {string} key
-     * @memberof Wallet
-     */
-    forgetStateHistory(key: string): void;
-
-    /**
-     * @param {string} key
-     * @param {any} value
-     * @param {Interfaces.ITransactionData | undefined} transaction
-     * @memberof Wallet
-     */
-    addStateHistory(key: string, value?: any, transaction?: Interfaces.ITransactionData | undefined): void;
-
-    /**
-     * @param {string} key
-     * @memberof Wallet
-     */
-    removeCurrentStateHistory(key: string): void;
-
-    /**
      * @param {string} delegate
      * @returns {Utils.BigNumber}
      * @memberof Wallet
@@ -212,13 +153,6 @@ export interface Wallet {
      * @memberof Wallet
      */
     getVoteDistribution(): Record<string, WalletVoteDistribution>;
-
-    /**
-     * @param {object} value
-     * @param {Interfaces.ITransactionData} transaction
-     * @memberof Wallet
-     */
-    changeVotes(value: object, transaction: Interfaces.ITransactionData): void;
 
     updateVoteBalances(): void;
 

--- a/packages/state/src/state-loader.ts
+++ b/packages/state/src/state-loader.ts
@@ -174,7 +174,6 @@ export class StateLoader {
                     let balance: bigint | number = 0;
                     let nonce: bigint | number = 1;
                     let publicKey: string | undefined;
-                    let stateHistory: Record<string, object[]> = {};
                     let voteBalances: Record<string, Utils.BigNumber> = {};
 
                     if ((1 & bits) !== 0) {
@@ -196,11 +195,6 @@ export class StateLoader {
 
                     if ((16 & bits) !== 0) {
                         const length: number = buffer.readUInt32LE();
-                        stateHistory = JSON.parse(buffer.readBuffer(length).toString(), reviver);
-                    }
-
-                    if ((32 & bits) !== 0) {
-                        const length: number = buffer.readUInt32LE();
                         voteBalances = JSON.parse(buffer.readBuffer(length).toString(), reviver);
                     }
 
@@ -217,7 +211,6 @@ export class StateLoader {
                         wallet.setAttribute(attribute, attributes[attribute]);
                     }
 
-                    wallet.setAllStateHistory(stateHistory);
                     wallet.setVoteBalances(voteBalances);
 
                     this.walletRepository.index(wallet);

--- a/packages/state/src/state-saver.ts
+++ b/packages/state/src/state-saver.ts
@@ -59,7 +59,6 @@ export class StateSaver {
 
             for (const wallet of this.walletRepository.allByAddress()) {
                 const attributes: Record<string, any> = wallet.getAttributes();
-                const stateHistory: Record<string, object[]> = wallet.getAllStateHistory();
                 const voteBalances: Record<string, Utils.BigNumber> = wallet.getVoteBalances();
 
                 let bits: number = 0;
@@ -80,12 +79,8 @@ export class StateSaver {
                     bits += 8;
                 }
 
-                if (Object.keys(stateHistory).length > 0) {
-                    bits += 16;
-                }
-
                 if (Object.keys(voteBalances).length > 0) {
-                    bits += 32;
+                    bits += 16;
                 }
 
                 if (buffer.getRemainderLength() === 0) {
@@ -121,7 +116,7 @@ export class StateSaver {
                     buffer.writeBuffer(publicKey);
                 }
 
-                for (const item of [attributes, stateHistory, voteBalances]) {
+                for (const item of [attributes, voteBalances]) {
                     if (Object.keys(item).length > 0) {
                         secondaryBuffer.reset();
                         this.byteBufferArray.reset();

--- a/packages/transactions/src/handlers/core/delegate-registration.ts
+++ b/packages/transactions/src/handlers/core/delegate-registration.ts
@@ -1,4 +1,4 @@
-import { Enums, Identities, Interfaces, Transactions, Utils } from "@solar-network/crypto";
+import { Identities, Interfaces, Transactions, Utils } from "@solar-network/crypto";
 import { Container, Contracts, Enums as AppEnums, Utils as AppUtils } from "@solar-network/kernel";
 
 import {
@@ -67,8 +67,6 @@ export class DelegateRegistrationTransactionHandler extends TransactionHandler {
                 voters: 0,
             });
 
-            wallet.initialiseStateHistory("delegateStatus");
-            wallet.addStateHistory("delegateStatus", Enums.DelegateStatus.NotResigned, transaction);
             this.walletRepository.index(wallet);
         }
 
@@ -195,9 +193,6 @@ export class DelegateRegistrationTransactionHandler extends TransactionHandler {
             voters: 0,
         });
 
-        senderWallet.initialiseStateHistory("delegateStatus");
-        senderWallet.addStateHistory("delegateStatus", Enums.DelegateStatus.NotResigned, transaction.data);
-
         this.walletRepository.index(senderWallet);
     }
 
@@ -211,7 +206,6 @@ export class DelegateRegistrationTransactionHandler extends TransactionHandler {
         );
 
         senderWallet.forgetAttribute("delegate");
-        senderWallet.forgetStateHistory("delegateStatus");
 
         this.walletRepository.index(senderWallet);
     }


### PR DESCRIPTION
This PR refactors Core to no longer require the generic state history concept, instead making use of the already existing transaction history service. This means that Core no longer has to store the entire history of certain wallet attributes in memory all the time.

This has resulted in an immediate 85% reduction in the size of our disk-stored saved state files based on the current state of mainnet at the time of writing.