### PR TITLE
refactor: use sender address instead of sender public key

### DIFF
--- a/packages/api/src/controllers/wallets.ts
+++ b/packages/api/src/controllers/wallets.ts
@@ -125,7 +125,7 @@ export class WalletsController extends Controller {
 
         const criteria: Contracts.Shared.TransactionCriteria = {
             ...request.query,
-            senderPublicKey: walletResource.publicKey,
+            senderId: walletResource.address,
         };
         const sorting: Contracts.Search.Sorting = this.getListingOrder(request);
         const pagination: Contracts.Search.Pagination = this.getListingPage(request);
@@ -210,14 +210,14 @@ export class WalletsController extends Controller {
             ...request.query,
             typeGroup: Enums.TransactionTypeGroup.Core,
             type: Enums.TransactionType.Core.Vote,
-            senderPublicKey: walletResource.publicKey,
+            senderId: walletResource.address,
         };
 
         const criteria: Contracts.Shared.TransactionCriteria = {
             ...request.query,
             typeGroup: Enums.TransactionTypeGroup.Solar,
             type: Enums.TransactionType.Solar.Vote,
-            senderPublicKey: walletResource.publicKey,
+            senderId: walletResource.address,
         };
 
         const sorting: Contracts.Search.Sorting = this.getListingOrder(request);

--- a/packages/api/src/resources-new/lock.ts
+++ b/packages/api/src/resources-new/lock.ts
@@ -10,6 +10,7 @@ export type LockCriteria = Contracts.Search.StandardCriteriaOf<LockResource>;
 
 export type LockResource = {
     lockId: string;
+    senderId: string;
     senderPublicKey: string;
     isExpired: boolean;
     amount: Utils.BigNumber;
@@ -27,7 +28,7 @@ export type LockResource = {
 
 export const lockCriteriaSchemaObject = {
     lockId: transactionCriteriaSchemaObject.id,
-    senderPublicKey: transactionCriteriaSchemaObject.senderPublicKey,
+    senderId: transactionCriteriaSchemaObject.senderId,
     isExpired: Joi.boolean(),
     amount: Schemas.createRangeCriteriaSchema(Schemas.bigNumber),
     secretHash: Joi.alternatives(

--- a/packages/api/src/resources-new/transaction.ts
+++ b/packages/api/src/resources-new/transaction.ts
@@ -12,6 +12,7 @@ export const transactionCriteriaSchemaObject = {
             .regex(/^[0-9a-z%]{1,64}$/)
             .regex(/%/),
     ),
+    senderId: walletCriteriaSchemaObject.address,
     senderPublicKey: walletCriteriaSchemaObject.publicKey,
     recipientId: walletCriteriaSchemaObject.address,
     memo: Joi.string().max(255),

--- a/packages/api/src/resources/transaction-with-block.ts
+++ b/packages/api/src/resources/transaction-with-block.ts
@@ -20,9 +20,8 @@ export class TransactionWithBlockResource implements Resource {
         const transactionData = resource.data;
         const blockData = resource.block;
 
-        AppUtils.assert.defined<string>(transactionData.senderPublicKey);
+        AppUtils.assert.defined<string>(transactionData.senderId);
 
-        const sender: string = this.walletRepository.findByPublicKey(transactionData.senderPublicKey).getAddress();
         const signSignature: string | undefined = transactionData.signSignature ?? transactionData.secondSignature;
         const confirmations: number = this.stateStore.getLastHeight() - blockData.height + 1;
 
@@ -51,7 +50,7 @@ export class TransactionWithBlockResource implements Resource {
             fee: transactionData.fee.toFixed(),
             burnedFee:
                 typeof transactionData.burnedFee !== "undefined" ? transactionData.burnedFee.toFixed() : undefined,
-            sender,
+            sender: transactionData.senderId,
             senderPublicKey: transactionData.senderPublicKey,
             recipient: transactionData.recipientId,
             signature: transactionData.signature,

--- a/packages/api/src/resources/transaction.ts
+++ b/packages/api/src/resources/transaction.ts
@@ -33,9 +33,7 @@ export class TransactionResource implements Resource {
      * @memberof Resource
      */
     public transform(resource: Interfaces.ITransactionData): object {
-        AppUtils.assert.defined<string>(resource.senderPublicKey);
-
-        const sender: string = this.walletRepository.findByPublicKey(resource.senderPublicKey).getAddress();
+        AppUtils.assert.defined<string>(resource.senderId);
 
         let amount: string | undefined =
             typeof resource.amount !== "undefined" && !resource.amount.isZero() ? resource.amount.toFixed() : undefined;
@@ -59,7 +57,7 @@ export class TransactionResource implements Resource {
             amount,
             fee: resource.fee.toFixed(),
             burnedFee: typeof resource.burnedFee !== "undefined" ? resource.burnedFee.toFixed() : undefined,
-            sender,
+            sender: resource.senderId,
             senderPublicKey: resource.senderPublicKey,
             recipient: resource.recipientId,
             signature: resource.signature,

--- a/packages/api/src/services/lock-search-service.ts
+++ b/packages/api/src/services/lock-search-service.ts
@@ -65,6 +65,7 @@ export class LockSearchService {
 
         return {
             lockId,
+            senderId: lockAttribute.senderId,
             senderPublicKey,
             isExpired,
             amount: lockAttribute.amount,

--- a/packages/blockchain/src/processor/block-processor.ts
+++ b/packages/blockchain/src/processor/block-processor.ts
@@ -149,7 +149,7 @@ export class BlockProcessor {
                             transaction.type === handler.type && transaction.typeGroup === handler.typeGroup,
                     );
                     const transactionsSet: Set<string> = new Set(
-                        transactions.map((transaction) => transaction.data.senderPublicKey),
+                        transactions.map((transaction) => transaction.data.senderId),
                     );
                     if (transactionsSet.size !== transactions.length) {
                         this.logger.warning(
@@ -216,9 +216,9 @@ export class BlockProcessor {
         for (const transaction of block.transactions) {
             const data = transaction.data;
 
-            AppUtils.assert.defined<string>(data.senderPublicKey);
+            AppUtils.assert.defined<string>(data.senderId);
 
-            const sender: string = data.senderPublicKey;
+            const sender: string = data.senderId;
 
             if (nonceBySender[sender] === undefined) {
                 nonceBySender[sender] = this.walletRepository.getNonce(sender);

--- a/packages/crypto/src/enums.ts
+++ b/packages/crypto/src/enums.ts
@@ -17,6 +17,11 @@ export enum SolarTransactionType {
     Vote = 2,
 }
 
+export enum TransactionHeaderType {
+    Standard = 0,
+    Extended = 1,
+}
+
 export const TransactionType = {
     Core: CoreTransactionType,
     Solar: SolarTransactionType,

--- a/packages/crypto/src/interfaces/transactions.ts
+++ b/packages/crypto/src/interfaces/transactions.ts
@@ -53,6 +53,7 @@ export interface ITransactionData {
     typeGroup?: number;
     type: number;
     nonce: BigNumber;
+    senderId: string;
     senderPublicKey: string;
     headerType?: number;
 
@@ -86,6 +87,7 @@ export interface ITransactionJson {
     type: number;
 
     nonce: string;
+    senderId: string;
     senderPublicKey: string;
 
     fee: string;
@@ -147,6 +149,7 @@ export interface IHtlcRefundAsset {
 export interface IHtlcLock extends IHtlcLockAsset {
     amount: BigNumber;
     recipientId: string | undefined;
+    senderId: string;
     timestamp: number;
     memo: string | undefined;
 }
@@ -174,11 +177,5 @@ export interface ISerialiseOptions {
     excludeSecondSignature?: boolean;
     excludeMultiSignature?: boolean;
 
-    // WORKAROUND: A handful of mainnet transactions have an invalid
-    // recipient. Due to a refactor of the Address network byte
-    // validation it is no longer trivially possible to handle them.
-    // If an invalid address is encountered during transfer serialization,
-    // this error field is used to bubble up the error and defer the
-    // `AddressNetworkByteError` until the actual id is available to call `isException`.
     addressError?: string;
 }

--- a/packages/crypto/src/transactions/builders/transactions/core/transfer.ts
+++ b/packages/crypto/src/transactions/builders/transactions/core/transfer.ts
@@ -59,7 +59,6 @@ export class TransferBuilder extends TransactionBuilder<TransferBuilder> {
 
     public getStruct(): ITransactionData {
         const struct: ITransactionData = super.getStruct();
-        struct.senderPublicKey = this.data.senderPublicKey;
         struct.amount = this.data.amount;
         struct.asset = this.data.asset;
 

--- a/packages/crypto/src/transactions/deserialiser.ts
+++ b/packages/crypto/src/transactions/deserialiser.ts
@@ -1,8 +1,10 @@
+import { TransactionHeaderType } from "../enums";
 import {
     DuplicateParticipantInMultiSignatureError,
     InvalidTransactionBytesError,
     TransactionVersionError,
 } from "../errors";
+import { Address } from "../identities";
 import { IDeserialiseOptions, ITransaction, ITransactionData } from "../interfaces";
 import { BigNumber, ByteBuffer, isSupportedTransactionVersion } from "../utils";
 import { TransactionTypeFactory } from "./types";
@@ -48,6 +50,13 @@ export class Deserialiser {
         transaction.nonce = BigNumber.make(buf.readBigUInt64LE());
 
         transaction.senderPublicKey = buf.readBuffer(33).toString("hex");
+
+        if (transaction.headerType === TransactionHeaderType.Standard) {
+            transaction.senderId = Address.fromPublicKey(transaction.senderPublicKey);
+        } else {
+            transaction.senderId = Address.fromBuffer(buf.readBuffer(21));
+        }
+
         transaction.fee = BigNumber.make(buf.readBigUInt64LE().toString());
     }
 

--- a/packages/crypto/src/transactions/serialiser.ts
+++ b/packages/crypto/src/transactions/serialiser.ts
@@ -1,5 +1,6 @@
-import { TransactionTypeGroup } from "../enums";
-import { TransactionVersionError } from "../errors";
+import { TransactionHeaderType, TransactionTypeGroup } from "../enums";
+import { AddressNetworkError, TransactionVersionError } from "../errors";
+import { Address } from "../identities";
 import { ISerialiseOptions } from "../interfaces";
 import { ITransaction, ITransactionData } from "../interfaces";
 import { configManager } from "../managers/config";
@@ -67,6 +68,15 @@ export class Serialiser {
         buff.writeBigInt64LE(transaction.nonce.toBigInt());
 
         buff.writeBuffer(Buffer.from(transaction.senderPublicKey, "hex"));
+        if (transaction.headerType === TransactionHeaderType.Extended) {
+            const { addressBuffer, addressError } = Address.toBuffer(transaction.senderId);
+            if (addressError) {
+                throw new AddressNetworkError(addressError);
+            }
+
+            buff.writeBuffer(addressBuffer);
+        }
+
         buff.writeBigInt64LE(transaction.fee.toBigInt());
     }
 

--- a/packages/crypto/src/transactions/types/schemas.ts
+++ b/packages/crypto/src/transactions/types/schemas.ts
@@ -27,6 +27,7 @@ export const transactionBaseSchema: Record<string, any> = {
         typeGroup: { type: "integer", minimum: 0 },
         fee: { bignumber: { minimum: 0, bypassGenesis: true } },
         burnedFee: { bignumber: { minimum: 0 } },
+        senderId: { $ref: "address" },
         senderPublicKey: { $ref: "publicKey" },
         memo: { anyOf: [{ type: "null" }, { type: "string", format: "memo" }] },
         signature: { allOf: [{ minLength: 128, maxLength: 128 }, { $ref: "hex" }] },

--- a/packages/crypto/src/transactions/types/transaction.ts
+++ b/packages/crypto/src/transactions/types/transaction.ts
@@ -1,6 +1,5 @@
 import { TransactionTypeGroup } from "../../enums";
 import { NotImplemented } from "../../errors";
-import { Address } from "../../identities";
 import {
     ISchemaValidationResult,
     ISerialiseOptions,
@@ -104,10 +103,10 @@ export abstract class Transaction implements ITransaction {
     public toString(): string {
         const parts: string[] = [];
 
-        if (this.data.senderPublicKey && this.data.nonce) {
-            parts.push(`${Address.fromPublicKey(this.data.senderPublicKey)}#${this.data.nonce}`);
-        } else if (this.data.senderPublicKey) {
-            parts.push(`${Address.fromPublicKey(this.data.senderPublicKey)}`);
+        if (this.data.senderId && this.data.nonce) {
+            parts.push(`${this.data.senderId}#${this.data.nonce}`);
+        } else if (this.data.senderId) {
+            parts.push(this.data.senderId);
         }
 
         if (this.data.id) {

--- a/packages/crypto/src/transactions/utils.ts
+++ b/packages/crypto/src/transactions/utils.ts
@@ -1,7 +1,6 @@
 import { HashAlgorithms } from "../crypto";
 import { AddressNetworkError } from "../errors";
 import { ISerialiseOptions, ITransactionData } from "../interfaces";
-import { configManager } from "../managers";
 import { isException } from "../utils";
 import { Serialiser } from "./serialiser";
 import { TransactionTypeFactory } from "./types/factory";
@@ -18,23 +17,8 @@ export class Utils {
     public static getId(transaction: ITransactionData, options: ISerialiseOptions = {}): string {
         const id: string = Utils.toHash(transaction, options).toString("hex");
 
-        // WORKAROUND:
-        // A handful of mainnet transactions have an invalid recipient. Due to a
-        // refactor of the Address network byte validation it is no longer
-        // trivially possible to handle them. If an invalid address is encountered
-        // during transfer serialization, the error is bubbled up to defer the
-        // `AddressNetworkByteError` until the actual id is available to call
-        // `isException`.
         if (options.addressError && !isException({ id })) {
             throw new AddressNetworkError(options.addressError);
-        }
-
-        // Apply fix for broken type 1 and 4 transactions, which were
-        // erroneously calculated with a recipient id.
-        const { transactionIdFixTable } = configManager.get("exceptions");
-
-        if (transactionIdFixTable && transactionIdFixTable[id]) {
-            return transactionIdFixTable[id];
         }
 
         return id;

--- a/packages/database/src/migrations/20220817000000-add-sender_id-to-transactions-table.ts
+++ b/packages/database/src/migrations/20220817000000-add-sender_id-to-transactions-table.ts
@@ -1,0 +1,34 @@
+import { Identities } from "@solar-network/crypto";
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddSenderIdToTransactionsTable20220817000000 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<any> {
+        queryRunner.connection.driver.options.extra.logger.debug(
+            "Database migration: Adding sender_id to transactions table",
+        );
+        await queryRunner.query(`
+            ALTER TABLE transactions ADD COLUMN sender_id VARCHAR(34);
+        `);
+        const senderPublicKeys = await queryRunner.query(
+            `SELECT DISTINCT(sender_public_key) "senderPublicKey" FROM transactions`,
+        );
+        for (const { senderPublicKey } of senderPublicKeys) {
+            await queryRunner.query(`
+                UPDATE transactions SET sender_id = '${Identities.Address.fromPublicKey(senderPublicKey)}'
+                WHERE sender_id IS NULL AND sender_public_key = '${senderPublicKey}';
+            `);
+        }
+        await queryRunner.query(`
+            ALTER TABLE transactions ALTER COLUMN sender_id SET NOT NULL;
+            CREATE INDEX transactions_sender_id ON transactions(sender_id);
+        `);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<any> {
+        await queryRunner.query(`
+            DROP INDEX transactions_sender_id;
+
+            ALTER TABLE transactions DROP COLUMN sender_id;
+        `);
+    }
+}

--- a/packages/database/src/models/transaction.ts
+++ b/packages/database/src/models/transaction.ts
@@ -10,6 +10,7 @@ import { transformBigInt, transformMemo } from "../utils/transform";
 })
 @Index(["type"])
 @Index(["blockId"])
+@Index(["senderId"])
 @Index(["senderPublicKey"])
 @Index(["recipientId"])
 @Index(["timestamp"])
@@ -58,6 +59,13 @@ export class Transaction implements Contracts.Database.TransactionModel {
         default: undefined,
     })
     public nonce!: Utils.BigNumber;
+
+    @Column({
+        type: "varchar",
+        length: 34,
+        nullable: false,
+    })
+    public senderId!: string;
 
     @Column({
         type: "varchar",

--- a/packages/database/src/repositories/transaction-repository.ts
+++ b/packages/database/src/repositories/transaction-repository.ts
@@ -172,16 +172,14 @@ export class TransactionRepository extends AbstractRepository<Transaction> {
         return amount;
     }
 
-    public async getSentTransactions(): Promise<
-        { senderPublicKey: string; amount: string; fee: string; nonce: string }[]
-    > {
+    public async getSentTransactions(): Promise<{ senderId: string; amount: string; fee: string; nonce: string }[]> {
         return this.createQueryBuilder()
             .select([])
-            .addSelect("sender_public_key", "senderPublicKey")
+            .addSelect("sender_id", "senderId")
             .addSelect("SUM(amount)", "amount")
             .addSelect("SUM(fee)", "fee")
             .addSelect("COUNT(id)::int8", "nonce")
-            .groupBy("sender_public_key")
+            .groupBy("sender_id")
             .getRawMany();
     }
 
@@ -293,9 +291,9 @@ export class TransactionRepository extends AbstractRepository<Transaction> {
             .getRawMany();
     }
 
-    public async getRefundedHtlcLockBalances(): Promise<{ senderPublicKey: string; refundedBalance: string }[]> {
+    public async getRefundedHtlcLockBalances(): Promise<{ senderId: string; refundedBalance: string }[]> {
         return this.createQueryBuilder()
-            .select(`sender_public_key AS "senderPublicKey"`)
+            .select(`sender_id AS "senderId"`)
             .addSelect("SUM(amount)", "refundedBalance")
             .where(`type_group = ${Enums.TransactionTypeGroup.Core}`)
             .andWhere(`type = ${Enums.TransactionType.Core.HtlcLock}`)
@@ -308,7 +306,7 @@ export class TransactionRepository extends AbstractRepository<Transaction> {
                     .andWhere(`type = ${Enums.TransactionType.Core.HtlcRefund}`);
                 return `id IN ${refundedLockIdsSubQuery.getQuery()}`;
             })
-            .groupBy("sender_public_key")
+            .groupBy("sender_id")
             .getRawMany();
     }
 }

--- a/packages/database/src/transaction-filter.ts
+++ b/packages/database/src/transaction-filter.ts
@@ -123,10 +123,7 @@ export class TransactionFilter implements Contracts.Database.TransactionFilter {
     ): Promise<Contracts.Search.Expression<Transaction>> {
         if (this.walletRepository.hasByAddress(criteria)) {
             const senderWallet = this.walletRepository.findByAddress(criteria);
-
-            if (senderWallet && senderWallet.getPublicKey()) {
-                return { op: "equal", property: "senderPublicKey", value: senderWallet.getPublicKey() };
-            }
+            return { op: "equal", property: "senderId", value: senderWallet.getAddress() };
         }
 
         return { op: "false" };
@@ -152,21 +149,19 @@ export class TransactionFilter implements Contracts.Database.TransactionFilter {
 
         if (this.walletRepository.hasByAddress(criteria)) {
             const recipientWallet = this.walletRepository.findByAddress(criteria);
-            if (recipientWallet && recipientWallet.getPublicKey()) {
-                const delegateRegistrationExpression: Contracts.Search.AndExpression<Transaction> = {
-                    op: "and",
-                    expressions: [
-                        { op: "equal", property: "typeGroup", value: Enums.TransactionTypeGroup.Core },
-                        { op: "equal", property: "type", value: Enums.TransactionType.Core.DelegateRegistration },
-                        { op: "equal", property: "senderPublicKey", value: recipientWallet.getPublicKey() },
-                    ],
-                };
+            const delegateRegistrationExpression: Contracts.Search.AndExpression<Transaction> = {
+                op: "and",
+                expressions: [
+                    { op: "equal", property: "typeGroup", value: Enums.TransactionTypeGroup.Core },
+                    { op: "equal", property: "type", value: Enums.TransactionType.Core.DelegateRegistration },
+                    { op: "equal", property: "senderId", value: recipientWallet.getAddress() },
+                ],
+            };
 
-                return {
-                    op: "or",
-                    expressions: [recipientIdExpression, transferRecipientIdExpression, delegateRegistrationExpression],
-                };
-            }
+            return {
+                op: "or",
+                expressions: [recipientIdExpression, transferRecipientIdExpression, delegateRegistrationExpression],
+            };
         }
         return {
             op: "or",

--- a/packages/kernel/src/contracts/database/models.ts
+++ b/packages/kernel/src/contracts/database/models.ts
@@ -33,6 +33,7 @@ export interface TransactionModel {
     sequence: number;
     timestamp: number;
     nonce: Utils.BigNumber;
+    senderId: string;
     senderPublicKey: string;
     recipientId: string;
     type: number;

--- a/packages/kernel/src/contracts/pool/mempool.ts
+++ b/packages/kernel/src/contracts/pool/mempool.ts
@@ -5,13 +5,13 @@ import { SenderMempool } from "./sender-mempool";
 export interface Mempool {
     getSize(): number;
 
-    hasSenderMempool(senderPublicKey: string): boolean;
-    getSenderMempool(senderPublicKey: string): SenderMempool;
+    hasSenderMempool(senderId: string): boolean;
+    getSenderMempool(senderId: string): SenderMempool;
     getSenderMempools(): Iterable<SenderMempool>;
 
     addTransaction(transaction: Interfaces.ITransaction): Promise<void>;
-    removeTransaction(senderPublicKey: string, id: string): Promise<Interfaces.ITransaction[]>;
-    removeForgedTransaction(senderPublicKey: string, id: string): Promise<Interfaces.ITransaction[]>;
+    removeTransaction(senderId: string, id: string): Promise<Interfaces.ITransaction[]>;
+    removeForgedTransaction(senderId: string, id: string): Promise<Interfaces.ITransaction[]>;
 
     flush(): void;
 }

--- a/packages/kernel/src/contracts/pool/query.ts
+++ b/packages/kernel/src/contracts/pool/query.ts
@@ -4,7 +4,7 @@ export type QueryPredicate = (transaction: Interfaces.ITransaction) => boolean;
 
 export interface Query {
     getAll(): QueryIterable;
-    getAllBySender(senderPublicKey: string): QueryIterable;
+    getAllBySender(senderId: string): QueryIterable;
     getFromLowestPriority(): QueryIterable;
     getFromHighestPriority(): QueryIterable;
 }

--- a/packages/kernel/src/contracts/pool/storage.ts
+++ b/packages/kernel/src/contracts/pool/storage.ts
@@ -1,7 +1,7 @@
 export type StoredTransaction = {
     height: number;
     id: string;
-    senderPublicKey: string;
+    senderId: string;
     serialised: Buffer;
 };
 

--- a/packages/kernel/src/contracts/state/wallets.ts
+++ b/packages/kernel/src/contracts/state/wallets.ts
@@ -275,6 +275,7 @@ export interface SearchContext<T = any> {
 
 export interface UnwrappedHtlcLock {
     lockId: string;
+    senderId: string;
     senderPublicKey: string;
     amount: Utils.BigNumber;
     recipientId: string;

--- a/packages/pool/src/collator.ts
+++ b/packages/pool/src/collator.ts
@@ -50,7 +50,7 @@ export class Collator implements Contracts.Pool.Collator {
                 break;
             }
 
-            if (failedTransactions.some((t) => t.data.senderPublicKey === transaction.data.senderPublicKey)) {
+            if (failedTransactions.some((t) => t.data.senderId === transaction.data.senderId)) {
                 continue;
             }
 

--- a/packages/pool/src/query.ts
+++ b/packages/pool/src/query.ts
@@ -76,10 +76,10 @@ export class Query implements Contracts.Pool.Query {
         return new QueryIterable(iterable);
     }
 
-    public getAllBySender(senderPublicKey: string): QueryIterable {
+    public getAllBySender(senderId: string): QueryIterable {
         const iterable: Iterable<Interfaces.ITransaction> = function* (this: Query) {
-            if (this.mempool.hasSenderMempool(senderPublicKey)) {
-                const transactions = this.mempool.getSenderMempool(senderPublicKey).getFromEarliest();
+            if (this.mempool.hasSenderMempool(senderId)) {
+                const transactions = this.mempool.getSenderMempool(senderId).getFromEarliest();
                 for (const transaction of transactions) {
                     yield transaction;
                 }

--- a/packages/pool/src/sender-mempool.ts
+++ b/packages/pool/src/sender-mempool.ts
@@ -39,13 +39,13 @@ export class SenderMempool implements Contracts.Pool.SenderMempool {
             this.concurrency++;
 
             await this.lock.runExclusive(async () => {
-                AppUtils.assert.defined<string>(transaction.data.senderPublicKey);
+                AppUtils.assert.defined<string>(transaction.data.senderId);
 
                 const maxTransactionsPerSender: number =
                     this.configuration.getRequired<number>("maxTransactionsPerSender");
                 if (this.transactions.length >= maxTransactionsPerSender) {
                     const allowedSenders: string[] = this.configuration.getOptional<string[]>("allowedSenders", []);
-                    if (!allowedSenders.includes(transaction.data.senderPublicKey)) {
+                    if (!allowedSenders.includes(transaction.data.senderId)) {
                         throw new SenderExceededMaximumTransactionCountError(transaction, maxTransactionsPerSender);
                     }
                 }

--- a/packages/pool/src/storage.ts
+++ b/packages/pool/src/storage.ts
@@ -48,7 +48,7 @@ export class Storage implements Contracts.Pool.Storage {
                 n                  INTEGER      PRIMARY KEY AUTOINCREMENT,
                 height             INTEGER      NOT NULL,
                 id                 VARCHAR(64)  NOT NULL,
-                senderPublicKey    VARCHAR(66)  NOT NULL,
+                senderId           VARCHAR(34)  NOT NULL,
                 serialised         BLOB         NOT NULL
             );
 
@@ -57,17 +57,17 @@ export class Storage implements Contracts.Pool.Storage {
         `);
 
         this.addTransactionStmt = this.database.prepare(
-            "INSERT INTO pool (height, id, senderPublicKey, serialised) VALUES (:height, :id, :senderPublicKey, :serialised)",
+            "INSERT INTO pool (height, id, senderId, serialised) VALUES (:height, :id, :senderId, :serialised)",
         );
 
         this.hasTransactionStmt = this.database.prepare("SELECT COUNT(*) FROM pool WHERE id = :id").pluck(true);
 
         this.getAllTransactionsStmt = this.database.prepare(
-            "SELECT height, id, senderPublicKey, serialised FROM pool ORDER BY n",
+            "SELECT height, id, senderId, serialised FROM pool ORDER BY n",
         );
 
         this.getOldTransactionsStmt = this.database.prepare(
-            "SELECT height, id, senderPublicKey, serialised FROM pool WHERE height <= :height ORDER BY n DESC",
+            "SELECT height, id, senderId, serialised FROM pool WHERE height <= :height ORDER BY n DESC",
         );
 
         this.removeTransactionStmt = this.database.prepare("DELETE FROM pool WHERE id = :id");

--- a/packages/snapshots/src/codecs/message-pack-codec.ts
+++ b/packages/snapshots/src/codecs/message-pack-codec.ts
@@ -120,6 +120,7 @@ export class MessagePackCodec implements Codec {
                 blockHeight: blockHeight,
                 sequence: sequence,
                 timestamp: timestamp,
+                senderId: transaction.data.senderId!,
                 senderPublicKey: transaction.data.senderPublicKey!,
                 recipientId: transaction.data.recipientId!,
                 type: transaction.data.type,

--- a/packages/state/src/block-state.ts
+++ b/packages/state/src/block-state.ts
@@ -121,9 +121,9 @@ export class BlockState implements Contracts.State.BlockState {
 
         await transactionHandler.apply(transaction);
 
-        AppUtils.assert.defined<string>(transaction.data.senderPublicKey);
+        AppUtils.assert.defined<string>(transaction.data.senderId);
 
-        const sender: Contracts.State.Wallet = this.walletRepository.findByPublicKey(transaction.data.senderPublicKey);
+        const sender: Contracts.State.Wallet = this.walletRepository.findByAddress(transaction.data.senderId);
 
         let recipient: Contracts.State.Wallet | undefined;
         if (transaction.data.recipientId) {
@@ -142,9 +142,9 @@ export class BlockState implements Contracts.State.BlockState {
 
         const transactionHandler = await this.handlerRegistry.getActivatedHandlerForData(transaction.data);
 
-        AppUtils.assert.defined<string>(data.senderPublicKey);
+        AppUtils.assert.defined<string>(data.senderId);
 
-        const sender: Contracts.State.Wallet = this.walletRepository.findByPublicKey(data.senderPublicKey);
+        const sender: Contracts.State.Wallet = this.walletRepository.findByAddress(data.senderId);
 
         let recipient: Contracts.State.Wallet | undefined;
         if (transaction.data.recipientId) {

--- a/packages/state/src/state-builder.ts
+++ b/packages/state/src/state-builder.ts
@@ -1,4 +1,4 @@
-import { Managers, Utils } from "@solar-network/crypto";
+import { Identities, Managers, Utils } from "@solar-network/crypto";
 import { Repositories } from "@solar-network/database";
 import { Application, Container, Contracts, Enums, Services, Utils as AppUtils } from "@solar-network/kernel";
 import { Handlers } from "@solar-network/transactions";
@@ -41,18 +41,18 @@ export class StateBuilder {
         const steps = registeredHandlers.length + 3;
 
         try {
-            this.logger.info(`State Generation - Step 1 of ${steps}: Fees & Nonces`);
-            await this.buildSentTransactions();
-
             const capitalise = (key: string) => key[0].toUpperCase() + key.slice(1);
             for (let i = 0; i < registeredHandlers.length; i++) {
                 const handler = registeredHandlers[i];
                 const ctorKey: string | undefined = handler.getConstructor().key;
                 AppUtils.assert.defined<string>(ctorKey);
 
-                this.logger.info(`State Generation - Step ${2 + i} of ${steps}: ${capitalise(ctorKey)}`);
+                this.logger.info(`State Generation - Step ${1 + i} of ${steps}: ${capitalise(ctorKey)}`);
                 await handler.bootstrap();
             }
+
+            this.logger.info(`State Generation - Step ${steps - 2} of ${steps}: Fees & Nonces`);
+            await this.buildSentTransactions();
 
             this.logger.info(`State Generation - Step ${steps - 1} of ${steps}: Block Rewards`);
             await this.buildBlockRewards();
@@ -102,7 +102,7 @@ export class StateBuilder {
         const transactions = await this.transactionRepository.getSentTransactions();
 
         for (const transaction of transactions) {
-            const wallet = this.walletRepository.findByPublicKey(transaction.senderPublicKey);
+            const wallet = this.walletRepository.findByAddress(transaction.senderId);
             wallet.setNonce(Utils.BigNumber.make(transaction.nonce));
             wallet.decreaseBalance(
                 Utils.BigNumber.make(transaction.amount || Utils.BigNumber.ZERO).plus(transaction.fee),
@@ -112,40 +112,36 @@ export class StateBuilder {
 
     private verifyWalletsConsistency(): void {
         const logNegativeBalance = (wallet, type, balance) =>
-            this.logger.warning(`Wallet ${wallet.address} has a negative ${type} of '${balance}'`);
+            this.logger.warning(`Wallet ${wallet.address} has a negative ${type} of ${balance}`);
 
-        const genesisPublicKeys: Record<string, true> = Managers.configManager
-            .get("genesisBlock.transactions")
-            .reduce((acc, curr) => Object.assign(acc, { [curr.senderPublicKey]: true }), {});
-
+        const genesisAddress: string = Identities.Address.fromPublicKey(
+            Managers.configManager.get("genesisBlock.transactions")[0].senderPublicKey,
+        );
         for (const wallet of this.walletRepository.allByAddress()) {
-            if (
-                wallet.getBalance().isLessThan(0) &&
-                (wallet.getPublicKey() === undefined || !genesisPublicKeys[wallet.getPublicKey()!])
-            ) {
-                // Senders of whitelisted transactions that result in a negative balance,
-                // also need to be special treated during bootstrap. Therefore, specific
-                // senderPublicKey/nonce pairs are allowed to be negative.
+            const address: string = wallet.getAddress();
+            const balance: Utils.BigNumber = wallet.getBalance();
+
+            if (balance.isLessThan(0) && (address === undefined || address !== genesisAddress)) {
                 const negativeBalanceExceptions: Record<string, Record<string, string>> = this.configRepository.get(
                     "crypto.exceptions.negativeBalances",
                     {},
                 );
 
-                const whitelistedNegativeBalances: Record<string, string> | undefined = wallet.getPublicKey()
-                    ? negativeBalanceExceptions[wallet.getPublicKey()!]
+                const whitelistedNegativeBalances: Record<string, string> | undefined = address
+                    ? negativeBalanceExceptions[address]
                     : undefined;
 
                 if (!whitelistedNegativeBalances) {
-                    logNegativeBalance(wallet, "balance", wallet.getBalance());
+                    logNegativeBalance(wallet, "balance", balance);
                     throw new Error("Non-genesis wallet with negative balance");
                 }
 
-                const allowedNegativeBalance = wallet
-                    .getBalance()
-                    .isEqualTo(whitelistedNegativeBalances[wallet.getNonce().toString()]);
+                const allowedNegativeBalance = balance.isEqualTo(
+                    whitelistedNegativeBalances[wallet.getNonce().toString()],
+                );
 
                 if (!allowedNegativeBalance) {
-                    logNegativeBalance(wallet, "balance", wallet.getBalance());
+                    logNegativeBalance(wallet, "balance", balance);
                     throw new Error("Non-genesis wallet with negative balance");
                 }
             }

--- a/packages/state/src/wallets/wallet-repository.ts
+++ b/packages/state/src/wallets/wallet-repository.ts
@@ -118,9 +118,9 @@ export class WalletRepository implements Contracts.State.WalletRepository {
         return this.getIndex(indexName).has(key);
     }
 
-    public getNonce(publicKey: string): Utils.BigNumber {
-        if (this.hasByPublicKey(publicKey)) {
-            return this.findByPublicKey(publicKey).getNonce();
+    public getNonce(address: string): Utils.BigNumber {
+        if (this.hasByAddress(address)) {
+            return this.findByAddress(address).getNonce();
         }
 
         return Utils.BigNumber.ZERO;

--- a/packages/transactions/src/errors.ts
+++ b/packages/transactions/src/errors.ts
@@ -311,3 +311,9 @@ export class ResignationTypeAssetMilestoneNotActiveError extends TransactionErro
         super("Failed to apply transaction, because different delegate resignation types are not enabled");
     }
 }
+
+export class UnexpectedHeaderTypeError extends TransactionError {
+    public constructor() {
+        super("Failed to apply transaction, because the extended transaction header type is not enabled");
+    }
+}

--- a/packages/transactions/src/handlers/core/multi-signature-registration.ts
+++ b/packages/transactions/src/handlers/core/multi-signature-registration.ts
@@ -1,4 +1,4 @@
-import { Identities, Interfaces, Transactions } from "@solar-network/crypto";
+import { Enums, Identities, Interfaces, Transactions } from "@solar-network/crypto";
 import { Container, Contracts, Utils as AppUtils } from "@solar-network/kernel";
 
 import { MultiSignatureAlreadyRegisteredError, MultiSignatureMinimumKeysError } from "../../errors";
@@ -31,19 +31,29 @@ export class MultiSignatureRegistrationTransactionHandler extends TransactionHan
         };
 
         for await (const transaction of this.transactionHistoryService.streamByCriteria(criteria)) {
+            AppUtils.assert.defined<string>(transaction.senderId);
             AppUtils.assert.defined<Interfaces.IMultiSignatureAsset>(transaction.asset?.multiSignature);
 
+            const wallet: Contracts.State.Wallet = this.walletRepository.findByAddress(transaction.senderId);
+            if (
+                transaction.headerType === Enums.TransactionHeaderType.Standard &&
+                wallet.getPublicKey() === undefined
+            ) {
+                wallet.setPublicKey(transaction.senderPublicKey);
+                this.walletRepository.index(wallet);
+            }
+
             const multiSignature: Contracts.State.WalletMultiSignatureAttributes = transaction.asset.multiSignature;
-            const wallet: Contracts.State.Wallet = this.walletRepository.findByPublicKey(
+            const multiSignatureWallet: Contracts.State.Wallet = this.walletRepository.findByPublicKey(
                 Identities.PublicKey.fromMultiSignatureAsset(multiSignature),
             );
 
-            if (wallet.hasMultiSignature()) {
+            if (multiSignatureWallet.hasMultiSignature()) {
                 throw new MultiSignatureAlreadyRegisteredError();
             }
 
-            wallet.setAttribute("multiSignature", multiSignature);
-            this.walletRepository.index(wallet);
+            multiSignatureWallet.setAttribute("multiSignature", multiSignature);
+            this.walletRepository.index(multiSignatureWallet);
         }
     }
 
@@ -77,19 +87,17 @@ export class MultiSignatureRegistrationTransactionHandler extends TransactionHan
     }
 
     public async throwIfCannotEnterPool(transaction: Interfaces.ITransaction): Promise<void> {
-        AppUtils.assert.defined<string>(transaction.data.senderPublicKey);
+        AppUtils.assert.defined<string>(transaction.data.senderId);
         AppUtils.assert.defined<Interfaces.IMultiSignatureAsset>(transaction.data.asset?.multiSignature);
 
         const hasSender: boolean = this.poolQuery
-            .getAllBySender(transaction.data.senderPublicKey)
+            .getAllBySender(transaction.data.senderId)
             .whereKind(transaction)
             .has();
 
         if (hasSender) {
             throw new Contracts.Pool.PoolError(
-                `${Identities.Address.fromPublicKey(
-                    transaction.data.senderPublicKey,
-                )} already has a multisignature registration transaction in the pool`,
+                `${transaction.data.senderId} already has a multisignature registration transaction in the pool`,
                 "ERR_PENDING",
             );
         }

--- a/packages/transactions/src/handlers/core/transfer.ts
+++ b/packages/transactions/src/handlers/core/transfer.ts
@@ -1,4 +1,4 @@
-import { Interfaces, Transactions, Utils } from "@solar-network/crypto";
+import { Enums, Interfaces, Transactions, Utils } from "@solar-network/crypto";
 import { Container, Contracts, Utils as AppUtils } from "@solar-network/kernel";
 
 import { InsufficientBalanceError } from "../../errors";
@@ -28,14 +28,22 @@ export class TransferTransactionHandler extends TransactionHandler {
         };
 
         for await (const transaction of this.transactionHistoryService.streamByCriteria(criteria)) {
-            AppUtils.assert.defined<string>(transaction.senderPublicKey);
+            AppUtils.assert.defined<string>(transaction.senderId);
             AppUtils.assert.defined<object>(transaction.asset?.transfers);
 
-            const sender: Contracts.State.Wallet = this.walletRepository.findByPublicKey(transaction.senderPublicKey);
+            const wallet: Contracts.State.Wallet = this.walletRepository.findByAddress(transaction.senderId);
+            if (
+                transaction.headerType === Enums.TransactionHeaderType.Standard &&
+                wallet.getPublicKey() === undefined
+            ) {
+                wallet.setPublicKey(transaction.senderPublicKey);
+                this.walletRepository.index(wallet);
+            }
+
             for (const transfer of transaction.asset.transfers) {
                 const recipient: Contracts.State.Wallet = this.walletRepository.findByAddress(transfer.recipientId);
                 recipient.increaseBalance(transfer.amount);
-                sender.decreaseBalance(transfer.amount);
+                wallet.decreaseBalance(transfer.amount);
             }
         }
     }
@@ -70,11 +78,9 @@ export class TransferTransactionHandler extends TransactionHandler {
             Utils.BigNumber.ZERO,
         );
 
-        AppUtils.assert.defined<string>(transaction.data.senderPublicKey);
+        AppUtils.assert.defined<string>(transaction.data.senderId);
 
-        const senderWallet: Contracts.State.Wallet = this.walletRepository.findByPublicKey(
-            transaction.data.senderPublicKey,
-        );
+        const senderWallet: Contracts.State.Wallet = this.walletRepository.findByAddress(transaction.data.senderId);
 
         senderWallet.decreaseBalance(totalTransfersAmount);
     }
@@ -89,11 +95,9 @@ export class TransferTransactionHandler extends TransactionHandler {
             Utils.BigNumber.ZERO,
         );
 
-        AppUtils.assert.defined<string>(transaction.data.senderPublicKey);
+        AppUtils.assert.defined<string>(transaction.data.senderId);
 
-        const senderWallet: Contracts.State.Wallet = this.walletRepository.findByPublicKey(
-            transaction.data.senderPublicKey,
-        );
+        const senderWallet: Contracts.State.Wallet = this.walletRepository.findByAddress(transaction.data.senderId);
 
         senderWallet.increaseBalance(totalPaymentsAmount);
     }

--- a/packages/transactions/src/handlers/core/vote.ts
+++ b/packages/transactions/src/handlers/core/vote.ts
@@ -1,4 +1,4 @@
-import { Identities, Interfaces, Managers, Transactions } from "@solar-network/crypto";
+import { Enums, Interfaces, Managers, Transactions } from "@solar-network/crypto";
 import { Container, Contracts, Enums as AppEnums, Utils } from "@solar-network/kernel";
 
 import {
@@ -38,10 +38,17 @@ export class LegacyVoteTransactionHandler extends TransactionHandler {
         };
 
         for await (const transaction of this.transactionHistoryService.streamByCriteria(criteria)) {
-            Utils.assert.defined<string>(transaction.senderPublicKey);
+            Utils.assert.defined<string>(transaction.senderId);
             Utils.assert.defined<string[]>(transaction.asset?.votes);
 
-            const wallet = this.walletRepository.findByPublicKey(transaction.senderPublicKey);
+            const wallet: Contracts.State.Wallet = this.walletRepository.findByAddress(transaction.senderId);
+            if (
+                transaction.headerType === Enums.TransactionHeaderType.Standard &&
+                wallet.getPublicKey() === undefined
+            ) {
+                wallet.setPublicKey(transaction.senderPublicKey);
+                this.walletRepository.index(wallet);
+            }
 
             let walletVote: { [vote: string]: number } = wallet.getAttribute("votes");
 
@@ -159,18 +166,16 @@ export class LegacyVoteTransactionHandler extends TransactionHandler {
     }
 
     public async throwIfCannotEnterPool(transaction: Interfaces.ITransaction): Promise<void> {
-        Utils.assert.defined<string>(transaction.data.senderPublicKey);
+        Utils.assert.defined<string>(transaction.data.senderId);
 
         const hasSender: boolean = this.poolQuery
-            .getAllBySender(transaction.data.senderPublicKey)
+            .getAllBySender(transaction.data.senderId)
             .whereKind(transaction)
             .has();
 
         if (hasSender) {
             throw new Contracts.Pool.PoolError(
-                `${Identities.Address.fromPublicKey(
-                    transaction.data.senderPublicKey,
-                )} already has a vote transaction in the pool`,
+                `${transaction.data.senderId} already has a vote transaction in the pool`,
                 "ERR_PENDING",
             );
         }
@@ -179,11 +184,9 @@ export class LegacyVoteTransactionHandler extends TransactionHandler {
     public async applyToSender(transaction: Interfaces.ITransaction): Promise<void> {
         await super.applyToSender(transaction);
 
-        Utils.assert.defined<string>(transaction.data.senderPublicKey);
+        Utils.assert.defined<string>(transaction.data.senderId);
 
-        const senderWallet: Contracts.State.Wallet = this.walletRepository.findByPublicKey(
-            transaction.data.senderPublicKey,
-        );
+        const senderWallet: Contracts.State.Wallet = this.walletRepository.findByAddress(transaction.data.senderId);
 
         Utils.assert.defined<string[]>(transaction.data.asset?.votes);
 
@@ -215,11 +218,9 @@ export class LegacyVoteTransactionHandler extends TransactionHandler {
     public async revertForSender(transaction: Interfaces.ITransaction): Promise<void> {
         await super.revertForSender(transaction);
 
-        Utils.assert.defined<string>(transaction.data.senderPublicKey);
+        Utils.assert.defined<string>(transaction.data.senderId);
 
-        const senderWallet: Contracts.State.Wallet = this.walletRepository.findByPublicKey(
-            transaction.data.senderPublicKey,
-        );
+        const senderWallet: Contracts.State.Wallet = this.walletRepository.findByAddress(transaction.data.senderId);
 
         let previousVotes;
 


### PR DESCRIPTION
This PR adds the logic to handle the new upcoming extended transaction header format which includes the sender's address, in addition to the current standard header format. It adds a new column to the `transactions` database table containing the address of the sender and changes most internal wallet lookups to use the sender's address rather than its public key.