### PR TITLE
feat: search the blockchain

### DIFF
--- a/packages/api/src/controllers/blockchain.ts
+++ b/packages/api/src/controllers/blockchain.ts
@@ -1,13 +1,22 @@
 import Hapi from "@hapi/hapi";
-import { Utils } from "@solar-network/crypto";
+import { Managers, Utils } from "@solar-network/crypto";
 import { Repositories } from "@solar-network/database";
 import { Container, Contracts, Utils as AppUtils } from "@solar-network/kernel";
 
+import { Identifiers } from "../identifiers";
+import { WalletSearchResource } from "../resources-new";
+import { WalletSearchService } from "../services";
 import { Controller } from "./controller";
 
 export class BlockchainController extends Controller {
+    @Container.inject(Container.Identifiers.BlockHistoryService)
+    private readonly blockHistoryService!: Contracts.Shared.BlockHistoryService;
+
     @Container.inject(Container.Identifiers.StateStore)
     private readonly stateStore!: Contracts.State.StateStore;
+
+    @Container.inject(Container.Identifiers.TransactionHistoryService)
+    private readonly transactionHistoryService!: Contracts.Shared.TransactionHistoryService;
 
     @Container.inject(Container.Identifiers.DatabaseTransactionRepository)
     private readonly transactionRepository!: Repositories.TransactionRepository;
@@ -16,7 +25,10 @@ export class BlockchainController extends Controller {
     @Container.tagged("state", "blockchain")
     private readonly walletRepository!: Contracts.State.WalletRepository;
 
-    public async index(request: Hapi.Request, h: Hapi.ResponseToolkit) {
+    @Container.inject(Identifiers.WalletSearchService)
+    private readonly walletSearchService!: WalletSearchService;
+
+    public async index(_: Hapi.Request, h: Hapi.ResponseToolkit) {
         const { data } = this.stateStore.getLastBlock();
 
         const fees = Utils.BigNumber.make(await this.transactionRepository.getFeesBurned());
@@ -37,5 +49,33 @@ export class BlockchainController extends Controller {
                 supply: AppUtils.supplyCalculator.calculate(this.walletRepository.allByAddress()),
             },
         };
+    }
+
+    public async search(request: Hapi.Request, h: Hapi.ResponseToolkit) {
+        const network = Managers.configManager.get("network");
+
+        const delegatesRegex: RegExp = new RegExp("^(?=.*[a-z!@$&_.])([a-z0-9!@$&_.]?){1,20}$", "i");
+        const hexRegex: RegExp = new RegExp("^([a-z0-9]){21,64}$", "i");
+        const publicKeysRegex: RegExp = new RegExp("^0([23]){1}([a-z0-9]){19,64}$", "i");
+        const walletsRegex: RegExp = new RegExp(`^(${network.addressCharacter})([a-z1-9]{20,33})$`, "i");
+
+        const blocks: Contracts.Shared.BlockSearchResource[] = [];
+        const transactions: Contracts.Shared.TransactionSearchResource[] = [];
+        const wallets: WalletSearchResource[] = [];
+
+        if (
+            delegatesRegex.test(request.params.id) ||
+            publicKeysRegex.test(request.params.id) ||
+            walletsRegex.test(request.params.id)
+        ) {
+            wallets.push(...this.walletSearchService.getWalletsLike(request.params.id));
+        }
+
+        if (hexRegex.test(request.params.id)) {
+            blocks.push(...(await this.blockHistoryService.getBlocksLike(request.params.id)));
+            transactions.push(...(await this.transactionHistoryService.getTransactionsLike(request.params.id)));
+        }
+
+        return { data: { blocks, transactions, wallets } };
     }
 }

--- a/packages/api/src/resources-new/wallet.ts
+++ b/packages/api/src/resources-new/wallet.ts
@@ -6,6 +6,13 @@ import * as Schemas from "../schemas";
 
 export type WalletCriteria = Contracts.Search.StandardCriteriaOf<WalletResource>;
 
+export type WalletSearchResource = {
+    address: string;
+    publicKey?: string;
+    balance: Utils.BigNumber;
+    votes: object;
+};
+
 export type WalletResource = {
     address: string;
     publicKey?: string;

--- a/packages/api/src/routes/blockchain.ts
+++ b/packages/api/src/routes/blockchain.ts
@@ -1,4 +1,5 @@
 import Hapi from "@hapi/hapi";
+import Joi from "joi";
 
 import { BlockchainController } from "../controllers/blockchain";
 
@@ -10,5 +11,20 @@ export const register = (server: Hapi.Server): void => {
         method: "GET",
         path: "/blockchain",
         handler: (request: Hapi.Request, h: Hapi.ResponseToolkit) => controller.index(request, h),
+    });
+
+    server.route({
+        method: "GET",
+        path: "/blockchain/search/{id}",
+        handler: (request: Hapi.Request, h: Hapi.ResponseToolkit) => controller.search(request, h),
+        options: {
+            validate: {
+                params: Joi.object({
+                    id: Joi.string()
+                        .pattern(/^[a-zA-Z0-9!@$&_.]{1,66}$/)
+                        .required(),
+                }),
+            },
+        },
     });
 };

--- a/packages/api/src/services/wallet-search-service.ts
+++ b/packages/api/src/services/wallet-search-service.ts
@@ -50,17 +50,10 @@ export class WalletSearchService {
                 const delegateAttributes: Record<string, any> = wallet.hasAttribute("delegate")
                     ? wallet.getAttribute("delegate")
                     : {};
-                if (criteria.length < 34) {
-                    if (criteria.length <= 20) {
-                        return delegateAttributes.username && delegateAttributes.username.startsWith(criteria);
-                    } else {
-                        return wallet.getAddress().toLowerCase().startsWith(criteria) || publicKey.startsWith(criteria);
-                    }
+                if (criteria.length <= 20) {
+                    return delegateAttributes.username && delegateAttributes.username.startsWith(criteria);
                 } else {
-                    return (
-                        criteria === wallet.getAddress().toLowerCase() ||
-                        (criteria.length > 20 && criteria === publicKey)
-                    );
+                    return wallet.getAddress().toLowerCase().startsWith(criteria) || publicKey.startsWith(criteria);
                 }
             })
             .slice(0, 100)

--- a/packages/api/src/services/wallet-search-service.ts
+++ b/packages/api/src/services/wallet-search-service.ts
@@ -1,7 +1,7 @@
-import { Identities } from "@solar-network/crypto";
+import { Enums, Identities } from "@solar-network/crypto";
 import { Container, Contracts, Services } from "@solar-network/kernel";
 
-import { WalletCriteria, WalletResource } from "../resources-new";
+import { WalletCriteria, WalletResource, WalletSearchResource } from "../resources-new";
 
 @Container.injectable()
 export class WalletSearchService {
@@ -39,6 +39,69 @@ export class WalletSearchService {
         }
 
         return undefined;
+    }
+
+    public getWalletsLike(criteria: string): WalletSearchResource[] {
+        criteria = criteria.toLowerCase();
+        return this.walletRepository
+            .allByAddress()
+            .filter((wallet) => {
+                const publicKey: string = wallet.hasPublicKey() ? wallet.getPublicKey()!.toLowerCase() : "";
+                const delegateAttributes: Record<string, any> = wallet.hasAttribute("delegate")
+                    ? wallet.getAttribute("delegate")
+                    : {};
+                if (criteria.length < 34) {
+                    if (criteria.length <= 20) {
+                        return delegateAttributes.username && delegateAttributes.username.startsWith(criteria);
+                    } else {
+                        return wallet.getAddress().toLowerCase().startsWith(criteria) || publicKey.startsWith(criteria);
+                    }
+                } else {
+                    return (
+                        criteria === wallet.getAddress().toLowerCase() ||
+                        (criteria.length > 20 && criteria === publicKey)
+                    );
+                }
+            })
+            .slice(0, 100)
+            .map((wallet) => {
+                let delegate: Record<string, any> | undefined;
+                if (wallet.hasAttribute("delegate")) {
+                    const isResigned = wallet.hasAttribute("delegate.resigned");
+                    let resigned: string | undefined;
+                    if (isResigned) {
+                        resigned =
+                            wallet.getAttribute("delegate.resigned") === Enums.DelegateStatus.PermanentResign
+                                ? "permanent"
+                                : "temporary";
+                    }
+                    delegate = {
+                        rank: wallet.hasAttribute("delegate.rank") ? wallet.getAttribute("delegate.rank") : undefined,
+                        resigned,
+                        username: wallet.getAttribute("delegate.username"),
+                        voters: wallet.getAttribute("delegate.voters"),
+                        votes: wallet.getAttribute("delegate.voteBalance"),
+                    };
+                }
+                return {
+                    address: wallet.getAddress(),
+                    delegate,
+                    publicKey: wallet.getPublicKey(),
+                    balance: wallet.getBalance(),
+                    votes: wallet.getVoteDistribution(),
+                };
+            })
+            .sort((a, b) => {
+                if (a.delegate && !a.delegate.resigned && !b.delegate) {
+                    return -1;
+                } else if (b.delegate && !b.delegate.resigned && !a.delegate) {
+                    return 1;
+                } else if (a.delegate && b.delegate && !a.delegate.resigned && !b.delegate.resigned) {
+                    return a.delegate.username.localeCompare(b.delegate.username, "en", { numeric: true });
+                } else {
+                    return a.address.localeCompare(b.address, "en", { numeric: true });
+                }
+            });
     }
 
     public getWalletsPage(

--- a/packages/crypto/src/networks/mainnet/network.json
+++ b/packages/crypto/src/networks/mainnet/network.json
@@ -1,6 +1,7 @@
 {
     "name": "mainnet",
     "messagePrefix": "Solar message:\n",
+    "addressCharacter": "S",
     "bip32": {
         "public": 70617039,
         "private": 70615956

--- a/packages/crypto/src/networks/testnet/network.json
+++ b/packages/crypto/src/networks/testnet/network.json
@@ -1,6 +1,7 @@
 {
     "name": "testnet",
     "messagePrefix": "Solar testnet message:\n",
+    "addressCharacter": "D",
     "bip32": {
         "public": 70617039,
         "private": 70615956

--- a/packages/database/src/block-filter.ts
+++ b/packages/database/src/block-filter.ts
@@ -23,7 +23,7 @@ export class BlockFilter implements Contracts.Database.BlockFilter {
             switch (key) {
                 case "id":
                     return handleOrCriteria(criteria.id!, async (c) => {
-                        return { property: "id", op: "equal", value: c };
+                        return { property: "id", op: "like", pattern: c + "%" };
                     });
                 case "version":
                     return handleOrCriteria(criteria.version!, async (c) => {

--- a/packages/database/src/block-history-service.ts
+++ b/packages/database/src/block-history-service.ts
@@ -37,6 +37,21 @@ export class BlockHistoryService implements Contracts.Shared.BlockHistoryService
         return this.modelConverter.getBlockData(models);
     }
 
+    public async getBlocksLike(criteria: string): Promise<Contracts.Shared.BlockSearchResource[]> {
+        return (
+            await this.listByCriteria({ id: criteria.toLowerCase() }, [{ property: "id", direction: "asc" }], {
+                offset: 0,
+                limit: 100,
+            })
+        ).results.map((block: Interfaces.IBlockData) => ({
+            height: block.height,
+            id: block.id,
+            timestamp: block.timestamp,
+            transactions: block.numberOfTransactions,
+            username: block.username,
+        }));
+    }
+
     public async listByCriteria(
         criteria: Contracts.Shared.OrBlockCriteria,
         sorting: Contracts.Search.Sorting,

--- a/packages/database/src/migrations/20220831000000-add-id-index-with-operator-class-to-blocks-table.ts
+++ b/packages/database/src/migrations/20220831000000-add-id-index-with-operator-class-to-blocks-table.ts
@@ -1,0 +1,18 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddIdIndexWithOperatorClassToBlocksTable20220831000000 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<any> {
+        queryRunner.connection.driver.options.extra.logger.debug(
+            "Database migration: Adding id index with operator class to blocks table",
+        );
+        await queryRunner.query(`
+            CREATE INDEX blocks_id ON blocks(id varchar_pattern_ops);
+        `);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<any> {
+        await queryRunner.query(`
+            DROP INDEX blocks_id;
+        `);
+    }
+}

--- a/packages/database/src/migrations/20220831100000-add-id-index-with-operator-class-to-transactions-table.ts
+++ b/packages/database/src/migrations/20220831100000-add-id-index-with-operator-class-to-transactions-table.ts
@@ -1,0 +1,18 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddIdIndexWithOperatorClassToTransactionsTable20220831100000 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<any> {
+        queryRunner.connection.driver.options.extra.logger.debug(
+            "Database migration: Adding id index with operator class to transactions table",
+        );
+        await queryRunner.query(`
+            CREATE INDEX transactions_id ON transactions(id varchar_pattern_ops);
+        `);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<any> {
+        await queryRunner.query(`
+            DROP INDEX transactions_id;
+        `);
+    }
+}

--- a/packages/database/src/transaction-filter.ts
+++ b/packages/database/src/transaction-filter.ts
@@ -41,7 +41,7 @@ export class TransactionFilter implements Contracts.Database.TransactionFilter {
                     });
                 case "id":
                     return handleOrCriteria(criteria.id!, async (c) => {
-                        return { property: "id", op: "equal", value: c };
+                        return { property: "id", op: "like", pattern: c + "%" };
                     });
                 case "version":
                     return handleOrCriteria(criteria.version!, async (c) => {

--- a/packages/kernel/src/contracts/shared/block-history-service.ts
+++ b/packages/kernel/src/contracts/shared/block-history-service.ts
@@ -1,10 +1,19 @@
 import { Interfaces, Utils } from "@solar-network/crypto";
 
-import { Options, OrCriteria, OrEqualCriteria, OrNumericCriteria, Pagination, ResultsPage, Sorting } from "../search";
+import {
+    Options,
+    OrCriteria,
+    OrEqualCriteria,
+    OrLikeCriteria,
+    OrNumericCriteria,
+    Pagination,
+    ResultsPage,
+    Sorting,
+} from "../search";
 import { OrTransactionCriteria } from "./transaction-history-service";
 
 export type BlockCriteria = {
-    id?: OrEqualCriteria<string>;
+    id?: OrLikeCriteria<string>;
     version?: OrEqualCriteria<number>;
     timestamp?: OrNumericCriteria<number>;
     previousBlock?: OrEqualCriteria<string>;
@@ -21,6 +30,14 @@ export type BlockCriteria = {
     blockSignature?: OrEqualCriteria<string>;
 };
 
+export type BlockSearchResource = {
+    height: number;
+    id?: string;
+    timestamp: number;
+    transactions: number;
+    username?: string;
+};
+
 export type OrBlockCriteria = OrCriteria<BlockCriteria>;
 
 export type BlockDataWithTransactionData = {
@@ -29,6 +46,8 @@ export type BlockDataWithTransactionData = {
 };
 
 export interface BlockHistoryService {
+    getBlocksLike(criteria: string): Promise<BlockSearchResource[]>;
+
     findOneByCriteria(criteria: OrBlockCriteria): Promise<Interfaces.IBlockData | undefined>;
 
     findManyByCriteria(criteria: OrBlockCriteria): Promise<Interfaces.IBlockData[]>;

--- a/packages/kernel/src/contracts/shared/transaction-history-service.ts
+++ b/packages/kernel/src/contracts/shared/transaction-history-service.ts
@@ -16,7 +16,7 @@ export type TransactionCriteria = {
     address?: OrEqualCriteria<string>;
     senderId?: OrEqualCriteria<string>;
     recipientId?: OrEqualCriteria<string>;
-    id?: OrEqualCriteria<string>;
+    id?: OrLikeCriteria<string>;
     version?: OrEqualCriteria<number>;
     blockHeight?: OrNumericCriteria<number>;
     blockId?: OrEqualCriteria<string>;
@@ -33,6 +33,16 @@ export type TransactionCriteria = {
     asset?: OrContainsCriteria<Record<string, any>>;
 };
 
+export type TransactionSearchResource = {
+    amount?: Utils.BigNumber;
+    asset?: Interfaces.ITransactionAsset;
+    id?: string;
+    recipient?: string;
+    sender: string;
+    type: number;
+    typeGroup?: number;
+};
+
 export type OrTransactionCriteria = OrCriteria<TransactionCriteria>;
 
 export type TransactionDataWithBlockData = {
@@ -41,6 +51,8 @@ export type TransactionDataWithBlockData = {
 };
 
 export interface TransactionHistoryService {
+    getTransactionsLike(criteria: string): Promise<TransactionSearchResource[]>;
+
     findOneByCriteria(criteria: OrTransactionCriteria): Promise<Interfaces.ITransactionData | undefined>;
 
     findManyByCriteria(criteria: OrTransactionCriteria): Promise<Interfaces.ITransactionData[]>;


### PR DESCRIPTION
This adds a new (ws)api endpoint `/blockchain/search/{id}` to search the blockchain, where `{id}` can be a (partial) address, block id, delegate name, public key or transaction id.