### PR TITLE
refactor: use delegate username instead of generator public key

### DIFF
--- a/packages/api/src/controllers/delegates.ts
+++ b/packages/api/src/controllers/delegates.ts
@@ -90,7 +90,7 @@ export class DelegatesController extends Controller {
         }
 
         if (request.query.transform) {
-            const blockCriteria = { generatorPublicKey: delegateResource.publicKey };
+            const blockCriteria = { username: delegateResource.username };
             const blockWithSomeTransactionsListResult = await this.blockHistoryService.listByCriteriaJoinTransactions(
                 blockCriteria,
                 { typeGroup: Enums.TransactionTypeGroup.Core, type: Enums.TransactionType.Core.Transfer },
@@ -101,7 +101,7 @@ export class DelegatesController extends Controller {
 
             return this.toPagination(blockWithSomeTransactionsListResult, BlockWithTransactionsResource, true);
         } else {
-            const blockCriteria = { generatorPublicKey: delegateResource.publicKey };
+            const blockCriteria = { username: delegateResource.username };
             const blockListResult = await this.blockHistoryService.listByCriteria(
                 blockCriteria,
                 this.getListingOrder(request),

--- a/packages/api/src/event-listener.ts
+++ b/packages/api/src/event-listener.ts
@@ -61,12 +61,7 @@ export class EventListener {
                             const endpoints = new Set([eventPath]);
 
                             if (eventGroupName === "BlockEvent") {
-                                if (this.walletRepository.hasByPublicKey(data.generatorPublicKey)) {
-                                    const wallet = this.walletRepository.findByPublicKey(data.generatorPublicKey);
-                                    if (wallet.hasAttribute("delegate.username")) {
-                                        endpoints.add(`${eventPath}/${wallet.getAttribute("delegate.username")}`);
-                                    }
-                                }
+                                endpoints.add(`${eventPath}/${data.username}`);
                             } else if (eventGroupName === "TransactionEvent") {
                                 if (this.walletRepository.hasByPublicKey(data.senderPublicKey)) {
                                     const wallet = this.walletRepository.findByPublicKey(data.senderPublicKey);

--- a/packages/api/src/resources/block-with-transactions.ts
+++ b/packages/api/src/resources/block-with-transactions.ts
@@ -27,7 +27,9 @@ export class BlockWithTransactionsResource implements Resource {
             .reduce((sum, transfer) => sum.plus(transfer!.amount), Utils.BigNumber.ZERO);
 
         const totalAmountTransferred: Utils.BigNumber = blockData.totalAmount.plus(totalTransferred);
-        const generator: Contracts.State.Wallet = this.walletRepository.findByPublicKey(blockData.generatorPublicKey);
+        const generator: Contracts.State.Wallet = blockData.username
+            ? this.walletRepository.findByUsername(blockData.username)
+            : this.walletRepository.findByPublicKey(blockData.generatorPublicKey);
         const lastBlock: Interfaces.IBlock = this.blockchainService.getLastBlock();
 
         return {
@@ -57,8 +59,7 @@ export class BlockWithTransactionsResource implements Resource {
                 username: generator.hasAttribute("delegate.username")
                     ? generator.getAttribute("delegate.username")
                     : undefined,
-                address: generator.getAddress(),
-                publicKey: generator.getPublicKey(),
+                publicKey: blockData.generatorPublicKey,
             },
             signature: blockData.blockSignature,
             confirmations: lastBlock ? lastBlock.data.height - blockData.height : 0,

--- a/packages/api/src/schemas.ts
+++ b/packages/api/src/schemas.ts
@@ -196,6 +196,12 @@ export const blockCriteriaSchemas = {
     payloadLength: orNumericCriteria(Joi.number().integer().min(0)),
     payloadHash: orEqualCriteria(Joi.string().hex()),
     generatorPublicKey: orEqualCriteria(Joi.string().hex().length(66)),
+    username: orEqualCriteria(
+        Joi.string()
+            .regex(/^(?=.*[a-z!@$&_.])([a-z0-9!@$&_.]?)+$/)
+            .min(1)
+            .max(20),
+    ),
     blockSignature: orEqualCriteria(Joi.string().hex().length(128)),
 };
 

--- a/packages/api/src/www/api.json
+++ b/packages/api/src/www/api.json
@@ -267,6 +267,14 @@
                         }
                     },
                     {
+                        "name": "username",
+                        "in": "query",
+                        "description": "Username of the delegate that forged the block(s) to be returned",
+                        "schema": {
+                            "$ref": "#/components/schemas/username"
+                        }
+                    },
+                    {
                         "name": "blockSignature",
                         "in": "query",
                         "description": "Signature of the block to be returned",
@@ -499,6 +507,8 @@
                                 "totalAmount:desc",
                                 "totalFee:asc",
                                 "totalFee:desc",
+                                "username:asc",
+                                "username:desc",
                                 "version:asc",
                                 "version:desc"
                             ]

--- a/packages/blockchain/src/processor/handlers/unchained-handler.ts
+++ b/packages/blockchain/src/processor/handlers/unchained-handler.ts
@@ -48,7 +48,7 @@ export class UnchainedHandler implements BlockHandler {
                     roundInfo,
                 })) as Contracts.State.Wallet[];
 
-                if (delegates.some((delegate) => delegate.getPublicKey() === block.data.generatorPublicKey)) {
+                if (delegates.some((delegate) => delegate.getAttribute("delegate.username") === block.data.username)) {
                     return BlockProcessorResult.Rollback;
                 }
 
@@ -94,12 +94,12 @@ export class UnchainedHandler implements BlockHandler {
             return UnchainedBlockStatus.InvalidTimestamp;
         } else {
             if (this.isValidGenerator) {
-                this.logger.warning(`Detect double forging by ${block.data.generatorPublicKey} :chains:`);
+                this.logger.warning(`Detected double forging by ${block.data.username} :chains:`);
                 return UnchainedBlockStatus.DoubleForging;
             }
 
             this.logger.info(
-                `Forked block disregarded because it is not allowed to be forged. Caused by delegate: ${block.data.generatorPublicKey} :bangbang:`,
+                `Forked block disregarded because it is not allowed to be forged. Caused by delegate ${block.data.username} :bangbang:`,
             );
 
             return UnchainedBlockStatus.GeneratorMismatch;

--- a/packages/crypto/src/blocks/block.ts
+++ b/packages/crypto/src/blocks/block.ts
@@ -92,10 +92,10 @@ export class Block implements IBlock {
         return "0".repeat(16 - temp.length) + temp;
     }
 
-    public static getBasicHeader(data: IBlockData, withBurnedFee: boolean = true): IBlockData {
+    public static getBasicHeader(data: IBlockData, withExtraData: boolean = true): IBlockData {
         return {
             blockSignature: data.blockSignature,
-            burnedFee: withBurnedFee ? data.burnedFee : undefined,
+            burnedFee: withExtraData ? data.burnedFee : undefined,
             generatorPublicKey: data.generatorPublicKey,
             height: data.height,
             id: data.id,
@@ -107,6 +107,7 @@ export class Block implements IBlock {
             timestamp: data.timestamp,
             totalAmount: data.totalAmount,
             totalFee: data.totalFee,
+            username: withExtraData ? data.username : undefined,
             version: data.version,
         };
     }
@@ -120,8 +121,8 @@ export class Block implements IBlock {
         return fees;
     }
 
-    public getHeader(withBurnedFee: boolean = true): IBlockData {
-        return Block.getBasicHeader(this.data, withBurnedFee);
+    public getHeader(withExtraData: boolean = true): IBlockData {
+        return Block.getBasicHeader(this.data, withExtraData);
     }
 
     public verifySignature(): boolean {

--- a/packages/crypto/src/blocks/factory.ts
+++ b/packages/crypto/src/blocks/factory.ts
@@ -59,6 +59,14 @@ export class BlockFactory {
                 ...Deserialiser.deserialise(serialised, false, options),
                 id: data.id,
             });
+
+            if (block.data.version === 0) {
+                const username = data.username;
+                if (!block.data.username && username) {
+                    block.data.username = username;
+                }
+            }
+
             block.serialised = serialised.toString("hex");
 
             return block;

--- a/packages/crypto/src/interfaces/block.ts
+++ b/packages/crypto/src/interfaces/block.ts
@@ -35,6 +35,7 @@ export interface IBlockData {
     burnedFee?: BigNumber;
     reward: BigNumber;
     devFund?: Record<string, BigNumber>;
+    username?: string;
     payloadLength: number;
     payloadHash: string;
     generatorPublicKey: string;

--- a/packages/database/src/block-filter.ts
+++ b/packages/database/src/block-filter.ts
@@ -73,6 +73,10 @@ export class BlockFilter implements Contracts.Database.BlockFilter {
                     return handleOrCriteria(criteria.generatorPublicKey!, async (c) => {
                         return { property: "generatorPublicKey", op: "equal", value: c };
                     });
+                case "username":
+                    return handleOrCriteria(criteria.username!, async (c) => {
+                        return { property: "username", op: "equal", value: c };
+                    });
                 case "blockSignature":
                     return handleOrCriteria(criteria.blockSignature!, async (c) => {
                         return { property: "blockSignature", op: "equal", value: c };

--- a/packages/database/src/migrations/20220813000000-add-username-to-blocks-table.ts
+++ b/packages/database/src/migrations/20220813000000-add-username-to-blocks-table.ts
@@ -1,0 +1,27 @@
+import { Enums } from "@solar-network/crypto";
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddUsernameToBlocksTable20220813000000 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<any> {
+        queryRunner.connection.driver.options.extra.logger.debug("Database migration: Adding username to blocks table");
+        await queryRunner.query(`
+            ALTER TABLE blocks ADD COLUMN username VARCHAR(20);
+            WITH delegates AS (
+                SELECT sender_public_key, asset->'delegate'->>'username' AS username FROM transactions WHERE type_group = ${Enums.TransactionTypeGroup.Core} AND type = ${Enums.CoreTransactionType.DelegateRegistration}
+            )
+            UPDATE blocks
+            SET username = delegates.username
+            FROM delegates
+            WHERE blocks.generator_public_key = delegates.sender_public_key;
+            CREATE INDEX blocks_username ON blocks(username);
+        `);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<any> {
+        await queryRunner.query(`
+            DROP INDEX blocks_username;
+
+            ALTER TABLE blocks DROP COLUMN username;
+        `);
+    }
+}

--- a/packages/database/src/model-converter.ts
+++ b/packages/database/src/model-converter.ts
@@ -11,7 +11,12 @@ export class ModelConverter implements Contracts.Database.ModelConverter {
     }
 
     public getBlockData(models: Contracts.Database.BlockModel[]): Interfaces.IBlockData[] {
-        return models;
+        return models.map((model) => {
+            if (model.username === null) {
+                delete model.username;
+            }
+            return model;
+        });
     }
 
     public getBlockDataWithTransactionData(

--- a/packages/database/src/models/block.ts
+++ b/packages/database/src/models/block.ts
@@ -105,6 +105,12 @@ export class Block implements Contracts.Database.BlockModel {
 
     @Column({
         type: "varchar",
+        length: 20,
+    })
+    public username!: string;
+
+    @Column({
+        type: "varchar",
         length: 256,
         nullable: false,
     })

--- a/packages/database/src/repositories/transaction-repository.ts
+++ b/packages/database/src/repositories/transaction-repository.ts
@@ -201,11 +201,11 @@ export class TransactionRepository extends AbstractRepository<Transaction> {
         typeGroup: number,
         limit?: number,
         offset?: number,
-    ): Promise<Array<Transaction & { blockHeight: number; blockGeneratorPublicKey: string; reward: Utils.BigNumber }>> {
+    ): Promise<Array<Transaction & { blockHeight: number; username: string; reward: Utils.BigNumber }>> {
         const transactions = await this.createQueryBuilder("transactions")
             .select()
             .addSelect('blocks.height as "blockHeight"')
-            .addSelect('blocks.generatorPublicKey as "blockGeneratorPublicKey"')
+            .addSelect("blocks.username as username")
             .addSelect('blocks.reward as "reward"')
             .addFrom(Block, "blocks")
             .where("block_id = blocks.id")

--- a/packages/kernel/src/contracts/blockchain/blockchain.ts
+++ b/packages/kernel/src/contracts/blockchain/blockchain.ts
@@ -124,4 +124,6 @@ export interface Blockchain {
     pushPingBlock(block: Interfaces.IBlockData, fromForger: boolean): void;
 
     checkForFork(blocks: Interfaces.IBlockData[]): Promise<boolean>;
+
+    setBlockUsername(block: Interfaces.IBlockData): void;
 }

--- a/packages/kernel/src/contracts/database/models.ts
+++ b/packages/kernel/src/contracts/database/models.ts
@@ -16,6 +16,7 @@ export interface BlockModel {
     payloadHash: string;
     generatorPublicKey: string;
     blockSignature: string;
+    username?: string;
 }
 
 export interface TransactionModel {

--- a/packages/kernel/src/contracts/shared/block-history-service.ts
+++ b/packages/kernel/src/contracts/shared/block-history-service.ts
@@ -17,6 +17,7 @@ export type BlockCriteria = {
     payloadLength?: OrNumericCriteria<number>;
     payloadHash?: OrEqualCriteria<string>;
     generatorPublicKey?: OrEqualCriteria<string>;
+    username?: OrEqualCriteria<string>;
     blockSignature?: OrEqualCriteria<string>;
 };
 

--- a/packages/p2p/src/network-state.ts
+++ b/packages/p2p/src/network-state.ts
@@ -251,7 +251,7 @@ export class NetworkState implements Contracts.P2P.NetworkState {
     private async setLastBlock(lastBlock: Interfaces.IBlock, monitor?: Contracts.P2P.NetworkMonitor): Promise<void> {
         this.nodeHeight = lastBlock.data.height;
         this.lastBlockId = lastBlock.data.id;
-        this.lastGenerator = lastBlock.data.generatorPublicKey;
+        this.lastGenerator = lastBlock.data.username;
 
         if (monitor) {
             const blockTimeLookup = await Utils.forgingInfoCalculator.getBlockTimeLookup(

--- a/packages/p2p/src/peer-verifier.ts
+++ b/packages/p2p/src/peer-verifier.ts
@@ -40,6 +40,9 @@ export class PeerVerifier implements Contracts.P2P.PeerVerifier {
     @Container.inject(Container.Identifiers.Application)
     private readonly app!: Contracts.Kernel.Application;
 
+    @Container.inject(Container.Identifiers.BlockchainService)
+    private readonly blockchain!: Contracts.Blockchain.Blockchain;
+
     @Container.inject(Container.Identifiers.DposState)
     @Container.tagged("state", "blockchain")
     private readonly dposState!: Contracts.State.DposState;
@@ -466,12 +469,11 @@ export class PeerVerifier implements Contracts.P2P.PeerVerifier {
             delegates = this.dposState.getRoundDelegates().slice();
         }
 
-        const delegatesByPublicKey: Record<string, Contracts.State.Wallet> = {};
+        const delegatesByUsername: Record<string, Contracts.State.Wallet> = {};
         for (const delegate of delegates) {
-            Utils.assert.defined<string>(delegate.getPublicKey());
-            delegatesByPublicKey[delegate.getPublicKey()!] = delegate;
+            delegatesByUsername[delegate.getAttribute("delegate.username")] = delegate;
         }
-        return delegatesByPublicKey;
+        return delegatesByUsername;
     }
 
     /**
@@ -535,23 +537,26 @@ export class PeerVerifier implements Contracts.P2P.PeerVerifier {
      * Verify a given block from the peer's chain - must be signed by one of the provided delegates.
      * @param {Interfaces.IBlockData} blockData the block to verify
      * @param {Number} expectedHeight the given block must be at this height
-     * @param {Object} delegatesByPublicKey a map of { publicKey: delegate, ... }, one of these
+     * @param {Object} delegatesByUsername a map of { username: delegate, ... }, one of these
      * delegates must have signed the block
      * @return {Boolean} true if the block is legit (signed by the appropriate delegate)
      */
     private verifyPeerBlock(
         blockData: Interfaces.IBlockData,
         expectedHeight: number,
-        delegatesByPublicKey: Record<string, Contracts.State.Wallet>,
+        delegatesByUsername: Record<string, Contracts.State.Wallet>,
     ): boolean {
         const block: Interfaces.IBlock | undefined = Blocks.BlockFactory.fromData(blockData);
 
         Utils.assert.defined<Interfaces.IBlock>(block);
 
+        this.blockchain.setBlockUsername(block.data);
+        Utils.assert.defined<Interfaces.IBlock>(block.data.username);
+
         if (!block.verifySignature()) {
             this.log(
                 Severity.DEBUG_EXTRA,
-                `failure: peer's block at height ${expectedHeight.toLocaleString()} does not pass crypto-validation`,
+                `failure: peer's block at height ${expectedHeight.toLocaleString()} does not pass crypto validation`,
             );
             return false;
         }
@@ -566,11 +571,10 @@ export class PeerVerifier implements Contracts.P2P.PeerVerifier {
             return false;
         }
 
-        if (delegatesByPublicKey[block.data.generatorPublicKey]) {
+        if (delegatesByUsername[block.data.username]) {
             this.log(
                 Severity.DEBUG_EXTRA,
-                `successfully verified block at height ${height.toLocaleString()}, signed by ` +
-                    block.data.generatorPublicKey,
+                `successfully verified block at height ${height.toLocaleString()}, signed by ` + block.data.username,
                 true,
             );
 
@@ -581,7 +585,7 @@ export class PeerVerifier implements Contracts.P2P.PeerVerifier {
             Severity.DEBUG_EXTRA,
             `failure: block ${this.anyToString(blockData)} is not signed by any of the delegates ` +
                 `for the corresponding round: ` +
-                this.anyToString(Object.values(delegatesByPublicKey)),
+                this.anyToString(Object.values(delegatesByUsername)),
         );
 
         return false;

--- a/packages/p2p/src/socket-server/controllers/internal.ts
+++ b/packages/p2p/src/socket-server/controllers/internal.ts
@@ -58,10 +58,10 @@ export class InternalController extends Controller {
 
         const { reward } =
             delegates[forgingInfo.currentForger] &&
-            this.walletRepository.hasByPublicKey(delegates[forgingInfo.currentForger].publicKey!)
+            this.walletRepository.hasByUsername(delegates[forgingInfo.currentForger].delegate.username)
                 ? await this.roundState.getRewardForBlockInRound(
                       height,
-                      this.walletRepository.findByPublicKey(delegates[forgingInfo.currentForger].publicKey!),
+                      this.walletRepository.findByUsername(delegates[forgingInfo.currentForger].delegate.username),
                   )
                 : Managers.configManager.getMilestone();
 

--- a/packages/snapshots/src/codecs/message-pack-codec.ts
+++ b/packages/snapshots/src/codecs/message-pack-codec.ts
@@ -23,13 +23,15 @@ export class MessagePackCodec implements Codec {
         Block_burned_fee: Utils.BigNumber;
         Block_dev_fund: Utils.BigNumber;
         Block_id: string;
+        Block_username: string;
+        Block_version: number;
     }): Buffer {
         try {
             const blockCamelised = cameliseKeys(MessagePackCodec.removePrefix(block, "Block_"));
-
             return encode([
                 block.Block_burned_fee,
                 block.Block_dev_fund,
+                block.Block_version === 0 ? block.Block_username : undefined,
                 Blocks.Serialiser.serialise(blockCamelised, true),
             ]);
         } catch (err) {
@@ -39,10 +41,13 @@ export class MessagePackCodec implements Codec {
 
     public decodeBlock(buffer: Buffer): Models.Block {
         try {
-            const [burnedFee, devFund, serialised] = decode(buffer);
+            const [burnedFee, devFund, username, serialised] = decode(buffer);
             const data = Blocks.Deserialiser.deserialise(serialised, false).data as Models.Block;
             data.burnedFee = burnedFee;
             data.devFund = devFund;
+            if (username) {
+                data.username = username;
+            }
             return data;
         } catch (err) {
             throw new CodecException.BlockDecodeException(undefined, err.message);

--- a/packages/state/src/block-state.ts
+++ b/packages/state/src/block-state.ts
@@ -30,12 +30,16 @@ export class BlockState implements Contracts.State.BlockState {
             index: number | undefined;
         },
     ): Promise<void> {
+        let forgerWallet: Contracts.State.Wallet;
+
         if (block.data.height === 1) {
             this.initGenesisForgerWallet(block.data.generatorPublicKey);
+            forgerWallet = this.walletRepository.findByPublicKey(block.data.generatorPublicKey);
+        } else {
+            forgerWallet = this.walletRepository.findByUsername(block.data.username!);
         }
 
         const previousBlock = this.state.getLastBlock();
-        const forgerWallet = this.walletRepository.findByPublicKey(block.data.generatorPublicKey);
 
         const appliedTransactions: Interfaces.ITransaction[] = [];
         try {
@@ -60,7 +64,7 @@ export class BlockState implements Contracts.State.BlockState {
     }
 
     public async revertBlock(block: Interfaces.IBlock): Promise<void> {
-        const forgerWallet = this.walletRepository.findByPublicKey(block.data.generatorPublicKey);
+        const forgerWallet = this.walletRepository.findByUsername(block.data.username!);
 
         const revertedTransactions: Interfaces.ITransaction[] = [];
         try {
@@ -220,7 +224,7 @@ export class BlockState implements Contracts.State.BlockState {
         delegateAttribute.devFunds = delegateAttribute.devFunds.minus(devFund);
 
         const { results } = await this.blockHistoryService.listByCriteria(
-            { generatorPublicKey: block.data.generatorPublicKey, height: { to: block.data.height - 1 } },
+            { username: block.data.username, height: { to: block.data.height - 1 } },
             [{ property: "height", direction: "desc" }],
             { offset: 0, limit: 1 },
         );

--- a/packages/state/src/round-state.ts
+++ b/packages/state/src/round-state.ts
@@ -137,7 +137,7 @@ export class RoundState implements Contracts.State.RoundState {
         let reward: Utils.BigNumber | undefined = undefined;
         if (dynamicReward && dynamicReward.enabled) {
             alreadyForged = this.blocksInCurrentRound.some(
-                (blockGenerator) => blockGenerator.data.generatorPublicKey === wallet.getPublicKey(),
+                (blockGenerator) => blockGenerator.data.username === wallet.getAttribute("delegate.username"),
             );
             if (alreadyForged) {
                 reward = Utils.BigNumber.make(dynamicReward.secondaryReward);
@@ -191,18 +191,16 @@ export class RoundState implements Contracts.State.RoundState {
     private detectMissedRound(): void {
         for (const delegate of this.forgingDelegates) {
             const isBlockProduced = this.blocksInCurrentRound.some(
-                (blockGenerator) => blockGenerator.data.generatorPublicKey === delegate.getPublicKey(),
+                (blockGenerator) => blockGenerator.data.username === delegate.getAttribute("delegate.username"),
             );
 
             if (!isBlockProduced) {
-                const wallet: Contracts.State.Wallet = this.walletRepository.findByPublicKey(delegate.getPublicKey()!);
-
                 this.logger.debug(
-                    `Delegate ${wallet.getAttribute("delegate.username")} just missed a round :cold_sweat:`,
+                    `Delegate ${delegate.getAttribute("delegate.username")} just missed a round :cold_sweat:`,
                 );
 
                 this.events.dispatch(Enums.RoundEvent.Missed, {
-                    delegate: wallet,
+                    delegate,
                 });
             }
         }

--- a/packages/transactions/src/handlers/core/delegate-registration.ts
+++ b/packages/transactions/src/handlers/core/delegate-registration.ts
@@ -72,14 +72,13 @@ export class DelegateRegistrationTransactionHandler extends TransactionHandler {
 
         const forgedBlocks = await this.blockRepository.getDelegatesForgedBlocks();
         const lastForgedBlocks = await this.blockRepository.getLastForgedBlocks();
-        for (const block of forgedBlocks) {
-            const wallet: Contracts.State.Wallet = this.walletRepository.findByPublicKey(block.generatorPublicKey);
 
-            // Genesis wallet is empty
-            if (!wallet.hasAttribute("delegate")) {
+        for (const block of forgedBlocks) {
+            if (!block.username) {
                 continue;
             }
 
+            const wallet: Contracts.State.Wallet = this.walletRepository.findByUsername(block.username);
             const delegate: Contracts.State.WalletDelegateAttributes = wallet.getAttribute("delegate");
             delegate.burnedFees = delegate.forgedFees.plus(block.burnedFees);
             delegate.forgedFees = delegate.forgedFees.plus(block.totalFees);
@@ -89,13 +88,11 @@ export class DelegateRegistrationTransactionHandler extends TransactionHandler {
         }
 
         for (const block of lastForgedBlocks) {
-            const wallet: Contracts.State.Wallet = this.walletRepository.findByPublicKey(block.generatorPublicKey);
-
-            // Genesis wallet is empty
-            if (!wallet.hasAttribute("delegate")) {
+            if (!block.username) {
                 continue;
             }
 
+            const wallet: Contracts.State.Wallet = this.walletRepository.findByUsername(block.username);
             wallet.setAttribute("delegate.lastBlock", block.id);
         }
     }


### PR DESCRIPTION
This PR lays the foundations for a new flexible format for blocks on the Solar blockchain. It adds a new column to the `blocks` database table containing the name of the delegate that produced the block and changes most internal delegate wallet lookups to use the delegate's username rather than its public key. It also adds support for searching and sorting by `username` in the `/blocks` API endpoint.

**Important note:** This will trigger a database migration that will take several minutes to complete.