### PR TITLE
feat(crypto): implement bls12-381

### DIFF
--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -23,6 +23,7 @@
         "rollup": "rollup -c"
     },
     "dependencies": {
+        "@noble/bls12-381": "1.3.0",
         "@scure/bip32": "1.1.0",
         "ajv": "6.12.6",
         "ajv-keywords": "3.4.1",

--- a/packages/crypto/src/blocks/factory.ts
+++ b/packages/crypto/src/blocks/factory.ts
@@ -10,7 +10,7 @@ export class BlockFactory {
     public static make(data: IBlockData, keys: IKeyPair, aux?: Buffer): IBlock {
         const { bip340 } = configManager.getMilestone(data.height);
 
-        data.generatorPublicKey = keys.publicKey;
+        data.generatorPublicKey = keys.publicKey.secp256k1;
 
         const payloadHash: Buffer = Serialiser.serialise(data, false);
         const hash: Buffer = HashAlgorithms.sha256(payloadHash);

--- a/packages/crypto/src/crypto/hash.ts
+++ b/packages/crypto/src/crypto/hash.ts
@@ -25,11 +25,11 @@ export class Hash {
         }
     }
 
-    public static async aggregatePublicKeysBLS(publicKeys: Buffer[] | string[]): Promise<Buffer> {
+    public static aggregatePublicKeysBLS(publicKeys: Buffer[] | string[]): Buffer {
         return Buffer.from(bls.aggregatePublicKeys(publicKeys));
     }
 
-    public static async aggregateSignaturesBLS(signatures: Buffer[] | string[]): Promise<Buffer> {
+    public static aggregateSignaturesBLS(signatures: Buffer[] | string[]): Buffer {
         return Buffer.from(bls.aggregateSignatures(signatures));
     }
 

--- a/packages/crypto/src/crypto/hdwallet.ts
+++ b/packages/crypto/src/crypto/hdwallet.ts
@@ -1,4 +1,6 @@
+import * as bls from "@noble/bls12-381";
 import { HDKey } from "@scure/bip32";
+import { secp256k1 } from "bcrypto";
 import { mnemonicToSeedSync } from "bip39";
 
 import { IKeyPair } from "../interfaces";
@@ -29,17 +31,14 @@ export class HDWallet {
             throw new Error();
         }
 
+        const privateKey: Buffer = Buffer.from(node.privateKey);
+
         return {
-            publicKey: Buffer.from(
-                node.publicKey.buffer,
-                node.publicKey.byteOffset,
-                node.publicKey.byteLength,
-            ).toString("hex"),
-            privateKey: Buffer.from(
-                node.privateKey.buffer,
-                node.privateKey.byteOffset,
-                node.privateKey.byteLength,
-            ).toString("hex"),
+            publicKey: {
+                secp256k1: secp256k1.publicKeyCreate(privateKey, true).toString("hex"),
+                bls12381: Buffer.from(bls.getPublicKey(privateKey)).toString("hex"),
+            },
+            privateKey: Buffer.from(node.privateKey).toString("hex"),
             compressed: true,
         };
     }

--- a/packages/crypto/src/crypto/message.ts
+++ b/packages/crypto/src/crypto/message.ts
@@ -10,7 +10,7 @@ export class Message {
         const keys: IKeyPair = Keys.fromPassphrase(passphrase);
 
         return {
-            publicKey: keys.publicKey,
+            publicKey: keys.publicKey.secp256k1,
             signature: Hash.signSchnorr(this.createHash(message), keys, true),
             message,
         };
@@ -24,7 +24,7 @@ export class Message {
         const keys: IKeyPair = Keys.fromWIF(wif, network);
 
         return {
-            publicKey: keys.publicKey,
+            publicKey: keys.publicKey.secp256k1,
             signature: Hash.signSchnorr(this.createHash(message), keys, true),
             message,
         };

--- a/packages/crypto/src/identities/keys.ts
+++ b/packages/crypto/src/identities/keys.ts
@@ -1,3 +1,4 @@
+import * as bls from "@noble/bls12-381";
 import { secp256k1 } from "bcrypto";
 import wif from "wif";
 
@@ -16,7 +17,10 @@ export class Keys {
         privateKey = privateKey instanceof Buffer ? privateKey : Buffer.from(privateKey, "hex");
 
         return {
-            publicKey: secp256k1.publicKeyCreate(privateKey, compressed).toString("hex"),
+            publicKey: {
+                secp256k1: secp256k1.publicKeyCreate(privateKey, compressed).toString("hex"),
+                bls12381: Buffer.from(bls.getPublicKey(privateKey)).toString("hex"),
+            },
             privateKey: privateKey.toString("hex"),
             compressed,
         };
@@ -38,7 +42,10 @@ export class Keys {
         }
 
         return {
-            publicKey: secp256k1.publicKeyCreate(privateKey, compressed).toString("hex"),
+            publicKey: {
+                secp256k1: secp256k1.publicKeyCreate(privateKey, compressed).toString("hex"),
+                bls12381: Buffer.from(bls.getPublicKey(privateKey)).toString("hex"),
+            },
             privateKey: privateKey.toString("hex"),
             compressed,
         };

--- a/packages/crypto/src/identities/public-key.ts
+++ b/packages/crypto/src/identities/public-key.ts
@@ -8,11 +8,11 @@ import { Keys } from "./keys";
 
 export class PublicKey {
     public static fromPassphrase(passphrase: string): string {
-        return Keys.fromPassphrase(passphrase).publicKey;
+        return Keys.fromPassphrase(passphrase).publicKey.secp256k1;
     }
 
     public static fromWIF(wif: string, network?: NetworkType): string {
-        return Keys.fromWIF(wif, network).publicKey;
+        return Keys.fromWIF(wif, network).publicKey.secp256k1;
     }
 
     public static fromMultiSignatureAsset(asset: IMultiSignatureAsset): string {

--- a/packages/crypto/src/interfaces/identities.ts
+++ b/packages/crypto/src/interfaces/identities.ts
@@ -1,5 +1,5 @@
 export interface IKeyPair {
-    publicKey: string;
+    publicKey: { secp256k1: string; bls12381: string };
     privateKey: string;
     compressed: boolean;
 }

--- a/packages/crypto/src/transactions/builders/transactions/core/second-signature.ts
+++ b/packages/crypto/src/transactions/builders/transactions/core/second-signature.ts
@@ -15,7 +15,7 @@ export class SecondSignatureBuilder extends TransactionBuilder<SecondSignatureBu
 
     public signatureAsset(secondPassphrase: string): SecondSignatureBuilder {
         if (this.data.asset && this.data.asset.signature) {
-            this.data.asset.signature.publicKey = Keys.fromPassphrase(secondPassphrase).publicKey;
+            this.data.asset.signature.publicKey = Keys.fromPassphrase(secondPassphrase).publicKey.secp256k1;
         }
 
         return this;

--- a/packages/crypto/src/transactions/builders/transactions/transaction.ts
+++ b/packages/crypto/src/transactions/builders/transactions/transaction.ts
@@ -166,7 +166,7 @@ export abstract class TransactionBuilder<TBuilder extends TransactionBuilder<TBu
     }
 
     private signWithKeyPair(keys: IKeyPair): TBuilder {
-        this.data.senderPublicKey = keys.publicKey;
+        this.data.senderPublicKey = keys.publicKey.secp256k1;
 
         this.data.signature = Signer.sign(this.getSigningObject(), keys, {
             disableVersionCheck: this.disableVersionCheck,

--- a/packages/forger/src/delegate.ts
+++ b/packages/forger/src/delegate.ts
@@ -32,7 +32,7 @@ export class Delegate implements IDelegate {
      */
     public constructor(privateKey: string) {
         this.keys = Identities.Keys.fromPrivateKey(privateKey);
-        this.publicKey = this.keys.publicKey;
+        this.publicKey = this.keys.publicKey.secp256k1;
         this.address = Identities.Address.fromPublicKey(this.publicKey);
     }
 
@@ -73,7 +73,7 @@ export class Delegate implements IDelegate {
         return Blocks.BlockFactory.make(
             {
                 version: 0,
-                generatorPublicKey: keys.publicKey,
+                generatorPublicKey: keys.publicKey.secp256k1,
                 timestamp: options.timestamp,
                 previousBlock: options.previousBlock.id,
                 height: options.previousBlock.height + 1,

--- a/packages/p2p/src/network-monitor.ts
+++ b/packages/p2p/src/network-monitor.ts
@@ -853,8 +853,11 @@ export class NetworkMonitor implements Contracts.P2P.NetworkMonitor {
             const { keys } = readJsonSync(`${this.app.configPath()}/delegates.json`);
             for (const key of keys) {
                 const keyPair: Interfaces.IKeyPair = Identities.Keys.fromPrivateKey(key);
-                if (delegates.includes(keyPair.publicKey) && publicKeys.includes(keyPair.publicKey)) {
-                    delegatesOnThisNode.push(keyPair.publicKey);
+                if (
+                    delegates.includes(keyPair.publicKey.secp256k1) &&
+                    publicKeys.includes(keyPair.publicKey.secp256k1)
+                ) {
+                    delegatesOnThisNode.push(keyPair.publicKey.secp256k1);
                 }
             }
         }

--- a/packages/p2p/src/socket-server/controllers/peer.ts
+++ b/packages/p2p/src/socket-server/controllers/peer.ts
@@ -107,8 +107,11 @@ export class PeerController extends Controller {
             const { keys } = readJsonSync(`${this.app.configPath()}/delegates.json`);
             for (const key of keys) {
                 const keyPair: Interfaces.IKeyPair = Identities.Keys.fromPrivateKey(key);
-                if (delegates.includes(keyPair.publicKey) && publicKeys.includes(keyPair.publicKey)) {
-                    header.publicKeys.push(keyPair.publicKey);
+                if (
+                    delegates.includes(keyPair.publicKey.secp256k1) &&
+                    publicKeys.includes(keyPair.publicKey.secp256k1)
+                ) {
+                    header.publicKeys.push(keyPair.publicKey.secp256k1);
                     header.signatures.push(Crypto.Hash.signSchnorr(stateBuffer, keyPair));
                 }
             }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -328,6 +328,7 @@ importers:
       '@babel/plugin-transform-runtime': 7.18.5
       '@babel/preset-typescript': 7.17.12
       '@babel/runtime': 7.18.3
+      '@noble/bls12-381': 1.3.0
       '@rollup/plugin-babel': 5.3.0
       '@rollup/plugin-commonjs': 21.1.0
       '@rollup/plugin-inject': 4.0.2
@@ -361,6 +362,7 @@ importers:
       util: 0.12.4
       wif: 2.0.6
     dependencies:
+      '@noble/bls12-381': 1.3.0
       '@scure/bip32': 1.1.0
       ajv: 6.12.6
       ajv-keywords: 3.4.1_ajv@6.12.6
@@ -3832,6 +3834,10 @@ packages:
   /@mdn/browser-compat-data/3.3.14:
     resolution: {integrity: sha512-n2RC9d6XatVbWFdHLimzzUJxJ1KY8LdjqrW6YvGPiRmsHkhOUx74/Ct10x5Yo7bC/Jvqx7cDEW8IMPv/+vwEzA==}
     dev: true
+
+  /@noble/bls12-381/1.3.0:
+    resolution: {integrity: sha512-rYQXhQ+Q6fDYLSO/ZUY9RsDE0Adi2Iua9xXxNxLmO8jXiBZGVxecWQsC1116aRlv3XGLvoZTGqyy5vAcBu368g==}
+    dev: false
 
   /@noble/hashes/1.1.2:
     resolution: {integrity: sha512-KYRCASVTv6aeUi1tsF8/vpyR7zpfs3FUzy2Jqm+MU+LmUKhQ0y2FpfwqkCcxSg2ua4GALJd8k2R76WxwZGbQpA==}


### PR DESCRIPTION
BLS12-381 has been on our radar for a while as the signature candidate for Solar's new block format which is finally being implemented, so this PR adds the necessary support for generating such key pairs, as well as signing and verifying messages and aggregating public keys and signatures.