### PR TITLE
refactor(pool): add method to get pool wallet

### DIFF
--- a/packages/kernel/src/contracts/pool/sender-mempool.ts
+++ b/packages/kernel/src/contracts/pool/sender-mempool.ts
@@ -1,5 +1,7 @@
 import { Interfaces } from "@solar-network/crypto";
 
+import { Wallet } from "../state";
+
 export interface SenderMempool {
     isDisposable(): boolean;
     getSize(): number;
@@ -10,6 +12,9 @@ export interface SenderMempool {
     addTransaction(transaction: Interfaces.ITransaction): Promise<void>;
     removeTransaction(id: string): Promise<Interfaces.ITransaction[]>;
     removeForgedTransaction(id: string): Promise<Interfaces.ITransaction[]>;
+
+    setAddress(address: string): void;
+    getWallet(): Wallet | undefined;
 }
 
 export type SenderMempoolFactory = () => SenderMempool;

--- a/packages/kernel/src/contracts/pool/sender-state.ts
+++ b/packages/kernel/src/contracts/pool/sender-state.ts
@@ -1,6 +1,9 @@
 import { Interfaces } from "@solar-network/crypto";
 
+import { Wallet } from "../state";
+
 export interface SenderState {
     apply(transaction: Interfaces.ITransaction): Promise<void>;
+    getWallet(address: string): Wallet | undefined;
     revert(transaction: Interfaces.ITransaction): Promise<void>;
 }

--- a/packages/kernel/src/contracts/pool/service.ts
+++ b/packages/kernel/src/contracts/pool/service.ts
@@ -1,9 +1,12 @@
 import { Interfaces } from "@solar-network/crypto";
 
+import { Wallet } from "../state";
+
 export interface Service {
     getPoolSize(): number;
 
     addTransaction(transaction: Interfaces.ITransaction): Promise<void>;
+    getPoolWallet(address: string): Wallet | undefined;
     readdTransactions(previouslyForgedTransactions?: Interfaces.ITransaction[]): Promise<void>;
     removeTransaction(transaction: Interfaces.ITransaction): Promise<void>;
     removeForgedTransaction(transaction: Interfaces.ITransaction): Promise<void>;

--- a/packages/pool/src/mempool.ts
+++ b/packages/pool/src/mempool.ts
@@ -37,6 +37,7 @@ export class Mempool implements Contracts.Pool.Mempool {
         let senderMempool = this.senderMempools.get(transaction.data.senderId);
         if (!senderMempool) {
             senderMempool = this.createSenderMempool();
+            senderMempool.setAddress(transaction.data.senderId);
             this.senderMempools.set(transaction.data.senderId, senderMempool);
             this.logger.debug(`${transaction.data.senderId} state created`);
         }

--- a/packages/pool/src/sender-mempool.ts
+++ b/packages/pool/src/sender-mempool.ts
@@ -12,6 +12,7 @@ export class SenderMempool implements Contracts.Pool.SenderMempool {
     @Container.inject(Container.Identifiers.PoolSenderState)
     private readonly senderState!: Contracts.Pool.SenderState;
 
+    private address!: string;
     private concurrency: number = 0;
 
     private readonly lock: AppUtils.Lock = new AppUtils.Lock();
@@ -101,5 +102,13 @@ export class SenderMempool implements Contracts.Pool.SenderMempool {
         } finally {
             this.concurrency--;
         }
+    }
+
+    public setAddress(address: string): void {
+        this.address = address;
+    }
+
+    public getWallet(): Contracts.State.Wallet | undefined {
+        return this.senderState.getWallet(this.address);
     }
 }

--- a/packages/pool/src/sender-state.ts
+++ b/packages/pool/src/sender-state.ts
@@ -88,4 +88,8 @@ export class SenderState implements Contracts.Pool.SenderState {
             throw error;
         }
     }
+
+    public getWallet(address: string): Contracts.State.Wallet | undefined {
+        return this.handlerRegistry.getRegisteredHandlers()[0].getWallet(address);
+    }
 }

--- a/packages/pool/src/service.ts
+++ b/packages/pool/src/service.ts
@@ -297,6 +297,14 @@ export class Service implements Contracts.Pool.Service {
         });
     }
 
+    public getPoolWallet(address: string): Contracts.State.Wallet | undefined {
+        if (!this.mempool.hasSenderMempool(address)) {
+            return undefined;
+        }
+
+        return this.mempool.getSenderMempool(address).getWallet();
+    }
+
     private async removeOldTransactions(): Promise<void> {
         const maxTransactionAge: number = this.configuration.getRequired<number>("maxTransactionAge");
         const lastHeight: number = this.stateStore.getLastHeight();

--- a/packages/transactions/src/handlers/transaction.ts
+++ b/packages/transactions/src/handlers/transaction.ts
@@ -217,6 +217,14 @@ export abstract class TransactionHandler {
         );
     }
 
+    public getWallet(address: string): Contracts.State.Wallet | undefined {
+        if (this.walletRepository.hasByAddress(address)) {
+            return this.walletRepository.findByAddress(address);
+        }
+
+        return undefined;
+    }
+
     protected async performGenericWalletChecks(
         transaction: Interfaces.ITransaction,
         sender: Contracts.State.Wallet,


### PR DESCRIPTION
This adds a public `getPoolWallet` method to the pool service which takes an address and returns a matching wallet from the pool if it exists. Unlike the blockchain wallet repository, this wallet takes into account the balance and nonce including any unconfirmed transactions in the pool, so it can be used by plugins to ensure that a wallet has a sufficient balance for a new transaction and to deduce the correct nonce to use when also considering any existing unconfirmed transactions in the pool for that wallet too for that specific node.

An example use case could be for a plugin that creates multiple transactions from the same wallet and adds them to the pool to be processed at the same time, without having to keep a local counter for the nonce and available balance, which may get out of sync if any of the transactions are rejected by the pool for any reason.