### PR TITLE
refactor(transactions): allow voting for resigned delegates

### DIFF
--- a/packages/transactions/src/handlers/core/vote.ts
+++ b/packages/transactions/src/handlers/core/vote.ts
@@ -1,13 +1,7 @@
 import { Enums, Interfaces, Managers, Transactions } from "@solar-network/crypto";
 import { Container, Contracts, Enums as AppEnums, Utils } from "@solar-network/kernel";
 
-import {
-    AlreadyVotedError,
-    NoVoteError,
-    UnvoteMismatchError,
-    VotedForNonDelegateError,
-    VotedForResignedDelegateError,
-} from "../../errors";
+import { AlreadyVotedError, NoVoteError, UnvoteMismatchError, VotedForNonDelegateError } from "../../errors";
 import { TransactionHandler, TransactionHandlerConstructor } from "../transaction";
 import { DelegateRegistrationTransactionHandler } from "./delegate-registration";
 
@@ -119,10 +113,6 @@ export class LegacyVoteTransactionHandler extends TransactionHandler {
             if (vote.startsWith("+")) {
                 if (walletVote) {
                     throw new AlreadyVotedError();
-                }
-
-                if (delegateWallet.hasAttribute("delegate.resigned")) {
-                    throw new VotedForResignedDelegateError(delegateVote);
                 }
 
                 walletVote = delegateVote;

--- a/packages/transactions/src/handlers/solar/vote.ts
+++ b/packages/transactions/src/handlers/solar/vote.ts
@@ -64,7 +64,7 @@ export class VoteTransactionHandler extends TransactionHandler {
     ): Promise<void> {
         AppUtils.assert.defined<string[]>(transaction.data.asset?.votes);
 
-        const { activeDelegates } = Managers.configManager.getMilestone();
+        const { activeDelegates, canVoteForResignedDelegates } = Managers.configManager.getMilestone();
         const votes = Object.keys(transaction.data.asset.votes);
 
         if (votes.length > activeDelegates) {
@@ -83,9 +83,11 @@ export class VoteTransactionHandler extends TransactionHandler {
                 throw new VotedForNonDelegateError(delegate);
             }
 
-            const delegateWallet: Contracts.State.Wallet = this.walletRepository.findByUsername(delegate);
-            if (delegateWallet.hasAttribute("delegate.resigned")) {
-                throw new VotedForResignedDelegateError(delegate);
+            if (!canVoteForResignedDelegates) {
+                const delegateWallet: Contracts.State.Wallet = this.walletRepository.findByUsername(delegate);
+                if (delegateWallet.hasAttribute("delegate.resigned")) {
+                    throw new VotedForResignedDelegateError(delegate);
+                }
             }
         }
 


### PR DESCRIPTION
The upstream implementation prohibits voting for a resigned delegate. In their context, it totally makes sense - resignations are always permanent and you can only vote for one delegate per wallet, so it is logical to prohibit voting for resigned delegates.

Here, though, the argument is less convincing. Resignations may be temporary, and a wallet may be voting for multiple delegates. It makes little sense to demand, on the protocol level, that a voter of multiple delegates must remove all their existing votes for a resigned delegate before being able to adjust their allocated vote weight for other completely unrelated delegates from the same wallet. The argument is also strong for allowing voting for temporarily resigned delegates so that they have enough votes to re-enter the top 53 before pulling the trigger on the revocation, so they can potentially set up their node again to resume active delegacy without missing blocks. 

On the other hand, it seems counterproductive to prohibit voting for temporarily resigned delegates as, by definition, a temporarily resigned delegate may revoke their resignation in the future and it is a disincentive to make use of that facility if it means they cannot accrue or at least maintain their existing votes when wallets voting for them change their other unrelated votes during their temporary resignation, since it dramatically reduces their chances of being able to maintain enough vote weight to re-enter the top 53 once their resignation is revoked. There is even a potential justification for allowing voting for permanently resigned delegates, e.g. a protest vote.

Ultimately, this PR means that users can vote for registered delegates however they see fit, whether resigned or not, and Core will not stop them from doing so. If the delegate is resigned or standby is none of our concern protocol-wise.