### PR TITLE
refactor: performance optimisations

### DIFF
--- a/packages/crypto/src/blocks/block.ts
+++ b/packages/crypto/src/blocks/block.ts
@@ -13,7 +13,7 @@ export class Block implements IBlock {
     public transactions: ITransaction[];
     public verification: IBlockVerification;
 
-    public constructor({ data, transactions }: { data: IBlockData; transactions: ITransaction[]; id?: string }) {
+    public constructor({ data, transactions }: { data: IBlockData; transactions: ITransaction[] }) {
         this.data = data;
 
         this.transactions = transactions.map((transaction, index) => {

--- a/packages/crypto/src/blocks/block.ts
+++ b/packages/crypto/src/blocks/block.ts
@@ -13,7 +13,7 @@ export class Block implements IBlock {
     public transactions: ITransaction[];
     public verification: IBlockVerification;
 
-    public constructor({ data, transactions, id }: { data: IBlockData; transactions: ITransaction[]; id?: string }) {
+    public constructor({ data, transactions }: { data: IBlockData; transactions: ITransaction[]; id?: string }) {
         this.data = data;
 
         this.transactions = transactions.map((transaction, index) => {

--- a/packages/crypto/src/blocks/factory.ts
+++ b/packages/crypto/src/blocks/factory.ts
@@ -57,7 +57,6 @@ export class BlockFactory {
             const serialised: Buffer = Serialiser.serialiseWithTransactions(data);
             const block: IBlock = new Block({
                 ...Deserialiser.deserialise(serialised, false, options),
-                id: data.id,
             });
 
             if (block.data.version === 0) {

--- a/packages/crypto/src/interfaces/transactions.ts
+++ b/packages/crypto/src/interfaces/transactions.ts
@@ -13,6 +13,7 @@ export interface ITransaction {
 
     isVerified: boolean;
 
+    addresses: IDeserialiseAddresses;
     data: ITransactionData;
     serialised: Buffer;
     timestamp: number;
@@ -20,7 +21,7 @@ export interface ITransaction {
     setBurnedFee(height: number): void;
 
     serialise(options?: ISerialiseOptions): ByteBuffer | undefined;
-    deserialise(buf: ByteBuffer): void;
+    deserialise(buf: ByteBuffer, transactionAddresses?: IDeserialiseAddresses): void;
 
     verify(options?: IVerifyOptions): boolean;
     verifySchema(strict?: boolean): ISchemaValidationResult;
@@ -164,6 +165,12 @@ export interface IHtlcExpiration {
 export interface IDeserialiseOptions {
     acceptLegacyVersion?: boolean;
     disableVersionCheck?: boolean;
+    transactionAddresses?: IDeserialiseAddresses;
+}
+
+export interface IDeserialiseAddresses {
+    senderId: string;
+    recipientId?: string[];
 }
 
 export interface IVerifyOptions {

--- a/packages/crypto/src/transactions/factory.ts
+++ b/packages/crypto/src/transactions/factory.ts
@@ -6,6 +6,7 @@ import {
     TransactionVersionError,
 } from "../errors";
 import {
+    IDeserialiseAddresses,
     IDeserialiseOptions,
     ISerialiseOptions,
     ITransaction,
@@ -35,9 +36,16 @@ export class TransactionFactory {
      * NOTE: Only use this internally when it is safe to assume the buffer has already been
      * verified.
      */
-    public static fromBytesUnsafe(buff: Buffer, id?: string): ITransaction {
+    public static fromBytesUnsafe(
+        buff: Buffer,
+        id?: string,
+        transactionAddresses?: IDeserialiseAddresses,
+    ): ITransaction {
         try {
-            const options: IDeserialiseOptions | ISerialiseOptions = { acceptLegacyVersion: true };
+            const options: IDeserialiseOptions | ISerialiseOptions = {
+                acceptLegacyVersion: true,
+                transactionAddresses,
+            };
             const transaction = Deserialiser.deserialise(buff, options);
             transaction.data.id = id || Utils.getId(transaction.data, options);
             transaction.isVerified = true;

--- a/packages/crypto/src/transactions/types/core/htlc-lock.ts
+++ b/packages/crypto/src/transactions/types/core/htlc-lock.ts
@@ -1,6 +1,6 @@
 import { TransactionType, TransactionTypeGroup } from "../../../enums";
 import { Address } from "../../../identities";
-import { ISerialiseOptions } from "../../../interfaces";
+import { IDeserialiseAddresses, ISerialiseOptions } from "../../../interfaces";
 import { BigNumber, ByteBuffer } from "../../../utils";
 import * as schemas from "../schemas";
 import { Transaction } from "../transaction";
@@ -11,6 +11,12 @@ export abstract class HtlcLockTransaction extends Transaction {
     public static key = "htlcLock";
 
     protected static defaultStaticFee: BigNumber = BigNumber.make("10000000");
+
+    public get addresses(): IDeserialiseAddresses {
+        const addresses = super.addresses;
+        addresses.recipientId = [this.data.recipientId!];
+        return addresses;
+    }
 
     public static getSchema(): schemas.TransactionSchema {
         return schemas.htlcLock;
@@ -44,7 +50,7 @@ export abstract class HtlcLockTransaction extends Transaction {
         return buff;
     }
 
-    public deserialise(buf: ByteBuffer): void {
+    public deserialise(buf: ByteBuffer, transactionAddresses?: IDeserialiseAddresses): void {
         const { data } = this;
 
         const amount: BigNumber = BigNumber.make(buf.readBigUInt64LE().toString());
@@ -52,10 +58,13 @@ export abstract class HtlcLockTransaction extends Transaction {
         const secretHash: string = buf.readBuffer(secretHashLength).toString("hex");
         const expirationType: number = buf.readUInt8();
         const expirationValue: number = buf.readUInt32LE();
-        const recipientId: string = Address.fromBuffer(buf.readBuffer(21));
-
         data.amount = amount;
-        data.recipientId = recipientId;
+        if (transactionAddresses?.recipientId) {
+            data.recipientId = transactionAddresses.recipientId[0];
+            buf.jump(21);
+        } else {
+            data.recipientId = Address.fromBuffer(buf.readBuffer(21));
+        }
         data.asset = {
             lock: {
                 secretHash,

--- a/packages/crypto/src/transactions/types/transaction.ts
+++ b/packages/crypto/src/transactions/types/transaction.ts
@@ -1,6 +1,7 @@
 import { TransactionTypeGroup } from "../../enums";
 import { NotImplemented } from "../../errors";
 import {
+    IDeserialiseAddresses,
     ISchemaValidationResult,
     ISerialiseOptions,
     ITransaction,
@@ -24,6 +25,12 @@ export abstract class Transaction implements ITransaction {
     public data!: ITransactionData;
     public serialised!: Buffer;
     public timestamp!: number;
+
+    public get addresses(): IDeserialiseAddresses {
+        return {
+            senderId: this.data.senderId,
+        };
+    }
 
     public get id(): string | undefined {
         return this.data.id;

--- a/packages/kernel/src/contracts/pool/storage.ts
+++ b/packages/kernel/src/contracts/pool/storage.ts
@@ -1,6 +1,7 @@
 export type StoredTransaction = {
     height: number;
     id: string;
+    recipientId: string;
     senderId: string;
     serialised: Buffer;
 };

--- a/packages/kernel/src/contracts/pool/worker.ts
+++ b/packages/kernel/src/contracts/pool/worker.ts
@@ -1,18 +1,18 @@
-import { Enums, Interfaces } from "@solar-network/crypto";
+import { Interfaces } from "@solar-network/crypto";
 
 import { IpcSubprocess } from "../../utils/ipc-subprocess";
 
 export type SerialisedTransaction = {
+    addresses: Interfaces.IDeserialiseAddresses;
     id: string;
     serialised: string;
     isVerified: boolean;
 };
 
 export interface WorkerScriptHandler {
-    loadCryptoPackage(packageName: string): void;
     setConfig(networkConfig: any): void;
     setHeight(height: number): void;
-    getTransactionFromData(transactionData: Interfaces.ITransactionData | string): Promise<SerialisedTransaction>;
+    getTransaction(transactionData: Interfaces.ITransactionData | string): Promise<SerialisedTransaction>;
 }
 
 export type WorkerIpcSubprocess = IpcSubprocess<WorkerScriptHandler>;
@@ -21,13 +21,11 @@ export type WorkerIpcSubprocessFactory = () => WorkerIpcSubprocess;
 
 export interface Worker {
     getQueueSize(): number;
-    loadCryptoPackage(packageName: string): void;
-    getTransactionFromData(transactionData: Interfaces.ITransactionData | Buffer): Promise<Interfaces.ITransaction>;
+    getTransaction(transactionData: Interfaces.ITransactionData | Buffer): Promise<Interfaces.ITransaction>;
 }
 
 export type WorkerFactory = () => Worker;
 
 export interface WorkerPool {
-    isTypeGroupSupported(typeGroup: Enums.TransactionTypeGroup): boolean;
-    getTransactionFromData(transactionData: Interfaces.ITransactionData | Buffer): Promise<Interfaces.ITransaction>;
+    getTransaction(transactionData: Interfaces.ITransactionData | Buffer): Promise<Interfaces.ITransaction>;
 }

--- a/packages/kernel/src/contracts/state/transaction-validator.ts
+++ b/packages/kernel/src/contracts/state/transaction-validator.ts
@@ -1,7 +1,7 @@
 import { Interfaces } from "@solar-network/crypto";
 
 export interface TransactionValidator {
-    validate(transaction: Interfaces.ITransaction): Promise<void>;
+    validate(transaction: Interfaces.ITransaction): Promise<Interfaces.ITransaction>;
 }
 
 export type TransactionValidatorFactory = () => TransactionValidator;

--- a/packages/pool/src/collator.ts
+++ b/packages/pool/src/collator.ts
@@ -71,14 +71,16 @@ export class Collator implements Contracts.Pool.Collator {
                     break;
                 }
 
+                let candidateTransaction: Interfaces.ITransaction;
                 if (validate) {
-                    await validator.validate(transaction);
+                    candidateTransaction = await validator.validate(transaction);
+                } else {
+                    candidateTransaction = transaction;
                 }
-
-                candidateTransactions.push(transaction);
+                candidateTransactions.push(candidateTransaction);
 
                 bytesLeft -= 4;
-                bytesLeft -= transaction.serialised.length;
+                bytesLeft -= candidateTransaction.serialised.length;
             } catch (error) {
                 this.logger.warning(`${transaction} failed to collate: ${error.message} :warning:`);
                 failedTransactions.push(transaction);

--- a/packages/pool/src/defaults.ts
+++ b/packages/pool/src/defaults.ts
@@ -38,6 +38,5 @@ export const defaults = {
     },
     workerPool: {
         workerCount,
-        cryptoPackages: [],
     },
 };

--- a/packages/pool/src/errors.ts
+++ b/packages/pool/src/errors.ts
@@ -10,12 +10,6 @@ export class AlreadyTriedTransactionError extends Contracts.Pool.PoolError {
     }
 }
 
-export class AlreadyForgedTransactionError extends Contracts.Pool.PoolError {
-    public constructor(transaction: Interfaces.ITransaction) {
-        super(`${transaction} was already forged`, "ERR_FORGED");
-    }
-}
-
 export class RetryTransactionError extends Contracts.Pool.PoolError {
     public constructor(transaction: Interfaces.ITransaction) {
         super(`${transaction} cannot be added to the pool, please retry`, "ERR_RETRY");
@@ -94,15 +88,6 @@ export class TransactionFailedToApplyError extends Contracts.Pool.PoolError {
 export class TransactionFailedToVerifyError extends Contracts.Pool.PoolError {
     public constructor(transaction: Interfaces.ITransaction) {
         super(`${transaction} failed signature verification check`, "ERR_BAD_DATA");
-    }
-}
-
-export class TransactionFromFutureError extends Contracts.Pool.PoolError {
-    public secondsInFuture: number;
-
-    public constructor(transaction: Interfaces.ITransaction, secondsInFuture: number) {
-        super(`${transaction} is ${Pool.pluralise("second", secondsInFuture, true)} in future`, "ERR_FROM_FUTURE");
-        this.secondsInFuture = secondsInFuture;
     }
 }
 

--- a/packages/pool/src/mempool.ts
+++ b/packages/pool/src/mempool.ts
@@ -3,9 +3,6 @@ import { Container, Contracts, Utils as AppUtils } from "@solar-network/kernel";
 
 @Container.injectable()
 export class Mempool implements Contracts.Pool.Mempool {
-    @Container.inject(Container.Identifiers.LogService)
-    private readonly logger!: Contracts.Kernel.Logger;
-
     @Container.inject(Container.Identifiers.PoolSenderMempoolFactory)
     private readonly createSenderMempool!: Contracts.Pool.SenderMempoolFactory;
 
@@ -39,7 +36,6 @@ export class Mempool implements Contracts.Pool.Mempool {
             senderMempool = this.createSenderMempool();
             senderMempool.setAddress(transaction.data.senderId);
             this.senderMempools.set(transaction.data.senderId, senderMempool);
-            this.logger.debug(`${transaction.data.senderId} state created`);
         }
 
         try {
@@ -47,7 +43,6 @@ export class Mempool implements Contracts.Pool.Mempool {
         } finally {
             if (senderMempool.isDisposable()) {
                 this.senderMempools.delete(transaction.data.senderId);
-                this.logger.debug(`${transaction.data.senderId} state disposed`);
             }
         }
     }
@@ -63,7 +58,6 @@ export class Mempool implements Contracts.Pool.Mempool {
         } finally {
             if (senderMempool.isDisposable()) {
                 this.senderMempools.delete(senderId);
-                this.logger.debug(`${senderId} state disposed`);
             }
         }
     }
@@ -79,7 +73,6 @@ export class Mempool implements Contracts.Pool.Mempool {
         } finally {
             if (senderMempool.isDisposable()) {
                 this.senderMempools.delete(senderId);
-                this.logger.debug(`${senderId} state disposed`);
             }
         }
     }

--- a/packages/pool/src/sender-state.ts
+++ b/packages/pool/src/sender-state.ts
@@ -1,4 +1,4 @@
-import { Crypto, Interfaces, Managers } from "@solar-network/crypto";
+import { Interfaces, Managers } from "@solar-network/crypto";
 import { Container, Contracts, Enums, Providers, Services } from "@solar-network/kernel";
 import { Handlers } from "@solar-network/transactions";
 
@@ -7,7 +7,6 @@ import {
     TransactionExceedsMaximumByteSizeError,
     TransactionFailedToApplyError,
     TransactionFailedToVerifyError,
-    TransactionFromFutureError,
     TransactionFromWrongNetworkError,
     TransactionHasExpiredError,
 } from "./errors";
@@ -42,12 +41,6 @@ export class SenderState implements Contracts.Pool.SenderState {
         const currentNetwork: number = Managers.configManager.get<number>("network.pubKeyHash");
         if (transaction.data.network && transaction.data.network !== currentNetwork) {
             throw new TransactionFromWrongNetworkError(transaction, currentNetwork);
-        }
-
-        const now: number = Crypto.Slots.getTime();
-        if (transaction.timestamp > now + 3600) {
-            const secondsInFuture: number = transaction.timestamp - now;
-            throw new TransactionFromFutureError(transaction, secondsInFuture);
         }
 
         if (this.expirationService.isExpired(transaction)) {

--- a/packages/pool/src/service-provider.ts
+++ b/packages/pool/src/service-provider.ts
@@ -83,14 +83,6 @@ export class ServiceProvider extends Providers.ServiceProvider {
             }).required(),
             workerPool: Joi.object({
                 workerCount: Joi.number().integer().min(1).required(),
-                cryptoPackages: Joi.array()
-                    .items(
-                        Joi.object({
-                            typeGroup: Joi.number().integer().min(3),
-                            packageName: Joi.string(),
-                        }),
-                    )
-                    .required(),
             }).required(),
         }).unknown(true);
     }

--- a/packages/pool/src/service.ts
+++ b/packages/pool/src/service.ts
@@ -257,7 +257,9 @@ export class Service implements Contracts.Pool.Service {
                             "transaction",
                             previouslyStoredFailures,
                             true,
-                        )} removed from the pool as they are no longer valid :zap:`,
+                        )} removed from the pool as ${
+                            previouslyStoredFailures !== 1 ? "they are" : "it is"
+                        } no longer valid :zap:`,
                     );
                 } else {
                     this.logger.warning(

--- a/packages/pool/src/worker-pool.ts
+++ b/packages/pool/src/worker-pool.ts
@@ -1,9 +1,5 @@
-import { Enums, Interfaces } from "@solar-network/crypto";
+import { Interfaces } from "@solar-network/crypto";
 import { Container, Contracts, Providers } from "@solar-network/kernel";
-
-import { defaults } from "./defaults";
-
-type CryptoPackagesConfig = typeof defaults.workerPool.cryptoPackages;
 
 @Container.injectable()
 export class WorkerPool implements Contracts.Pool.WorkerPool {
@@ -14,42 +10,17 @@ export class WorkerPool implements Contracts.Pool.WorkerPool {
     @Container.tagged("plugin", "@solar-network/pool")
     private readonly pluginConfiguration!: Providers.PluginConfiguration;
 
-    @Container.inject(Container.Identifiers.PluginDiscoverer)
-    private readonly pluginDiscoverer!: Providers.PluginDiscoverer;
-
     private workers: Contracts.Pool.Worker[] = [];
 
     @Container.postConstruct()
     public initialise(): void {
         const workerCount: number = this.pluginConfiguration.getRequired("workerPool.workerCount");
-        const cryptoPackages: CryptoPackagesConfig = this.pluginConfiguration.getOptional(
-            "workerPool.cryptoPackages",
-            [],
-        );
-
         for (let i = 0; i < workerCount; i++) {
-            const worker = this.createWorker();
-            for (const { packageName } of cryptoPackages) {
-                const packageId = this.pluginDiscoverer.get(packageName).packageId;
-                worker.loadCryptoPackage(packageId);
-            }
-            this.workers.push(worker);
+            this.workers.push(this.createWorker());
         }
     }
 
-    public isTypeGroupSupported(typeGroup: Enums.TransactionTypeGroup): boolean {
-        if (typeGroup === Enums.TransactionTypeGroup.Core || typeGroup === Enums.TransactionTypeGroup.Solar) {
-            return true;
-        }
-
-        const cryptoPackages: CryptoPackagesConfig = this.pluginConfiguration.getOptional(
-            "workerPool.cryptoPackages",
-            [],
-        );
-        return cryptoPackages.some((p: any) => p.typeGroup === typeGroup);
-    }
-
-    public async getTransactionFromData(
+    public async getTransaction(
         transactionData: Interfaces.ITransactionData | Buffer,
     ): Promise<Interfaces.ITransaction> {
         const worker: Contracts.Pool.Worker = this.workers.reduce((prev, next) => {
@@ -60,6 +31,6 @@ export class WorkerPool implements Contracts.Pool.WorkerPool {
             }
         });
 
-        return worker.getTransactionFromData(transactionData);
+        return worker.getTransaction(transactionData);
     }
 }

--- a/packages/pool/src/worker-script-handler.ts
+++ b/packages/pool/src/worker-script-handler.ts
@@ -2,13 +2,6 @@ import { Interfaces, Managers, Transactions } from "@solar-network/crypto";
 import { Contracts } from "@solar-network/kernel";
 
 export class WorkerScriptHandler implements Contracts.Pool.WorkerScriptHandler {
-    public loadCryptoPackage(packageName: string): void {
-        const pkgTransactions = require(packageName).Transactions;
-        for (const txConstructor of Object.values(pkgTransactions)) {
-            Transactions.TransactionRegistry.registerTransactionType(txConstructor as any);
-        }
-    }
-
     public setConfig(networkConfig: Interfaces.NetworkConfig): void {
         Managers.configManager.setConfig(networkConfig);
     }
@@ -17,13 +10,19 @@ export class WorkerScriptHandler implements Contracts.Pool.WorkerScriptHandler {
         Managers.configManager.setHeight(height);
     }
 
-    public async getTransactionFromData(
+    public async getTransaction(
         transactionData: Interfaces.ITransactionData | string,
     ): Promise<Contracts.Pool.SerialisedTransaction> {
         const tx =
             typeof transactionData === "string"
                 ? Transactions.TransactionFactory.fromBytes(Buffer.from(transactionData, "hex"))
                 : Transactions.TransactionFactory.fromData(transactionData);
-        return { id: tx.id!, serialised: tx.serialised.toString("hex"), isVerified: tx.isVerified };
+
+        return {
+            addresses: tx.addresses,
+            id: tx.id!,
+            serialised: tx.serialised.toString("hex"),
+            isVerified: tx.isVerified,
+        };
     }
 }

--- a/packages/pool/src/worker-script.ts
+++ b/packages/pool/src/worker-script.ts
@@ -3,7 +3,6 @@ import { Utils as AppUtils } from "@solar-network/kernel";
 import { WorkerScriptHandler } from "./worker-script-handler";
 
 const ipcHandler = new AppUtils.IpcHandler(new WorkerScriptHandler());
-ipcHandler.handleAction("loadCryptoPackage");
 ipcHandler.handleAction("setConfig");
 ipcHandler.handleAction("setHeight");
-ipcHandler.handleRequest("getTransactionFromData");
+ipcHandler.handleRequest("getTransaction");

--- a/packages/pool/src/worker.ts
+++ b/packages/pool/src/worker.ts
@@ -18,11 +18,7 @@ export class Worker implements Contracts.Pool.Worker {
         return this.ipcSubprocess.getQueueSize();
     }
 
-    public loadCryptoPackage(packageName: string): void {
-        this.ipcSubprocess.sendAction("loadCryptoPackage", packageName);
-    }
-
-    public async getTransactionFromData(
+    public async getTransaction(
         transactionData: Interfaces.ITransactionData | Buffer,
     ): Promise<Interfaces.ITransaction> {
         const currentHeight = Managers.configManager.getHeight()!;
@@ -32,13 +28,17 @@ export class Worker implements Contracts.Pool.Worker {
             this.ipcSubprocess.sendAction("setHeight", currentHeight);
         }
 
-        const { id, serialised, isVerified } = await this.ipcSubprocess.sendRequest(
-            "getTransactionFromData",
+        const { addresses, id, serialised, isVerified } = await this.ipcSubprocess.sendRequest(
+            "getTransaction",
             transactionData instanceof Buffer ? transactionData.toString("hex") : transactionData,
         );
-        const transaction = Transactions.TransactionFactory.fromBytesUnsafe(Buffer.from(serialised, "hex"), id);
-        transaction.isVerified = isVerified;
 
+        const transaction = Transactions.TransactionFactory.fromBytesUnsafe(
+            Buffer.from(serialised, "hex"),
+            id,
+            addresses,
+        );
+        transaction.isVerified = isVerified;
         return transaction;
     }
 }

--- a/packages/state/src/transaction-validator.ts
+++ b/packages/state/src/transaction-validator.ts
@@ -9,10 +9,11 @@ export class TransactionValidator implements Contracts.State.TransactionValidato
     @Container.tagged("state", "clone")
     private readonly handlerRegistry!: Handlers.Registry;
 
-    public async validate(transaction: Interfaces.ITransaction): Promise<void> {
+    public async validate(transaction: Interfaces.ITransaction): Promise<Interfaces.ITransaction> {
         const deserialised: Interfaces.ITransaction = Transactions.TransactionFactory.fromBytes(transaction.serialised);
         strictEqual(transaction.id, deserialised.id);
-        const handler = await this.handlerRegistry.getActivatedHandlerForData(transaction.data);
-        await handler.apply(transaction);
+        const handler = await this.handlerRegistry.getActivatedHandlerForData(deserialised.data);
+        await handler.apply(deserialised);
+        return deserialised;
     }
 }

--- a/plugins/sxp-swap/src/sxp-swap.ts
+++ b/plugins/sxp-swap/src/sxp-swap.ts
@@ -447,13 +447,14 @@ export class SXPSwap {
             }
         };
 
-        TransactionValidator.prototype.validate = async function (transaction: Interfaces.ITransaction): Promise<void> {
+        TransactionValidator.prototype.validate = async function (transaction: Interfaces.ITransaction): Promise<Interfaces.ITransaction> {
             const deserialised: Interfaces.ITransaction = Transactions.TransactionFactory.fromBytes(
                 transaction.serialised,
             );
             assert.strictEqual(transaction.id, deserialised.id);
-            const handler = await (this as any).handlerRegistry.getActivatedHandlerForData(transaction.data);
-            await handler.apply(transaction, "validate");
+            const handler = await (this as any).handlerRegistry.getActivatedHandlerForData(deserialised.data);
+            await handler.apply(deserialised, "validate");
+            return deserialised;
         };
 
         this.app.get<Services.Triggers.Triggers>(Container.Identifiers.TriggerService).unbind("applyTransaction");


### PR DESCRIPTION
This PR includes several optimisations to try to make transaction handling more efficient, especially in the context of the pool. Some redundant upstream code was removed, such as future timestamp checking since we do not have the legacy baggage of their original transaction version that included timestamps, and we ensure that all incoming transactions are handled by workers.

The main performance pain point is the way that addresses are encoded from the 21-byte buffer to the base58 address string during transaction deserialisation. This is a relatively slow process and there are cases where a full pool consisting of multi-recipient transfers with 100 addresses could take in excess of 6 seconds to process. If this coincided with a milestone change, all transactions in the full pool would be re-verified on the main thread which would inevitably cause network degradation and missed blocks. To tackle this, since we know the transactions in the pool have already been cryptographically verified at the time they were originally processed, and we know their id, we can use the light-touch `fromBytesUnsafe` method instead to quickly process them again while avoiding the slow heavy lifting. In addition, we separately save the sender and recipient addresses as text in the pool database to skip the computationally expensive base58check calculations. These combined changes reduced the processing time for a full pool from more than 6 seconds to less than 1 second.

Since full pool re-verification is now a relatively fast process, we can do it more regularly to remove transactions that were once valid but became invalidated by a subsequent transaction prior to their inclusion in a block, to keep the pools clean and free from pollution. So now, if there are 7500 or fewer transactions in the pool, we re-verify everything every time the process queue finishes executing. If there are more than 7500 transactions, we re-verify everything at the start of the round instead.