### PR TITLE
feat: calculate delegate productivity

### DIFF
--- a/packages/api/src/controllers/blocks.ts
+++ b/packages/api/src/controllers/blocks.ts
@@ -3,7 +3,7 @@ import Hapi from "@hapi/hapi";
 import { Enums } from "@solar-network/crypto";
 import { Container, Contracts } from "@solar-network/kernel";
 
-import { BlockResource, BlockWithTransactionsResource, TransactionResource } from "../resources";
+import { BlockResource, BlockWithTransactionsResource, MissedBlockResource, TransactionResource } from "../resources";
 import { Controller } from "./controller";
 
 @Container.injectable()
@@ -13,6 +13,9 @@ export class BlocksController extends Controller {
 
     @Container.inject(Container.Identifiers.BlockHistoryService)
     private readonly blockHistoryService!: Contracts.Shared.BlockHistoryService;
+
+    @Container.inject(Container.Identifiers.MissedBlockHistoryService)
+    private readonly missedBlockHistoryService!: Contracts.Shared.MissedBlockHistoryService;
 
     @Container.inject(Container.Identifiers.TransactionHistoryService)
     private readonly transactionHistoryService!: Contracts.Shared.TransactionHistoryService;
@@ -37,6 +40,17 @@ export class BlocksController extends Controller {
 
             return this.toPagination(blockListResult, BlockResource, false);
         }
+    }
+
+    public async missed(request: Hapi.Request, h: Hapi.ResponseToolkit): Promise<object> {
+        const missedBlockListResult = await this.missedBlockHistoryService.listByCriteria(
+            request.query,
+            this.getListingOrder(request),
+            this.getListingPage(request),
+            this.getListingOptions(),
+        );
+
+        return this.toPagination(missedBlockListResult, MissedBlockResource, true);
     }
 
     public async first(request: Hapi.Request, h: Hapi.ResponseToolkit): Promise<object> {

--- a/packages/api/src/defaults.ts
+++ b/packages/api/src/defaults.ts
@@ -54,6 +54,7 @@ export const defaults = {
         events: [
             Enums.BlockEvent.Applied,
             Enums.BlockEvent.Reverted,
+            Enums.DelegateEvent.ProductivityChanged,
             Enums.ForgerEvent.Missing,
             Enums.RoundEvent.Created,
             Enums.RoundEvent.Missed,

--- a/packages/api/src/resources-new/block.ts
+++ b/packages/api/src/resources-new/block.ts
@@ -33,3 +33,8 @@ export const blockCriteriaSchemaObject = {
 
 export const blockParamSchema = Joi.alternatives(blockIdSchema, blockHeightSchema);
 export const blockSortingSchema = Schemas.createSortingSchema(Schemas.blockCriteriaSchemas, [], false);
+export const blockSortingSchemaWithoutUsernameOrGeneratorPublicKey = Schemas.createSortingSchema(
+    Schemas.blockCriteriaSchemasWithoutUsernameOrGeneratorPublicKey,
+    [],
+    false,
+);

--- a/packages/api/src/resources-new/delegate.ts
+++ b/packages/api/src/resources-new/delegate.ts
@@ -22,6 +22,7 @@ export type DelegateResource = {
     resignationType: string | undefined;
     blocks: {
         produced: number;
+        productivity: number | undefined;
         last: string | undefined;
     };
     forged: {
@@ -48,6 +49,7 @@ export const delegateCriteriaSchemaObject = {
     resignationType: Joi.string().valid("permanent", "temporary"),
     blocks: {
         produced: Schemas.createRangeCriteriaSchema(Joi.number().integer().min(0)),
+        productivity: Schemas.createRangeCriteriaSchema(Joi.number().min(0)),
         last: {
             id: blockCriteriaSchemaObject.id,
             height: blockCriteriaSchemaObject.height,

--- a/packages/api/src/resources-new/index.ts
+++ b/packages/api/src/resources-new/index.ts
@@ -1,5 +1,6 @@
 export * from "./block";
 export * from "./delegate";
 export * from "./lock";
+export * from "./missed-block";
 export * from "./transaction";
 export * from "./wallet";

--- a/packages/api/src/resources-new/missed-block.ts
+++ b/packages/api/src/resources-new/missed-block.ts
@@ -1,0 +1,9 @@
+import * as Schemas from "../schemas";
+
+export const missedBlockSortingSchema = Schemas.createSortingSchema(Schemas.missedBlockCriteriaSchemas, [], false);
+
+export const missedBlockSortingSchemaWithoutUsername = Schemas.createSortingSchema(
+    Schemas.missedBlockCriteriaSchemasWithoutUsername,
+    [],
+    false,
+);

--- a/packages/api/src/resources/index.ts
+++ b/packages/api/src/resources/index.ts
@@ -1,6 +1,7 @@
 export * from "./block-with-transactions";
 export * from "./block";
 export * from "./fee-statistics";
+export * from "./missed-block";
 export * from "./peer";
 export * from "./ports";
 export * from "./round";

--- a/packages/api/src/resources/missed-block.ts
+++ b/packages/api/src/resources/missed-block.ts
@@ -1,0 +1,32 @@
+import { Container, Utils } from "@solar-network/kernel";
+
+import { Resource } from "../interfaces";
+
+@Container.injectable()
+export class MissedBlockResource implements Resource {
+    /**
+     * Return the raw representation of the resource.
+     *
+     * @param {*} resource
+     * @returns {object}
+     * @memberof Resource
+     */
+    public raw(resource: object): object {
+        return resource;
+    }
+
+    /**
+     * Return the transformed representation of the resource.
+     *
+     * @param {*} resource
+     * @returns {object}
+     * @memberof Resource
+     */
+    public transform(resource: { timestamp: number; height: number; username: string }): object {
+        return {
+            height: resource.height,
+            timestamp: Utils.formatTimestamp(resource.timestamp),
+            username: resource.username,
+        };
+    }
+}

--- a/packages/api/src/routes/blocks.ts
+++ b/packages/api/src/routes/blocks.ts
@@ -2,7 +2,7 @@ import Hapi from "@hapi/hapi";
 import Joi from "joi";
 
 import { BlocksController } from "../controllers/blocks";
-import { blockSortingSchema, transactionSortingSchema } from "../resources-new";
+import { blockSortingSchema, missedBlockSortingSchema, transactionSortingSchema } from "../resources-new";
 import * as Schemas from "../schemas";
 
 export const register = (server: Hapi.Server): void => {
@@ -21,6 +21,27 @@ export const register = (server: Hapi.Server): void => {
                     transform: Joi.bool().default(true),
                 })
                     .concat(blockSortingSchema)
+                    .concat(Schemas.pagination),
+            },
+            plugins: {
+                pagination: {
+                    enabled: true,
+                },
+            },
+        },
+    });
+
+    server.route({
+        method: "GET",
+        path: "/blocks/missed",
+        handler: (request: Hapi.Request, h: Hapi.ResponseToolkit) => controller.missed(request, h),
+        options: {
+            validate: {
+                query: Joi.object({
+                    ...server.app.schemas.missedBlockCriteriaSchemas,
+                    orderBy: server.app.schemas.missedBlocksOrderBy,
+                })
+                    .concat(missedBlockSortingSchema)
                     .concat(Schemas.pagination),
             },
             plugins: {

--- a/packages/api/src/routes/delegates.ts
+++ b/packages/api/src/routes/delegates.ts
@@ -3,9 +3,10 @@ import Joi from "joi";
 
 import { DelegatesController } from "../controllers/delegates";
 import {
-    blockSortingSchema,
+    blockSortingSchemaWithoutUsernameOrGeneratorPublicKey,
     delegateCriteriaSchema,
     delegateSortingSchema,
+    missedBlockSortingSchema,
     walletCriteriaSchema,
     walletParamSchema,
     walletSortingSchema,
@@ -73,11 +74,35 @@ export const register = (server: Hapi.Server): void => {
                     id: walletParamSchema,
                 }),
                 query: Joi.object({
-                    ...server.app.schemas.blockCriteriaSchemas,
+                    ...server.app.schemas.blockCriteriaSchemasWithoutUsernameOrGeneratorPublicKey,
                     orderBy: server.app.schemas.blocksOrderBy,
                     transform: Joi.bool().default(true),
                 })
-                    .concat(blockSortingSchema)
+                    .concat(blockSortingSchemaWithoutUsernameOrGeneratorPublicKey)
+                    .concat(Schemas.pagination),
+            },
+            plugins: {
+                pagination: {
+                    enabled: true,
+                },
+            },
+        },
+    });
+
+    server.route({
+        method: "GET",
+        path: "/delegates/{id}/blocks/missed",
+        handler: (request: Hapi.Request, h: Hapi.ResponseToolkit) => controller.missedBlocks(request, h),
+        options: {
+            validate: {
+                params: Joi.object({
+                    id: walletParamSchema,
+                }),
+                query: Joi.object({
+                    ...server.app.schemas.missedBlockCriteriaSchemasWithoutUsername,
+                    orderBy: server.app.schemas.missedBlocksOrderBy,
+                })
+                    .concat(missedBlockSortingSchema)
                     .concat(Schemas.pagination),
             },
             plugins: {

--- a/packages/api/src/schemas.ts
+++ b/packages/api/src/schemas.ts
@@ -164,6 +164,7 @@ export const orderBy = Joi.alternatives().try(
 );
 
 export const blocksOrderBy = orderBy.default("height:desc");
+export const missedBlocksOrderBy = orderBy.default("timestamp:desc");
 export const transactionsOrderBy = orderBy.default(["timestamp:desc", "sequence:desc"]);
 
 const equalCriteria = (value: any) => value;
@@ -204,6 +205,26 @@ export const blockCriteriaSchemas = {
     ),
     blockSignature: orEqualCriteria(Joi.string().hex().length(128)),
 };
+
+export const blockCriteriaSchemasWithoutUsernameOrGeneratorPublicKey = { ...blockCriteriaSchemas } as any;
+delete blockCriteriaSchemasWithoutUsernameOrGeneratorPublicKey.generatorPublicKey;
+delete blockCriteriaSchemasWithoutUsernameOrGeneratorPublicKey.username;
+
+export const missedBlockCriteriaSchemas = {
+    timestamp: orNumericCriteria(Joi.number().integer().min(0)),
+    height: orNumericCriteria(Joi.number().integer().min(1)),
+    username: orEqualCriteria(
+        Joi.string()
+            .regex(/^(?=.*[a-z!@$&_.])([a-z0-9!@$&_.]?)+$/)
+            .min(1)
+            .max(20),
+    ),
+};
+
+export const missedBlockCriteriaSchemasWithoutUsername = {
+    ...blockCriteriaSchemasWithoutUsernameOrGeneratorPublicKey,
+} as any;
+delete missedBlockCriteriaSchemasWithoutUsername.username;
 
 export const transactionCriteriaSchemas = {
     address: orEqualCriteria(address),

--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -32,6 +32,15 @@ export class Server {
      * @memberof Server
      */
     @Container.inject(Container.Identifiers.PluginConfiguration)
+    @Container.tagged("plugin", "@solar-network/blockchain")
+    private readonly blockchainConfiguration!: Providers.PluginConfiguration;
+
+    /**
+     * @private
+     * @type {Providers.PluginConfiguration}
+     * @memberof Server
+     */
+    @Container.inject(Container.Identifiers.PluginConfiguration)
     @Container.tagged("plugin", "@solar-network/api")
     private readonly configuration!: Providers.PluginConfiguration;
 
@@ -154,6 +163,17 @@ export class Server {
             swaggerJson.components.schemas.transactionTypeGroups.enum = [...typeGroups];
             swaggerJson.components.schemas.transactionVersions.enum =
                 Transactions.schemas.transactionBaseSchema.properties.version.enum;
+
+            const seconds: number = this.blockchainConfiguration.get("missedBlocksLookback") as number;
+            const days: number = +(seconds / 86400).toFixed(2);
+
+            swaggerJson.paths["/blocks/missed"].get.summary = swaggerJson.paths["/blocks/missed"].get.summary.replace(
+                "X",
+                days,
+            );
+            swaggerJson.paths["/delegates/{identifier}/blocks/missed"].get.summary = swaggerJson.paths[
+                "/delegates/{identifier}/blocks/missed"
+            ].get.summary.replace("X", days);
 
             this.server.route({
                 method: "GET",

--- a/packages/api/src/services/delegate-search-service.ts
+++ b/packages/api/src/services/delegate-search-service.ts
@@ -82,6 +82,7 @@ export class DelegateSearchService {
             resignationType,
             blocks: {
                 produced: delegateAttribute.producedBlocks,
+                productivity: delegateAttribute.productivity,
                 last: delegateAttribute.lastBlock,
             },
             forged: {

--- a/packages/api/src/www/api.json
+++ b/packages/api/src/www/api.json
@@ -555,6 +555,112 @@
                 }
             }
         },
+        "/blocks/missed": {
+            "get": {
+                "tags": [
+                    "Blocks"
+                ],
+                "summary": "Find missed blocks in the last X days",
+                "parameters": [
+                    {
+                        "name": "page",
+                        "in": "query",
+                        "description": "The number of the page that will be returned",
+                        "schema": {
+                            "$ref": "#/components/schemas/page"
+                        }
+                    },
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "description": "The number of results per page",
+                        "schema": {
+                            "$ref": "#/components/schemas/limit"
+                        }
+                    },
+                    {
+                        "name": "username",
+                        "in": "query",
+                        "description": "Username of the delegate that missed the block(s) to be returned",
+                        "schema": {
+                            "$ref": "#/components/schemas/username"
+                        }
+                    },
+                    {
+                        "name": "height",
+                        "in": "query",
+                        "description": "Exact height of the missed block to be returned",
+                        "schema": {
+                            "$ref": "#/components/schemas/oneOrMore"
+                        }
+                    },
+                    {
+                        "name": "height.from",
+                        "in": "query",
+                        "description": "Earliest height of the missed block(s) to be returned",
+                        "schema": {
+                            "$ref": "#/components/schemas/oneOrMore"
+                        }
+                    },
+                    {
+                        "name": "height.to",
+                        "in": "query",
+                        "description": "Latest height of the missed block(s) to be returned",
+                        "schema": {
+                            "$ref": "#/components/schemas/oneOrMore"
+                        }
+                    },
+                    {
+                        "name": "timestamp",
+                        "in": "query",
+                        "description": "Exact time, in seconds since the epoch, of the missed block to be returned",
+                        "schema": {
+                            "$ref": "#/components/schemas/zeroOrMore"
+                        }
+                    },
+                    {
+                        "name": "timestamp.from",
+                        "in": "query",
+                        "description": "Earliest time, in seconds since the epoch, of the missed block(s) to be returned",
+                        "schema": {
+                            "$ref": "#/components/schemas/zeroOrMore"
+                        }
+                    },
+                    {
+                        "name": "timestamp.to",
+                        "in": "query",
+                        "description": "Latest time, in seconds since the epoch, of the missed block(s) to be returned",
+                        "schema": {
+                            "$ref": "#/components/schemas/zeroOrMore"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "404": {
+                        "description": "Delegate not found"
+                    },
+                    "422": {
+                        "description": "Invalid parameter(s)"
+                    }
+                }
+            }
+        },
+        "/blocks/first": {
+            "get": {
+                "tags": [
+                    "Blocks"
+                ],
+                "summary": "Get the first block in the blockchain",
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                }
+            }
+        },
         "/blocks/last": {
             "get": {
                 "tags": [
@@ -886,6 +992,30 @@
                         }
                     },
                     {
+                        "name": "blocks.productivity",
+                        "in": "query",
+                        "description": "Exact productivity rate of the delegate(s) to be returned",
+                        "schema": {
+                            "$ref": "#/components/schemas/zeroOrMore"
+                        }
+                    },
+                    {
+                        "name": "blocks.productivity.from",
+                        "in": "query",
+                        "description": "Lowest productivity rate of the delegate(s) to be returned",
+                        "schema": {
+                            "$ref": "#/components/schemas/zeroOrMore"
+                        }
+                    },
+                    {
+                        "name": "blocks.productivity.to",
+                        "in": "query",
+                        "description": "Highest productivity rate of the delegate(s) to be returned",
+                        "schema": {
+                            "$ref": "#/components/schemas/zeroOrMore"
+                        }
+                    },
+                    {
                         "name": "rank",
                         "in": "query",
                         "description": "Exact rank of the delegate to be returned",
@@ -944,6 +1074,8 @@
                                 "address:desc",
                                 "blocks.produced:asc",
                                 "blocks.produced:desc",
+                                "blocks.productivity:asc",
+                                "blocks.productivity:desc",
                                 "forged.burnedFees:asc",
                                 "forged.burnedFees:desc",
                                 "forged.devFunds:asc",
@@ -1042,6 +1174,100 @@
                         "description": "The number of results per page",
                         "schema": {
                             "$ref": "#/components/schemas/limit"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "404": {
+                        "description": "Delegate not found"
+                    },
+                    "422": {
+                        "description": "Invalid parameter(s)"
+                    }
+                }
+            }
+        },
+        "/delegates/{identifier}/blocks/missed": {
+            "get": {
+                "tags": [
+                    "Delegates"
+                ],
+                "summary": "Find missed blocks in the last X days by a specific delegate",
+                "parameters": [
+                    {
+                        "name": "identifier",
+                        "in": "path",
+                        "description": "Identifier for delegate (address, public key, username)",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/components/schemas/walletIdentifier"
+                        }
+                    },
+                    {
+                        "name": "page",
+                        "in": "query",
+                        "description": "The number of the page that will be returned",
+                        "schema": {
+                            "$ref": "#/components/schemas/page"
+                        }
+                    },
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "description": "The number of results per page",
+                        "schema": {
+                            "$ref": "#/components/schemas/limit"
+                        }
+                    },
+                    {
+                        "name": "height",
+                        "in": "query",
+                        "description": "Exact height of the missed block to be returned",
+                        "schema": {
+                            "$ref": "#/components/schemas/oneOrMore"
+                        }
+                    },
+                    {
+                        "name": "height.from",
+                        "in": "query",
+                        "description": "Earliest height of the missed block(s) to be returned",
+                        "schema": {
+                            "$ref": "#/components/schemas/oneOrMore"
+                        }
+                    },
+                    {
+                        "name": "height.to",
+                        "in": "query",
+                        "description": "Latest height of the missed block(s) to be returned",
+                        "schema": {
+                            "$ref": "#/components/schemas/oneOrMore"
+                        }
+                    },
+                    {
+                        "name": "timestamp",
+                        "in": "query",
+                        "description": "Exact time, in seconds since the epoch, of the missed block to be returned",
+                        "schema": {
+                            "$ref": "#/components/schemas/zeroOrMore"
+                        }
+                    },
+                    {
+                        "name": "timestamp.from",
+                        "in": "query",
+                        "description": "Earliest time, in seconds since the epoch, of the missed block(s) to be returned",
+                        "schema": {
+                            "$ref": "#/components/schemas/zeroOrMore"
+                        }
+                    },
+                    {
+                        "name": "timestamp.to",
+                        "in": "query",
+                        "description": "Latest time, in seconds since the epoch, of the missed block(s) to be returned",
+                        "schema": {
+                            "$ref": "#/components/schemas/zeroOrMore"
                         }
                     }
                 ],

--- a/packages/blockchain/src/defaults.ts
+++ b/packages/blockchain/src/defaults.ts
@@ -3,4 +3,5 @@ export const defaults = {
         maxBlockRewind: 10000,
         steps: 1000,
     },
+    missedBlocksLookback: 2592000, // 30 days
 };

--- a/packages/database/src/database-service.ts
+++ b/packages/database/src/database-service.ts
@@ -54,7 +54,7 @@ export class DatabaseService {
     }
 
     public async reset(): Promise<void> {
-        await this.connection.query("TRUNCATE TABLE blocks, rounds, transactions RESTART IDENTITY;");
+        await this.connection.query("TRUNCATE TABLE blocks, missed_blocks, rounds, transactions RESTART IDENTITY;");
     }
 
     public async getBlock(id: string): Promise<Interfaces.IBlock | undefined> {

--- a/packages/database/src/migrations/20220814000000-create-missed_blocks-table.ts
+++ b/packages/database/src/migrations/20220814000000-create-missed_blocks-table.ts
@@ -1,0 +1,43 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class CreateMissedBlocksTable20220814000000 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<any> {
+        queryRunner.connection.driver.options.extra.logger.debug("Database migration: Creating missed_blocks table");
+        await queryRunner.query(`
+            CREATE TABLE missed_blocks (
+                "timestamp" INTEGER PRIMARY KEY,
+                "height" INTEGER NOT NULL,
+                "username" VARCHAR(20) NOT NULL
+            );
+
+            CREATE FUNCTION delete_missed_blocks_on_delete() RETURNS TRIGGER
+            AS
+            $$
+            BEGIN
+                DELETE
+                FROM missed_blocks
+                WHERE height >= OLD.height;
+                RETURN OLD;
+            END;
+            $$
+            LANGUAGE PLPGSQL
+            VOLATILE;
+
+            CREATE TRIGGER delete_missed_blocks_on_delete
+            BEFORE DELETE
+            ON blocks
+            FOR EACH ROW
+            EXECUTE PROCEDURE delete_missed_blocks_on_delete();
+    `);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<any> {
+        await queryRunner.query(`
+            DROP TRIGGER delete_missed_blocks_on_delete ON blocks;
+
+            DROP FUNCTION delete_missed_blocks_on_delete();
+
+            DROP TABLE missed_blocks;
+        `);
+    }
+}

--- a/packages/database/src/missed-block-filter.ts
+++ b/packages/database/src/missed-block-filter.ts
@@ -1,0 +1,41 @@
+import { Container, Contracts, Utils as AppUtils } from "@solar-network/kernel";
+
+import { MissedBlock } from "./models/missed-block";
+
+const { handleAndCriteria, handleOrCriteria, handleNumericCriteria, optimiseExpression } = AppUtils.Search;
+
+@Container.injectable()
+export class MissedBlockFilter implements Contracts.Database.MissedBlockFilter {
+    public async getExpression(
+        ...criteria: Contracts.Shared.OrBlockCriteria[]
+    ): Promise<Contracts.Search.Expression<MissedBlock>> {
+        const expressions = await Promise.all(
+            criteria.map((c) => handleOrCriteria(c, (c) => this.handleMissedBlockCriteria(c))),
+        );
+
+        return optimiseExpression({ op: "and", expressions });
+    }
+
+    private async handleMissedBlockCriteria(
+        criteria: Contracts.Shared.MissedBlockCriteria,
+    ): Promise<Contracts.Search.Expression<MissedBlock>> {
+        return handleAndCriteria(criteria, async (key) => {
+            switch (key) {
+                case "timestamp":
+                    return handleOrCriteria(criteria.timestamp!, async (c) => {
+                        return handleNumericCriteria("timestamp", c);
+                    });
+                case "height":
+                    return handleOrCriteria(criteria.height!, async (c) => {
+                        return handleNumericCriteria("height", c);
+                    });
+                case "username":
+                    return handleOrCriteria(criteria.username!, async (c) => {
+                        return { property: "username", op: "equal", value: c };
+                    });
+                default:
+                    return { op: "true" };
+            }
+        });
+    }
+}

--- a/packages/database/src/missed-block-history-service.ts
+++ b/packages/database/src/missed-block-history-service.ts
@@ -1,0 +1,68 @@
+import { Interfaces, Managers } from "@solar-network/crypto";
+import { Container, Contracts, Providers, Utils } from "@solar-network/kernel";
+
+import { MissedBlockRepository } from "./repositories/missed-block-repository";
+
+@Container.injectable()
+export class MissedBlockHistoryService implements Contracts.Shared.MissedBlockHistoryService {
+    @Container.inject(Container.Identifiers.BlockchainService)
+    private readonly blockchain!: Contracts.Blockchain.Blockchain;
+
+    @Container.inject(Container.Identifiers.PluginConfiguration)
+    @Container.tagged("plugin", "@solar-network/blockchain")
+    private readonly configuration!: Providers.PluginConfiguration;
+
+    @Container.inject(Container.Identifiers.DatabaseBlockFilter)
+    private readonly missedBlockFilter!: Contracts.Database.MissedBlockFilter;
+
+    @Container.inject(Container.Identifiers.DatabaseMissedBlockRepository)
+    private readonly missedBlockRepository!: MissedBlockRepository;
+
+    public async listByCriteria(
+        criteria: Contracts.Shared.OrBlockCriteria,
+        sorting: Contracts.Search.Sorting,
+        pagination: Contracts.Search.Pagination,
+        options?: Contracts.Search.Options,
+    ): Promise<Contracts.Search.ResultsPage<{ timestamp: number; height: number; username: string }>> {
+        const lastBlock: Interfaces.IBlock = this.blockchain.getLastBlock();
+        const timestamp =
+            (new Date(Utils.formatTimestamp(lastBlock.data.timestamp).unix * 1000).setUTCHours(0, 0, 0, 0) -
+                new Date(Managers.configManager.getMilestone(1).epoch).getTime()) /
+            1000;
+        const earliestTimestamp = timestamp - (this.configuration.get("missedBlocksLookback") as number);
+
+        let clonedCriteria = Utils.cloneDeep(criteria);
+        if (!Array.isArray(clonedCriteria)) {
+            clonedCriteria = [clonedCriteria];
+        }
+
+        for (const criterion of clonedCriteria) {
+            if (typeof criterion.timestamp !== "undefined") {
+                if (typeof criterion.timestamp === "number") {
+                    if (criterion.timestamp < earliestTimestamp) {
+                        criterion.timestamp = 0;
+                    }
+                } else if (typeof criterion.timestamp === "object") {
+                    if (
+                        typeof criterion.timestamp["from"] !== "number" ||
+                        criterion.timestamp["from"] < earliestTimestamp
+                    ) {
+                        criterion.timestamp["from"] = earliestTimestamp;
+                    }
+                }
+            } else {
+                criterion.timestamp = { from: earliestTimestamp };
+            }
+        }
+
+        const expression = await this.missedBlockFilter.getExpression(clonedCriteria);
+        const modelResultsPage = await this.missedBlockRepository.listByExpression(
+            expression,
+            sorting,
+            pagination,
+            options,
+        );
+        const data = modelResultsPage.results;
+        return { ...modelResultsPage, results: data };
+    }
+}

--- a/packages/database/src/models/index.ts
+++ b/packages/database/src/models/index.ts
@@ -1,4 +1,5 @@
 export * from "./block";
 export * from "./migration";
+export * from "./missed-block";
 export * from "./round";
 export * from "./transaction";

--- a/packages/database/src/models/missed-block.ts
+++ b/packages/database/src/models/missed-block.ts
@@ -1,0 +1,26 @@
+import { Contracts } from "@solar-network/kernel";
+import { Column, Entity } from "typeorm";
+
+@Entity({
+    name: "missed_blocks",
+})
+export class MissedBlock implements Contracts.Database.MissedBlockModel {
+    @Column({
+        primary: true,
+        type: "integer",
+        nullable: false,
+    })
+    public timestamp!: number;
+
+    @Column({
+        type: "integer",
+        nullable: false,
+    })
+    public height!: number;
+
+    @Column({
+        type: "varchar",
+        nullable: false,
+    })
+    public username!: string;
+}

--- a/packages/database/src/repositories/index.ts
+++ b/packages/database/src/repositories/index.ts
@@ -1,4 +1,5 @@
 export { AbstractRepository } from "./abstract-repository";
 export { BlockRepository } from "./block-repository";
+export { MissedBlockRepository } from "./missed-block-repository";
 export { RoundRepository } from "./round-repository";
 export { TransactionRepository } from "./transaction-repository";

--- a/packages/database/src/repositories/missed-block-repository.ts
+++ b/packages/database/src/repositories/missed-block-repository.ts
@@ -1,0 +1,63 @@
+import { Enums } from "@solar-network/crypto";
+import { EntityRepository } from "typeorm";
+
+import { MissedBlock } from "../models";
+import { AbstractRepository } from "./abstract-repository";
+
+@EntityRepository(MissedBlock)
+export class MissedBlockRepository extends AbstractRepository<MissedBlock> {
+    public async addMissedBlocks(
+        missedBlocks: { timestamp: number; height: number; username: string }[],
+    ): Promise<void> {
+        const missedBlockEntities: MissedBlock[] = [];
+        return this.manager.transaction(async (manager) => {
+            for (const missedBlock of missedBlocks) {
+                const missedBlockEntity = Object.assign(new MissedBlock(), { ...missedBlock });
+                missedBlockEntities.push(missedBlockEntity);
+            }
+            await manager.save<MissedBlock>(missedBlockEntities, { chunk: 1000 });
+        });
+    }
+
+    public async getBlockProductivity(timestamp: number): Promise<Record<string, number>> {
+        const productivityStatistics = await this.query(`
+            SELECT
+            usernames.username,
+            CASE WHEN produced IS NULL THEN
+                CASE WHEN missed IS NULL THEN
+                    NULL
+                ELSE
+                    0.00
+                END
+            ELSE
+                ROUND((COALESCE(produced.count::numeric, 0) / (COALESCE(produced.count::numeric, 0) + COALESCE(missed.count::numeric, 0))) * 100, 2)
+            END productivity
+            FROM
+                (SELECT asset->'delegate'->>'username' AS username
+                FROM transactions
+                WHERE type_group = ${Enums.TransactionTypeGroup.Core} AND type = ${Enums.CoreTransactionType.DelegateRegistration})
+                usernames
+            FULL OUTER JOIN
+                (SELECT COUNT(username) AS count, username
+                FROM blocks
+                WHERE timestamp >= ${timestamp} GROUP BY username)
+                produced ON usernames.username = produced.username
+            FULL OUTER JOIN
+                (SELECT COUNT(username) AS count, username
+                FROM missed_blocks
+                WHERE timestamp >= ${timestamp} GROUP BY username)
+                missed ON usernames.username = missed.username;
+        `);
+
+        const delegateProductivity = {};
+        for (const { username, productivity } of productivityStatistics) {
+            delegateProductivity[username] = productivity;
+        }
+
+        return delegateProductivity;
+    }
+
+    public async hasMissedBlocks(): Promise<boolean> {
+        return (await this.query("SELECT COUNT(*) count FROM missed_blocks"))[0].count > 0;
+    }
+}

--- a/packages/database/src/service-provider.ts
+++ b/packages/database/src/service-provider.ts
@@ -7,8 +7,10 @@ import { Connection, createConnection, getCustomRepository } from "typeorm";
 import { BlockFilter } from "./block-filter";
 import { BlockHistoryService } from "./block-history-service";
 import { DatabaseService } from "./database-service";
+import { MissedBlockFilter } from "./missed-block-filter";
+import { MissedBlockHistoryService } from "./missed-block-history-service";
 import { ModelConverter } from "./model-converter";
-import { BlockRepository, RoundRepository, TransactionRepository } from "./repositories";
+import { BlockRepository, MissedBlockRepository, RoundRepository, TransactionRepository } from "./repositories";
 import { TransactionFilter } from "./transaction-filter";
 import { TransactionHistoryService } from "./transaction-history-service";
 import { SnakeNamingStrategy } from "./utils/snake-naming-strategy";
@@ -29,6 +31,12 @@ export class ServiceProvider extends Providers.ServiceProvider {
         this.app.bind(Container.Identifiers.DatabaseBlockRepository).toConstantValue(this.getBlockRepository());
         this.app.bind(Container.Identifiers.DatabaseBlockFilter).to(BlockFilter);
         this.app.bind(Container.Identifiers.BlockHistoryService).to(BlockHistoryService);
+
+        this.app
+            .bind(Container.Identifiers.DatabaseMissedBlockRepository)
+            .toConstantValue(this.getMissedBlockRepository());
+        this.app.bind(Container.Identifiers.DatabaseMissedBlockFilter).to(MissedBlockFilter);
+        this.app.bind(Container.Identifiers.MissedBlockHistoryService).to(MissedBlockHistoryService);
 
         this.app
             .bind(Container.Identifiers.DatabaseTransactionRepository)
@@ -105,6 +113,10 @@ export class ServiceProvider extends Providers.ServiceProvider {
 
     public getBlockRepository(): BlockRepository {
         return getCustomRepository(BlockRepository);
+    }
+
+    public getMissedBlockRepository(): MissedBlockRepository {
+        return getCustomRepository(MissedBlockRepository);
     }
 
     public getTransactionRepository(): TransactionRepository {

--- a/packages/kernel/src/contracts/database/index.ts
+++ b/packages/kernel/src/contracts/database/index.ts
@@ -1,4 +1,5 @@
 export * from "./block-filter";
+export * from "./missed-block-filter";
 export * from "./model-converter";
 export * from "./models";
 export * from "./transaction-filter";

--- a/packages/kernel/src/contracts/database/missed-block-filter.ts
+++ b/packages/kernel/src/contracts/database/missed-block-filter.ts
@@ -1,0 +1,7 @@
+import { Expression } from "../search";
+import { OrMissedBlockCriteria } from "../shared/missed-block-history-service";
+import { MissedBlockModel } from "./models";
+
+export interface MissedBlockFilter {
+    getExpression(...criteria: OrMissedBlockCriteria[]): Promise<Expression<MissedBlockModel>>;
+}

--- a/packages/kernel/src/contracts/database/models.ts
+++ b/packages/kernel/src/contracts/database/models.ts
@@ -19,6 +19,12 @@ export interface BlockModel {
     username?: string;
 }
 
+export interface MissedBlockModel {
+    timestamp: number;
+    height: number;
+    username: string;
+}
+
 export interface TransactionModel {
     id: string;
     version: number;

--- a/packages/kernel/src/contracts/shared/index.ts
+++ b/packages/kernel/src/contracts/shared/index.ts
@@ -2,5 +2,6 @@ export * from "./block-history-service";
 export * from "./download-block";
 export * from "./dynamic-fee";
 export * from "./forging-info";
+export * from "./missed-block-history-service";
 export * from "./rounds";
 export * from "./transaction-history-service";

--- a/packages/kernel/src/contracts/shared/missed-block-history-service.ts
+++ b/packages/kernel/src/contracts/shared/missed-block-history-service.ts
@@ -1,0 +1,18 @@
+import { Options, OrCriteria, OrEqualCriteria, OrNumericCriteria, Pagination, ResultsPage, Sorting } from "../search";
+
+export type MissedBlockCriteria = {
+    timestamp?: OrNumericCriteria<number>;
+    height?: OrNumericCriteria<number>;
+    username?: OrEqualCriteria<string>;
+};
+
+export type OrMissedBlockCriteria = OrCriteria<MissedBlockCriteria>;
+
+export interface MissedBlockHistoryService {
+    listByCriteria(
+        criteria: OrMissedBlockCriteria,
+        sorting: Sorting,
+        pagination: Pagination,
+        options?: Options,
+    ): Promise<ResultsPage<{ timestamp: number; height: number; username: string }>>;
+}

--- a/packages/kernel/src/enums/events.ts
+++ b/packages/kernel/src/enums/events.ts
@@ -68,6 +68,7 @@ export enum DatabaseEvent {
  * @enum {number}
  */
 export enum DelegateEvent {
+    ProductivityChanged = "delegate.productivityChanged",
     Registered = "delegate.registered",
     Resigned = "delegate.resigned",
 }

--- a/packages/kernel/src/ioc/identifiers.ts
+++ b/packages/kernel/src/ioc/identifiers.ts
@@ -45,6 +45,7 @@ export const Identifiers = {
     ProcessActionsService: Symbol.for("Service<ProcessActions>"),
     ValidationService: Symbol.for("Service<Validation>"),
     BlockHistoryService: Symbol.for("Service<BlockHistory>"),
+    MissedBlockHistoryService: Symbol.for("Service<MissedBlockHistory>"),
     TransactionHistoryService: Symbol.for("Service<TransactionHistory>"),
 
     // Factories
@@ -59,6 +60,8 @@ export const Identifiers = {
     DatabaseRoundRepository: Symbol.for("Database<RoundRepository>"),
     DatabaseBlockRepository: Symbol.for("Database<BlockRepository>"),
     DatabaseBlockFilter: Symbol.for("Database<BlockFilter>"),
+    DatabaseMissedBlockFilter: Symbol.for("Database<MissedBlockFilter>"),
+    DatabaseMissedBlockRepository: Symbol.for("Database<MissedBlockRepository>"),
     DatabaseTransactionRepository: Symbol.for("Database<TransactionRepository>"),
     DatabaseTransactionFilter: Symbol.for("Database<TransactionFilter>"),
     DatabaseModelConverter: Symbol.for("Database<ModelConverter>"),

--- a/packages/snapshots/src/codecs/json-codec.ts
+++ b/packages/snapshots/src/codecs/json-codec.ts
@@ -63,6 +63,26 @@ export class JSONCodec implements Codec {
         }
     }
 
+    public encodeMissedBlock(missedBlock: { MissedBlock_timestamp: number }): Buffer {
+        try {
+            const missedBlockStringified = JSONCodec.stringify(
+                cameliseKeys(JSONCodec.removePrefix(missedBlock, "MissedBlock_")),
+            );
+
+            return Buffer.from(missedBlockStringified);
+        } catch (err) {
+            throw new CodecException.MissedBlockEncodeException(missedBlock.MissedBlock_timestamp, err.message);
+        }
+    }
+
+    public decodeMissedBlock(buffer: Buffer): Models.MissedBlock {
+        try {
+            return JSON.parse(buffer.toString());
+        } catch (err) {
+            throw new CodecException.MissedBlockDecodeException(undefined, err.message);
+        }
+    }
+
     public encodeTransaction(transaction: { Transaction_id: string }): Buffer {
         try {
             let tmp = JSONCodec.removePrefix(transaction, "Transaction_");

--- a/packages/snapshots/src/codecs/message-pack-codec.ts
+++ b/packages/snapshots/src/codecs/message-pack-codec.ts
@@ -54,6 +54,30 @@ export class MessagePackCodec implements Codec {
         }
     }
 
+    public encodeMissedBlock(missedBlock: {
+        MissedBlock_timestamp: number;
+        MissedBlock_height: number;
+        MissedBlock_username: string;
+    }): Buffer {
+        try {
+            return encode([
+                missedBlock.MissedBlock_timestamp,
+                missedBlock.MissedBlock_height,
+                missedBlock.MissedBlock_username,
+            ]);
+        } catch (err) {
+            throw new CodecException.MissedBlockEncodeException(missedBlock.MissedBlock_timestamp, err.message);
+        }
+    }
+
+    public decodeMissedBlock(buffer: Buffer): Models.MissedBlock {
+        try {
+            const [timestamp, height, username] = decode(buffer);
+            return { timestamp, height, username };
+        } catch (err) {
+            throw new CodecException.MissedBlockDecodeException(undefined, err.message);
+        }
+    }
     public encodeTransaction(transaction: {
         Transaction_id: string;
         Transaction_block_id: string;

--- a/packages/snapshots/src/contracts/codec.ts
+++ b/packages/snapshots/src/contracts/codec.ts
@@ -4,6 +4,9 @@ export interface Codec {
     encodeBlock(block: any): Buffer;
     decodeBlock(buffer: Buffer): Models.Block;
 
+    encodeMissedBlock(missedBlock: any): Buffer;
+    decodeMissedBlock(buffer: Buffer): Models.MissedBlock;
+
     encodeTransaction(transaction: any): Buffer;
     decodeTransaction(buffer: Buffer): Models.Transaction;
 

--- a/packages/snapshots/src/contracts/database.ts
+++ b/packages/snapshots/src/contracts/database.ts
@@ -9,6 +9,10 @@ export interface DumpRange {
     lastBlockHeight: number;
     blocksCount: number;
 
+    firstMissedBlockHeight: number;
+    lastMissedBlockHeight: number;
+    missedBlocksCount: number;
+
     firstTransactionTimestamp: number;
     lastTransactionTimestamp: number;
     transactionsCount: number;

--- a/packages/snapshots/src/contracts/meta-data.ts
+++ b/packages/snapshots/src/contracts/meta-data.ts
@@ -1,5 +1,6 @@
 export interface MetaData {
     blocks: TableMetaData;
+    missedBlocks: TableMetaData;
     transactions: TableMetaData;
     rounds: TableMetaData;
 

--- a/packages/snapshots/src/exceptions/codec.ts
+++ b/packages/snapshots/src/exceptions/codec.ts
@@ -12,6 +12,18 @@ export class BlockEncodeException extends Exceptions.Base.Exception {
     }
 }
 
+export class MissedBlockDecodeException extends Exceptions.Base.Exception {
+    public constructor(timestamp: number | undefined, message: string) {
+        super(`Missed block with timestamp ${timestamp} could not be decoded. ${message}`);
+    }
+}
+
+export class MissedBlockEncodeException extends Exceptions.Base.Exception {
+    public constructor(timestamp: number, message: string) {
+        super(`Missed block with timestamp ${timestamp} could not be encoded. ${message}`);
+    }
+}
+
 export class TransactionDecodeException extends Exceptions.Base.Exception {
     public constructor(id: string | undefined, message: string) {
         super(`Transaction with id ${id} could not be decoded. ${message}`);

--- a/packages/snapshots/src/ioc/identifiers.ts
+++ b/packages/snapshots/src/ioc/identifiers.ts
@@ -8,6 +8,7 @@ export const Identifiers = {
     SnapshotDatabaseService: Symbol.for("Service<SnapshotDatabase>"),
     SnapshotRepositoryFactory: Symbol.for("Factory<SnapshotRepository>"),
     SnapshotBlockRepository: Symbol.for("Snapshot<BlockRepository>"),
+    SnapshotMissedBlockRepository: Symbol.for("Snapshot<MissedBlockRepository>"),
     SnapshotRoundRepository: Symbol.for("Snapshot<RoundRepository>"),
     SnapshotTransactionRepository: Symbol.for("Snapshot<TransactionRepository>"),
     SnapshotFilesystem: Symbol.for("Snapshot<Filesystem>"),

--- a/packages/snapshots/src/progress-renderer.ts
+++ b/packages/snapshots/src/progress-renderer.ts
@@ -10,12 +10,14 @@ export class ProgressRenderer {
 
     private count = {
         blocks: 0,
+        missedBlocks: 0,
         transactions: 0,
         rounds: 0,
     };
 
     private progress = {
         blocks: "---.--",
+        missedBlocks: "---.--",
         transactions: "---.--",
         rounds: "---.--",
     };

--- a/packages/snapshots/src/repositories/block-repository.ts
+++ b/packages/snapshots/src/repositories/block-repository.ts
@@ -15,7 +15,7 @@ export class BlockRepository extends AbstractRepository<Models.Block> {
     }
 
     public async truncate(): Promise<void> {
-        await this.manager.query("TRUNCATE TABLE transactions, rounds, blocks");
+        await this.manager.query("TRUNCATE TABLE transactions, rounds, missed_blocks, blocks");
     }
 
     public async countInRange(start: number, end: number): Promise<number> {

--- a/packages/snapshots/src/repositories/index.ts
+++ b/packages/snapshots/src/repositories/index.ts
@@ -1,3 +1,4 @@
 export * from "./block-repository";
+export * from "./missed-block-repository";
 export * from "./round-repository";
 export * from "./transaction-repository";

--- a/packages/snapshots/src/repositories/missed-block-repository.ts
+++ b/packages/snapshots/src/repositories/missed-block-repository.ts
@@ -1,0 +1,47 @@
+import { Models } from "@solar-network/database";
+import { Readable } from "stream";
+import { EntityRepository } from "typeorm";
+
+import { AbstractRepository } from "./abstract-repository";
+
+@EntityRepository(Models.MissedBlock)
+export class MissedBlockRepository extends AbstractRepository<Models.MissedBlock> {
+    public async getReadStream(start: number, end: number): Promise<Readable> {
+        return this.createQueryBuilder()
+            .where("height >= :start AND height <= :end", { start, end })
+            .orderBy("height", "ASC")
+            .stream();
+    }
+
+    public async countInRange(start: number, end: number): Promise<number> {
+        return this.fastCount({ where: "height >= :start AND height <= :end", parameters: { start, end } });
+    }
+
+    public async findLast(): Promise<Models.MissedBlock | undefined> {
+        const topBlocks = await this.find({
+            take: 1,
+            order: {
+                height: "DESC",
+            },
+        });
+
+        return topBlocks[0];
+    }
+
+    public async findFirst(): Promise<Models.MissedBlock | undefined> {
+        const topBlocks = await this.find({
+            take: 1,
+            order: {
+                height: "ASC",
+            },
+        });
+
+        return topBlocks[0];
+    }
+
+    public async findByHeight(height: number): Promise<Models.MissedBlock | undefined> {
+        return this.findOne({
+            height: height,
+        });
+    }
+}

--- a/packages/snapshots/src/service-provider.ts
+++ b/packages/snapshots/src/service-provider.ts
@@ -6,7 +6,7 @@ import { SnapshotDatabaseService } from "./database-service";
 import { Filesystem } from "./filesystem/filesystem";
 import { Identifiers } from "./ioc";
 import { ProgressDispatcher } from "./progress-dispatcher";
-import { BlockRepository, RoundRepository, TransactionRepository } from "./repositories";
+import { BlockRepository, MissedBlockRepository, RoundRepository, TransactionRepository } from "./repositories";
 import { SnapshotService } from "./snapshot-service";
 
 export class ServiceProvider extends Providers.ServiceProvider {
@@ -46,6 +46,9 @@ export class ServiceProvider extends Providers.ServiceProvider {
         this.app.bind(Identifiers.ProgressDispatcher).to(ProgressDispatcher).inTransientScope();
 
         this.app.bind(Identifiers.SnapshotBlockRepository).toConstantValue(getCustomRepository(BlockRepository));
+        this.app
+            .bind(Identifiers.SnapshotMissedBlockRepository)
+            .toConstantValue(getCustomRepository(MissedBlockRepository));
         this.app
             .bind(Identifiers.SnapshotTransactionRepository)
             .toConstantValue(getCustomRepository(TransactionRepository));

--- a/packages/snapshots/src/snapshot-service.ts
+++ b/packages/snapshots/src/snapshot-service.ts
@@ -27,17 +27,17 @@ export class SnapshotService implements Contracts.Snapshot.SnapshotService {
         try {
             Utils.assert.defined<string>(options.network);
 
-            this.logger.info(`Running DUMP for network: ${options.network}`);
+            this.logger.info(`Saving snapshot for ${options.network}`);
 
             this.database.init(options.codec, options.skipCompression);
 
             await this.database.dump(options);
             renderer.spinner.succeed();
 
-            this.logger.info(`Snapshot was saved to: ${this.filesystem.getSnapshotPath()}`);
+            this.logger.info(`Snapshot was saved to ${this.filesystem.getSnapshotPath()}`);
         } catch (err) {
             renderer.spinner.fail();
-            this.logger.error(`DUMP failed`);
+            this.logger.error("Snapshot dump failed");
             this.logger.error(err.stack);
         }
     }
@@ -64,7 +64,7 @@ export class SnapshotService implements Contracts.Snapshot.SnapshotService {
                 return;
             }
 
-            this.logger.info(`Running RESTORE for network: ${options.network}`);
+            this.logger.info(`Restoring from snapshot for ${options.network}`);
 
             this.database.init(meta!.codec, meta!.skipCompression, options.verify);
 
@@ -76,14 +76,18 @@ export class SnapshotService implements Contracts.Snapshot.SnapshotService {
 
             this.logger.info(
                 `Successfully restored ${Utils.pluralise("block", meta!.blocks.count, true)}, ${Utils.pluralise(
-                    "transaction",
-                    meta!.transactions.count,
+                    "missed block",
+                    meta!.missedBlocks.count,
                     true,
-                )}, ${Utils.pluralise("round", meta!.rounds.count, true)}`,
+                )}, ${Utils.pluralise("transaction", meta!.transactions.count, true)}, ${Utils.pluralise(
+                    "round",
+                    meta!.rounds.count,
+                    true,
+                )}`,
             );
         } catch (err) {
             renderer.spinner.fail();
-            this.logger.error(`RESTORE failed`);
+            this.logger.error("Snapshot restore failed");
         }
     }
 
@@ -91,7 +95,7 @@ export class SnapshotService implements Contracts.Snapshot.SnapshotService {
         const renderer = new ProgressRenderer(this.app);
 
         try {
-            this.logger.info("Running VERIFICATION");
+            this.logger.info("Verifying snapshot");
 
             Utils.assert.defined<string>(options.network);
             Utils.assert.defined<string>(options.blocks);
@@ -114,17 +118,17 @@ export class SnapshotService implements Contracts.Snapshot.SnapshotService {
 
             await this.database.verify(meta!);
             renderer.spinner.succeed();
-            this.logger.info(`VERIFICATION is successful`);
+            this.logger.info("Verification was successful");
         } catch (err) {
             renderer.spinner.fail();
-            this.logger.error(`VERIFICATION failed`);
+            this.logger.error("Verification failed");
             this.logger.error(err.stack);
         }
     }
 
     public async rollbackByHeight(height: number): Promise<void> {
         try {
-            this.logger.info("Running ROLLBACK");
+            this.logger.info("Rolling back the blockchain");
 
             if (!height || height <= 0) {
                 this.logger.error(`Rollback height ${height.toLocaleString()} is invalid`);
@@ -154,13 +158,13 @@ export class SnapshotService implements Contracts.Snapshot.SnapshotService {
 
             this.forceIntegrityCheckOnNextBoot();
         } catch (err) {
-            this.logger.error("ROLLBACK failed");
+            this.logger.error("Rollback failed");
             this.logger.error(err.stack);
         }
     }
 
     public async rollbackByNumber(number: number): Promise<void> {
-        this.logger.info("Running ROLLBACK");
+        this.logger.info("Rolling back the blockchain");
 
         const lastBlock = await this.database.getLastBlock();
 
@@ -169,12 +173,12 @@ export class SnapshotService implements Contracts.Snapshot.SnapshotService {
 
     public async truncate(): Promise<void> {
         try {
-            this.logger.info("Running TRUNCATE");
+            this.logger.info("Wiping the database");
 
             await this.database.truncate();
             this.forceIntegrityCheckOnNextBoot();
         } catch (err) {
-            this.logger.error("TRUNCATE failed");
+            this.logger.error("Wipe failed");
             this.logger.error(err.stack);
         }
     }

--- a/packages/snapshots/src/verifier.ts
+++ b/packages/snapshots/src/verifier.ts
@@ -9,6 +9,10 @@ export class Verifier {
         Verifier.verifyBlockSignature(block);
     }
 
+    public static verifyMissedBlock(missedBlock: Models.MissedBlock): void {
+        // nothing to verify
+    }
+
     public static verifyTransaction(transaction: Models.Transaction): void {
         Verifier.verifyTransactionSignature(transaction);
     }

--- a/packages/snapshots/src/workers/worker.ts
+++ b/packages/snapshots/src/workers/worker.ts
@@ -21,7 +21,7 @@ const connect = async (options: any): Promise<Connection> => {
     return createConnection({
         ...options.connection,
         namingStrategy: new Utils.SnakeNamingStrategy(),
-        entities: [Models.Block, Models.Transaction, Models.Round],
+        entities: [Models.Block, Models.MissedBlock, Models.Transaction, Models.Round],
     });
 };
 
@@ -44,13 +44,20 @@ export const init = async (): Promise<void> => {
     }
 
     app.bind(Identifiers.SnapshotRepositoryFactory).toFactory<Repository>(() => (table: string) => {
-        if (table === "blocks") {
-            return getCustomRepository(Repositories.BlockRepository);
+        switch (table) {
+            case "blocks": {
+                return getCustomRepository(Repositories.BlockRepository);
+            }
+            case "missedBlocks": {
+                return getCustomRepository(Repositories.MissedBlockRepository);
+            }
+            case "transactions": {
+                return getCustomRepository(Repositories.TransactionRepository);
+            }
+            default: {
+                return getCustomRepository(Repositories.RoundRepository);
+            }
         }
-        if (table === "transactions") {
-            return getCustomRepository(Repositories.TransactionRepository);
-        }
-        return getCustomRepository(Repositories.RoundRepository);
     });
 
     app.bind<StreamReader>(Identifiers.StreamReaderFactory).toFactory<StreamReader>(

--- a/packages/transactions/src/handlers/core/delegate-registration.ts
+++ b/packages/transactions/src/handlers/core/delegate-registration.ts
@@ -29,6 +29,7 @@ export class DelegateRegistrationTransactionHandler extends TransactionHandler {
             "delegate.forgedTotal", // Used by the API
             "delegate.lastBlock",
             "delegate.producedBlocks", // Used by the API
+            "delegate.productivity", // Used by the API
             "delegate.rank",
             "delegate.round",
             "delegate.username",


### PR DESCRIPTION
This PR adds a productivity metric to calculate the block production rate of a delegate over the last 30 days.

It is accessible as a percentage via the `delegate.productivity` wallet attribute and as `blocks.productivity` on the `/api/delegates` and `/api/delegates/{id}` endpoints, or as a list of missed blocks on the `/api/blocks/missed` and `/api/delegates/{id}/blocks/missed` endpoints.

There is also a new event, `delegate.productivityChanged` which is mapped to the `DelegateEvent.ProductivityChanged` enum which can be listened to via plugins, webhooks and WS-API to give real-time updates when a delegate's productivity changes.

**Important note:** The first start of Core will trigger a database migration to create a new table to store missed block data, and will calculate all missed blocks to date, which will take several minutes to complete. 