### PR TITLE
refactor: block reward donations

### DIFF
--- a/packages/api/src/resources-new/delegate.ts
+++ b/packages/api/src/resources-new/delegate.ts
@@ -30,7 +30,7 @@ export type DelegateResource = {
         fees: Utils.BigNumber;
         burnedFees: Utils.BigNumber;
         rewards: Utils.BigNumber;
-        devFunds: Utils.BigNumber;
+        donations: Utils.BigNumber;
         total: Utils.BigNumber;
     };
     version?: AppUtils.Semver;
@@ -66,7 +66,7 @@ export const delegateCriteriaSchemaObject = {
         burnedFees: Schemas.createRangeCriteriaSchema(Schemas.nonNegativeBigNumber),
         fees: Schemas.createRangeCriteriaSchema(Schemas.nonNegativeBigNumber),
         rewards: Schemas.createRangeCriteriaSchema(Schemas.nonNegativeBigNumber),
-        devFunds: Schemas.createRangeCriteriaSchema(Schemas.nonNegativeBigNumber),
+        donations: Schemas.createRangeCriteriaSchema(Schemas.nonNegativeBigNumber),
         total: Schemas.createRangeCriteriaSchema(Schemas.nonNegativeBigNumber),
     },
     version: Schemas.createRangeCriteriaSchema(Schemas.semver),

--- a/packages/api/src/resources/block-with-transactions.ts
+++ b/packages/api/src/resources/block-with-transactions.ts
@@ -39,13 +39,16 @@ export class BlockWithTransactionsResource implements Resource {
             previous: blockData.previousBlock,
             forged: {
                 reward: blockData.reward.toFixed(),
-                devFund: blockData.devFund,
+                donations: blockData.donations,
                 fee: blockData.totalFee.toFixed(),
                 burnedFee: blockData.burnedFee!.toFixed(),
                 amount: totalAmountTransferred.toFixed(),
                 total: blockData.reward
                     .minus(
-                        Object.values(blockData.devFund!).reduce((prev, curr) => prev.plus(curr), Utils.BigNumber.ZERO),
+                        Object.values(blockData.donations!).reduce(
+                            (prev, curr) => prev.plus(curr),
+                            Utils.BigNumber.ZERO,
+                        ),
                     )
                     .plus(blockData.totalFee)
                     .minus(blockData.burnedFee!)

--- a/packages/api/src/services/delegate-search-service.ts
+++ b/packages/api/src/services/delegate-search-service.ts
@@ -90,11 +90,11 @@ export class DelegateSearchService {
                 fees: delegateAttribute.forgedFees,
                 burnedFees: delegateAttribute.burnedFees,
                 rewards: delegateAttribute.forgedRewards,
-                devFunds: delegateAttribute.devFunds,
+                donations: delegateAttribute.donations,
                 total: delegateAttribute.forgedFees
                     .minus(delegateAttribute.burnedFees)
                     .plus(delegateAttribute.forgedRewards)
-                    .minus(delegateAttribute.devFunds),
+                    .minus(delegateAttribute.donations),
             },
             version:
                 delegateAttribute.version && delegateAttribute.rank && delegateAttribute.rank <= activeDelegates

--- a/packages/api/src/www/api.json
+++ b/packages/api/src/www/api.json
@@ -870,25 +870,25 @@
                         }
                     },
                     {
-                        "name": "forged.devFunds",
+                        "name": "forged.donations",
                         "in": "query",
-                        "description": "Exact amount, in satoshis, of all development funds raised by the delegate(s) to be returned",
+                        "description": "Exact amount, in satoshis, of all donations by the delegate(s) to be returned",
                         "schema": {
                             "$ref": "#/components/schemas/zeroOrMore"
                         }
                     },
                     {
-                        "name": "forged.devFunds.from",
+                        "name": "forged.donations.from",
                         "in": "query",
-                        "description": "Minimum amount, in satoshis, of all development funds raised by the delegate(s) to be returned",
+                        "description": "Minimum amount, in satoshis, of all donations by the delegate(s) to be returned",
                         "schema": {
                             "$ref": "#/components/schemas/zeroOrMore"
                         }
                     },
                     {
-                        "name": "forged.devFunds.to",
+                        "name": "forged.donations.to",
                         "in": "query",
-                        "description": "Maximum amount, in satoshis, of all all development funds raised by the delegate(s) to be returned",
+                        "description": "Maximum amount, in satoshis, of all donations by the delegate(s) to be returned",
                         "schema": {
                             "$ref": "#/components/schemas/zeroOrMore"
                         }
@@ -1131,8 +1131,8 @@
                                 "blocks.productivity:desc",
                                 "forged.burnedFees:asc",
                                 "forged.burnedFees:desc",
-                                "forged.devFunds:asc",
-                                "forged.devFunds:desc",
+                                "forged.donations:asc",
+                                "forged.donations:desc",
                                 "forged.fees:asc",
                                 "forged.fees:desc",
                                 "forged.rewards:asc",

--- a/packages/crypto/src/blocks/block.ts
+++ b/packages/crypto/src/blocks/block.ts
@@ -3,7 +3,7 @@ import { Hash, HashAlgorithms, Slots } from "../crypto";
 import { BlockSchemaError } from "../errors";
 import { IBlock, IBlockData, IBlockJson, IBlockVerification, ITransaction, ITransactionData } from "../interfaces";
 import { configManager } from "../managers/config";
-import { BigNumber, calculateDevFund, isException } from "../utils";
+import { BigNumber, calculateDonations, isException } from "../utils";
 import { validator } from "../validation";
 import { Serialiser } from "./serialiser";
 
@@ -28,7 +28,7 @@ export class Block implements IBlock {
 
         this.data.burnedFee = this.getBurnedFees();
 
-        this.data.devFund = calculateDevFund(this.data.height, this.data.reward);
+        this.data.donations = calculateDonations(this.data.height, this.data.reward);
 
         this.verification = this.verify();
     }
@@ -96,7 +96,7 @@ export class Block implements IBlock {
         return {
             blockSignature: data.blockSignature,
             burnedFee: withExtraData ? data.burnedFee : undefined,
-            devFund: withExtraData ? data.devFund : undefined,
+            donations: withExtraData ? data.donations : undefined,
             generatorPublicKey: data.generatorPublicKey,
             height: data.height,
             id: data.id,

--- a/packages/crypto/src/interfaces/block.ts
+++ b/packages/crypto/src/interfaces/block.ts
@@ -34,7 +34,7 @@ export interface IBlockData {
     totalFee: BigNumber;
     burnedFee?: BigNumber;
     reward: BigNumber;
-    devFund?: Record<string, BigNumber>;
+    donations?: Record<string, BigNumber>;
     username?: string;
     payloadLength: number;
     payloadHash: string;
@@ -58,7 +58,7 @@ export interface IBlockJson {
     totalFee: string;
     burnedFee: string;
     reward: string;
-    devFund: string;
+    donations: string;
     payloadLength: number;
     payloadHash: string;
     generatorPublicKey: string;

--- a/packages/crypto/src/interfaces/donation.ts
+++ b/packages/crypto/src/interfaces/donation.ts
@@ -1,0 +1,4 @@
+export interface IDonation {
+    percent: number;
+    purpose: string;
+}

--- a/packages/crypto/src/interfaces/index.ts
+++ b/packages/crypto/src/interfaces/index.ts
@@ -1,5 +1,6 @@
 export * from "./block";
 export * from "./crypto";
+export * from "./donation";
 export * from "./identities";
 export * from "./managers";
 export * from "./message";

--- a/packages/crypto/src/networks/mainnet/milestones.json
+++ b/packages/crypto/src/networks/mainnet/milestones.json
@@ -130,8 +130,11 @@
         "height": 671988,
         "acceptLegacySchnorrTransactions": true,
         "bip340": true,
-        "devFund": {
-            "Sgymbo4rg9aBeJJ2YmV12xdRY2xo6b94U9": 5
+        "donations": {
+            "Sgymbo4rg9aBeJJ2YmV12xdRY2xo6b94U9": {
+                "percent": 5,
+                "purpose": "development"
+            }
         }
     },
     {

--- a/packages/crypto/src/networks/testnet/milestones.json
+++ b/packages/crypto/src/networks/testnet/milestones.json
@@ -134,8 +134,11 @@
     },
     {
         "height": 671352,
-        "devFund": {
-            "DSXP3m8MJhqZvybUMCnUkfAP5PQ4aVjozy": 5
+        "donations": {
+            "DSXP3m8MJhqZvybUMCnUkfAP5PQ4aVjozy": {
+                "percent": 5,
+                "purpose": "development"
+            }
         }
     },
     {

--- a/packages/crypto/src/utils/index.ts
+++ b/packages/crypto/src/utils/index.ts
@@ -1,5 +1,5 @@
 import { SATOSHI } from "../constants";
-import { ITransactionData } from "../interfaces";
+import { IDonation, ITransactionData } from "../interfaces";
 import { configManager } from "../managers";
 import { Base58 } from "./base58";
 import { BigNumber } from "./big-number";
@@ -100,19 +100,19 @@ export const isSupportedTransactionVersion = (version: number): boolean => {
     return version === 3 || (version === 2 && (acceptLegacySchnorrTransactions || !bip340));
 };
 
-export const calculateDevFund = (height: number, reward: BigNumber): Record<string, BigNumber> => {
+export const calculateDonations = (height: number, reward: BigNumber): Record<string, BigNumber> => {
     const constants = configManager.getMilestone(height);
-    const devFund = {};
+    const donations = {};
 
-    if (!constants.devFund) {
+    if (!constants.donations) {
         return {};
     }
 
-    for (const [wallet, percent] of Object.entries(constants.devFund)) {
-        devFund[wallet] = reward.times(Math.round((percent as number) * 100)).dividedBy(10000);
+    for (const [wallet, { percent }] of Object.entries(constants.donations as Record<string, IDonation>)) {
+        donations[wallet] = reward.times(Math.round(percent * 100)).dividedBy(10000);
     }
 
-    return devFund;
+    return donations;
 };
 
 export {

--- a/packages/database/src/migrations/20220902000000-rename-dev_fund-to-donations-in-blocks-table.ts
+++ b/packages/database/src/migrations/20220902000000-rename-dev_fund-to-donations-in-blocks-table.ts
@@ -1,0 +1,18 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class RenameDevFundToDonationsInBlocksTable20220902000000 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<any> {
+        queryRunner.connection.driver.options.extra.logger.debug(
+            "Database migration: Renaming dev_fund to donations in blocks table",
+        );
+        await queryRunner.query(`
+            ALTER TABLE blocks RENAME dev_fund TO donations;
+        `);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<any> {
+        await queryRunner.query(`
+            ALTER TABLE blocks RENAME donations TO dev_fund;
+        `);
+    }
+}

--- a/packages/database/src/models/block.ts
+++ b/packages/database/src/models/block.ts
@@ -81,7 +81,7 @@ export class Block implements Contracts.Database.BlockModel {
         type: "jsonb",
         nullable: false,
     })
-    public devFund!: Record<string, Utils.BigNumber>;
+    public donations!: Record<string, Utils.BigNumber>;
 
     @Column({
         type: "integer",

--- a/packages/database/src/repositories/block-repository.ts
+++ b/packages/database/src/repositories/block-repository.ts
@@ -115,7 +115,7 @@ export class BlockRepository extends AbstractRepository<Block> {
             username: string;
             height: number;
             totalRewards: string;
-            devFunds: string;
+            donations: string;
             burnedFees: string;
             totalFees: string;
             totalProduced: number;
@@ -131,26 +131,26 @@ export class BlockRepository extends AbstractRepository<Block> {
             .groupBy("username")
             .getRawMany();
 
-        const devFunds = await this.createQueryBuilder()
+        const donations = await this.createQueryBuilder()
             .select([])
             .addSelect("username")
             .addSelect("sum(amount::bigint)", "amount")
             .leftJoin(
                 "(SELECT 1)",
                 "_",
-                "TRUE CROSS JOIN LATERAL jsonb_each_text(dev_fund::jsonb) json(address, amount)",
+                "TRUE CROSS JOIN LATERAL jsonb_each_text(donations::jsonb) json(address, amount)",
             )
             .groupBy("username")
             .getRawMany();
 
-        for (const devFund of devFunds) {
-            rewardsAndFees.find((block) => block.username === devFund.username).devFunds = devFund.amount;
+        for (const donation of donations) {
+            rewardsAndFees.find((block) => block.username === donation.username).donations = donation.amount;
         }
 
         return rewardsAndFees;
     }
 
-    public async getDevFunds(): Promise<{ address: string; amount: string; username: string }[]> {
+    public async getDonations(): Promise<{ address: string; amount: string; username: string }[]> {
         return this.createQueryBuilder()
             .select([])
             .addSelect("username")
@@ -159,7 +159,7 @@ export class BlockRepository extends AbstractRepository<Block> {
             .leftJoin(
                 "(SELECT 1)",
                 "_",
-                "TRUE CROSS JOIN LATERAL jsonb_each_text(dev_fund::jsonb) json(address, amount)",
+                "TRUE CROSS JOIN LATERAL jsonb_each_text(donations::jsonb) json(address, amount)",
             )
             .groupBy("username, address")
             .getRawMany();

--- a/packages/kernel/src/contracts/database/models.ts
+++ b/packages/kernel/src/contracts/database/models.ts
@@ -11,7 +11,7 @@ export interface BlockModel {
     totalFee: Utils.BigNumber;
     burnedFee: Utils.BigNumber;
     reward: Utils.BigNumber;
-    devFund: Record<string, Utils.BigNumber>;
+    donations: Record<string, Utils.BigNumber>;
     payloadLength: number;
     payloadHash: string;
     generatorPublicKey: string;

--- a/packages/kernel/src/contracts/state/wallets.ts
+++ b/packages/kernel/src/contracts/state/wallets.ts
@@ -191,7 +191,7 @@ export interface WalletDelegateAttributes {
     forgedFees: Utils.BigNumber;
     burnedFees: Utils.BigNumber;
     forgedRewards: Utils.BigNumber;
-    devFunds: Utils.BigNumber;
+    donations: Utils.BigNumber;
     producedBlocks: number;
     rank?: number;
     lastBlock?: string;

--- a/packages/snapshots/src/codecs/message-pack-codec.ts
+++ b/packages/snapshots/src/codecs/message-pack-codec.ts
@@ -21,7 +21,7 @@ export class MessagePackCodec implements Codec {
 
     public encodeBlock(block: {
         Block_burned_fee: Utils.BigNumber;
-        Block_dev_fund: Utils.BigNumber;
+        Block_donations: Utils.BigNumber;
         Block_id: string;
         Block_username: string;
         Block_version: number;
@@ -30,7 +30,7 @@ export class MessagePackCodec implements Codec {
             const blockCamelised = cameliseKeys(MessagePackCodec.removePrefix(block, "Block_"));
             return encode([
                 block.Block_burned_fee,
-                block.Block_dev_fund,
+                block.Block_donations,
                 block.Block_version === 0 ? block.Block_username : undefined,
                 Blocks.Serialiser.serialise(blockCamelised, true),
             ]);
@@ -41,10 +41,10 @@ export class MessagePackCodec implements Codec {
 
     public decodeBlock(buffer: Buffer): Models.Block {
         try {
-            const [burnedFee, devFund, username, serialised] = decode(buffer);
+            const [burnedFee, donations, username, serialised] = decode(buffer);
             const data = Blocks.Deserialiser.deserialise(serialised, false).data as Models.Block;
             data.burnedFee = burnedFee;
-            data.devFund = devFund;
+            data.donations = donations;
             if (username) {
                 data.username = username;
             }

--- a/packages/state/src/state-builder.ts
+++ b/packages/state/src/state-builder.ts
@@ -85,15 +85,15 @@ export class StateBuilder {
             }
         }
 
-        const devFunds = await this.blockRepository.getDevFunds();
+        const donations = await this.blockRepository.getDonations();
 
-        for (const devFund of devFunds) {
-            const amount: Utils.BigNumber = Utils.BigNumber.make(devFund.amount);
+        for (const donation of donations) {
+            const amount: Utils.BigNumber = Utils.BigNumber.make(donation.amount);
 
-            const devFundWallet = this.walletRepository.findByAddress(devFund.address);
-            devFundWallet.increaseBalance(amount);
+            const donationWallet = this.walletRepository.findByAddress(donation.address);
+            donationWallet.increaseBalance(amount);
 
-            const delegateWallet = this.walletRepository.findByUsername(devFund.username);
+            const delegateWallet = this.walletRepository.findByUsername(donation.username);
             delegateWallet.decreaseBalance(amount);
         }
     }

--- a/packages/transactions/src/handlers/core/delegate-registration.ts
+++ b/packages/transactions/src/handlers/core/delegate-registration.ts
@@ -25,7 +25,7 @@ export class DelegateRegistrationTransactionHandler extends TransactionHandler {
             "delegate.forgedFees", // Used by the API
             "delegate.burnedFees", // Used by the API
             "delegate.forgedRewards", // Used by the API
-            "delegate.devFunds", // Used by the API
+            "delegate.donations", // Used by the API
             "delegate.forgedTotal", // Used by the API
             "delegate.lastBlock",
             "delegate.missedBlocks", // Used by the API
@@ -69,7 +69,7 @@ export class DelegateRegistrationTransactionHandler extends TransactionHandler {
                 forgedFees: Utils.BigNumber.ZERO,
                 burnedFees: Utils.BigNumber.ZERO,
                 forgedRewards: Utils.BigNumber.ZERO,
-                devFunds: Utils.BigNumber.ZERO,
+                donations: Utils.BigNumber.ZERO,
                 producedBlocks: 0,
                 rank: undefined,
                 voters: 0,
@@ -91,7 +91,7 @@ export class DelegateRegistrationTransactionHandler extends TransactionHandler {
             delegate.burnedFees = delegate.forgedFees.plus(block.burnedFees);
             delegate.forgedFees = delegate.forgedFees.plus(block.totalFees);
             delegate.forgedRewards = delegate.forgedRewards.plus(block.totalRewards);
-            delegate.devFunds = delegate.devFunds.plus(block.devFunds || Utils.BigNumber.ZERO);
+            delegate.donations = delegate.donations.plus(block.donations || Utils.BigNumber.ZERO);
             delegate.producedBlocks += +block.totalProduced;
         }
 
@@ -191,7 +191,7 @@ export class DelegateRegistrationTransactionHandler extends TransactionHandler {
             forgedFees: Utils.BigNumber.ZERO,
             burnedFees: Utils.BigNumber.ZERO,
             forgedRewards: Utils.BigNumber.ZERO,
-            devFunds: Utils.BigNumber.ZERO,
+            donations: Utils.BigNumber.ZERO,
             producedBlocks: 0,
             round: 0,
             voters: 0,


### PR DESCRIPTION
This PR renames `devFund` to `donations` to better reflect its nature as a generic platform for allocating donations from block rewards.