### PR TITLE
release: mainnet 4.1.2

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/api",
-    "version": "4.1.2-next.0",
+    "version": "4.1.2",
     "description": "Public API for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/blockchain/package.json
+++ b/packages/blockchain/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/blockchain",
-    "version": "4.1.2-next.0",
+    "version": "4.1.2",
     "description": "Blockchain Manager for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/blockchain/src/state-machine/actions/initialise.ts
+++ b/packages/blockchain/src/state-machine/actions/initialise.ts
@@ -158,7 +158,7 @@ export class Initialise implements Action {
             return true;
         }
 
-        this.logger.info("Calculating productivity data, this might take a while :abacus:");
+        this.logger.info("Calculating productivity data :abacus:");
 
         const chunkSize = 10000;
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/cli",
-    "version": "4.1.2-next.0",
+    "version": "4.1.2",
     "description": "Command Line Interface to manage the Core of the Solar Network Blockchain",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core",
-    "version": "4.1.2-next.0",
+    "version": "4.1.2",
     "description": "Core of the Solar Network Blockchain",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/crypto",
-    "version": "4.1.2-next.0",
+    "version": "4.1.2",
     "description": "Crypto utilities for the Solar Network Blockchain",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/crypto/src/blocks/block.ts
+++ b/packages/crypto/src/blocks/block.ts
@@ -13,7 +13,7 @@ export class Block implements IBlock {
     public transactions: ITransaction[];
     public verification: IBlockVerification;
 
-    public constructor({ data, transactions, id }: { data: IBlockData; transactions: ITransaction[]; id?: string }) {
+    public constructor({ data, transactions }: { data: IBlockData; transactions: ITransaction[] }) {
         this.data = data;
 
         this.transactions = transactions.map((transaction, index) => {

--- a/packages/crypto/src/blocks/factory.ts
+++ b/packages/crypto/src/blocks/factory.ts
@@ -57,7 +57,6 @@ export class BlockFactory {
             const serialised: Buffer = Serialiser.serialiseWithTransactions(data);
             const block: IBlock = new Block({
                 ...Deserialiser.deserialise(serialised, false, options),
-                id: data.id,
             });
 
             if (block.data.version === 0) {

--- a/packages/crypto/src/interfaces/transactions.ts
+++ b/packages/crypto/src/interfaces/transactions.ts
@@ -13,6 +13,7 @@ export interface ITransaction {
 
     isVerified: boolean;
 
+    addresses: IDeserialiseAddresses;
     data: ITransactionData;
     serialised: Buffer;
     timestamp: number;
@@ -20,7 +21,7 @@ export interface ITransaction {
     setBurnedFee(height: number): void;
 
     serialise(options?: ISerialiseOptions): ByteBuffer | undefined;
-    deserialise(buf: ByteBuffer): void;
+    deserialise(buf: ByteBuffer, transactionAddresses?: IDeserialiseAddresses): void;
 
     verify(options?: IVerifyOptions): boolean;
     verifySchema(strict?: boolean): ISchemaValidationResult;
@@ -164,6 +165,12 @@ export interface IHtlcExpiration {
 export interface IDeserialiseOptions {
     acceptLegacyVersion?: boolean;
     disableVersionCheck?: boolean;
+    transactionAddresses?: IDeserialiseAddresses;
+}
+
+export interface IDeserialiseAddresses {
+    senderId: string;
+    recipientId?: string[];
 }
 
 export interface IVerifyOptions {

--- a/packages/crypto/src/networks/mainnet/milestones.json
+++ b/packages/crypto/src/networks/mainnet/milestones.json
@@ -53,7 +53,7 @@
         "legacyTransfer": true,
         "legacyVote": true,
         "p2p": {
-            "minimumVersions": [">=4.0.0"]
+            "minimumVersions": [">=4.1.0"]
         },
         "transfer": {
             "maximum": 256,
@@ -145,7 +145,6 @@
     },
     {
         "height": 1812866,
-        "canVoteForResignedDelegates": true,
         "donations": {
             "Sgymbo4rg9aBeJJ2YmV12xdRY2xo6b94U9": {
                 "percent": 5,

--- a/packages/crypto/src/networks/testnet/milestones.json
+++ b/packages/crypto/src/networks/testnet/milestones.json
@@ -53,7 +53,7 @@
         "legacyTransfer": true,
         "legacyVote": true,
         "p2p": {
-            "minimumVersions": [">=4.1.0-next.0"]
+            "minimumVersions": [">=4.1.2-next.0"]
         },
         "transfer": {
             "maximum": 256,
@@ -150,7 +150,6 @@
     },
     {
         "height": 1260712,
-        "canVoteForResignedDelegates": true,
         "donations": {
             "DSXP3m8MJhqZvybUMCnUkfAP5PQ4aVjozy": {
                 "percent": 5,

--- a/packages/crypto/src/networks/testnet/milestones.json
+++ b/packages/crypto/src/networks/testnet/milestones.json
@@ -32,7 +32,7 @@
             },
             "minFee": 11299
         },
-        "epoch": "2022-03-16T18:00:00.000Z",
+        "epoch": "2022-07-20T18:00:00.000Z",
         "fees": {
             "staticFees": {
                 "burn": 0,
@@ -134,26 +134,17 @@
         "htlcEnabled": true
     },
     {
-        "height": 671352,
-        "donations": {
-            "DSXP3m8MJhqZvybUMCnUkfAP5PQ4aVjozy": {
-                "percent": 5,
-                "purpose": "development"
-            }
-        }
-    },
-    {
-        "height": 918650,
+        "height": 535780,
         "acceptLegacySchnorrTransactions": false,
         "legacyTransfer": false,
         "legacyVote": false
     },
     {
-        "height": 1260712,
+        "height": 535884,
         "donations": {
             "DSXP3m8MJhqZvybUMCnUkfAP5PQ4aVjozy": {
                 "percent": 5,
-                "purpose": "development"
+                "purpose": "testing"
             },
             "D646b6dx3sW5NAgMDTKAZ2hdC57K1BeRaK": {
                 "percent": 5,

--- a/packages/crypto/src/transactions/factory.ts
+++ b/packages/crypto/src/transactions/factory.ts
@@ -6,6 +6,7 @@ import {
     TransactionVersionError,
 } from "../errors";
 import {
+    IDeserialiseAddresses,
     IDeserialiseOptions,
     ISerialiseOptions,
     ITransaction,
@@ -35,9 +36,16 @@ export class TransactionFactory {
      * NOTE: Only use this internally when it is safe to assume the buffer has already been
      * verified.
      */
-    public static fromBytesUnsafe(buff: Buffer, id?: string): ITransaction {
+    public static fromBytesUnsafe(
+        buff: Buffer,
+        id?: string,
+        transactionAddresses?: IDeserialiseAddresses,
+    ): ITransaction {
         try {
-            const options: IDeserialiseOptions | ISerialiseOptions = { acceptLegacyVersion: true };
+            const options: IDeserialiseOptions | ISerialiseOptions = {
+                acceptLegacyVersion: true,
+                transactionAddresses,
+            };
             const transaction = Deserialiser.deserialise(buff, options);
             transaction.data.id = id || Utils.getId(transaction.data, options);
             transaction.isVerified = true;

--- a/packages/crypto/src/transactions/types/core/htlc-lock.ts
+++ b/packages/crypto/src/transactions/types/core/htlc-lock.ts
@@ -1,6 +1,6 @@
 import { TransactionType, TransactionTypeGroup } from "../../../enums";
 import { Address } from "../../../identities";
-import { ISerialiseOptions } from "../../../interfaces";
+import { IDeserialiseAddresses, ISerialiseOptions } from "../../../interfaces";
 import { BigNumber, ByteBuffer } from "../../../utils";
 import * as schemas from "../schemas";
 import { Transaction } from "../transaction";
@@ -11,6 +11,12 @@ export abstract class HtlcLockTransaction extends Transaction {
     public static key = "htlcLock";
 
     protected static defaultStaticFee: BigNumber = BigNumber.make("10000000");
+
+    public get addresses(): IDeserialiseAddresses {
+        const addresses = super.addresses;
+        addresses.recipientId = [this.data.recipientId!];
+        return addresses;
+    }
 
     public static getSchema(): schemas.TransactionSchema {
         return schemas.htlcLock;
@@ -44,7 +50,7 @@ export abstract class HtlcLockTransaction extends Transaction {
         return buff;
     }
 
-    public deserialise(buf: ByteBuffer): void {
+    public deserialise(buf: ByteBuffer, transactionAddresses?: IDeserialiseAddresses): void {
         const { data } = this;
 
         const amount: BigNumber = BigNumber.make(buf.readBigUInt64LE().toString());
@@ -52,10 +58,13 @@ export abstract class HtlcLockTransaction extends Transaction {
         const secretHash: string = buf.readBuffer(secretHashLength).toString("hex");
         const expirationType: number = buf.readUInt8();
         const expirationValue: number = buf.readUInt32LE();
-        const recipientId: string = Address.fromBuffer(buf.readBuffer(21));
-
         data.amount = amount;
-        data.recipientId = recipientId;
+        if (transactionAddresses?.recipientId) {
+            data.recipientId = transactionAddresses.recipientId[0];
+            buf.jump(21);
+        } else {
+            data.recipientId = Address.fromBuffer(buf.readBuffer(21));
+        }
         data.asset = {
             lock: {
                 secretHash,

--- a/packages/crypto/src/transactions/types/transaction.ts
+++ b/packages/crypto/src/transactions/types/transaction.ts
@@ -1,6 +1,7 @@
 import { TransactionTypeGroup } from "../../enums";
 import { NotImplemented } from "../../errors";
 import {
+    IDeserialiseAddresses,
     ISchemaValidationResult,
     ISerialiseOptions,
     ITransaction,
@@ -24,6 +25,12 @@ export abstract class Transaction implements ITransaction {
     public data!: ITransactionData;
     public serialised!: Buffer;
     public timestamp!: number;
+
+    public get addresses(): IDeserialiseAddresses {
+        return {
+            senderId: this.data.senderId,
+        };
+    }
 
     public get id(): string | undefined {
         return this.data.id;

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/database",
-    "version": "4.1.2-next.0",
+    "version": "4.1.2",
     "description": "Database Interface for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/forger/package.json
+++ b/packages/forger/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/forger",
-    "version": "4.1.2-next.0",
+    "version": "4.1.2",
     "description": "Forger for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/kernel/package.json
+++ b/packages/kernel/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/kernel",
-    "version": "4.1.2-next.0",
+    "version": "4.1.2",
     "description": "Kernel of Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/kernel/src/contracts/pool/sender-mempool.ts
+++ b/packages/kernel/src/contracts/pool/sender-mempool.ts
@@ -1,5 +1,7 @@
 import { Interfaces } from "@solar-network/crypto";
 
+import { Wallet } from "../state";
+
 export interface SenderMempool {
     isDisposable(): boolean;
     getSize(): number;
@@ -10,6 +12,9 @@ export interface SenderMempool {
     addTransaction(transaction: Interfaces.ITransaction): Promise<void>;
     removeTransaction(id: string): Promise<Interfaces.ITransaction[]>;
     removeForgedTransaction(id: string): Promise<Interfaces.ITransaction[]>;
+
+    setAddress(address: string): void;
+    getWallet(): Wallet | undefined;
 }
 
 export type SenderMempoolFactory = () => SenderMempool;

--- a/packages/kernel/src/contracts/pool/sender-state.ts
+++ b/packages/kernel/src/contracts/pool/sender-state.ts
@@ -1,6 +1,9 @@
 import { Interfaces } from "@solar-network/crypto";
 
+import { Wallet } from "../state";
+
 export interface SenderState {
     apply(transaction: Interfaces.ITransaction): Promise<void>;
+    getWallet(address: string): Wallet | undefined;
     revert(transaction: Interfaces.ITransaction): Promise<void>;
 }

--- a/packages/kernel/src/contracts/pool/service.ts
+++ b/packages/kernel/src/contracts/pool/service.ts
@@ -1,9 +1,12 @@
 import { Interfaces } from "@solar-network/crypto";
 
+import { Wallet } from "../state";
+
 export interface Service {
     getPoolSize(): number;
 
     addTransaction(transaction: Interfaces.ITransaction): Promise<void>;
+    getPoolWallet(address: string): Wallet | undefined;
     readdTransactions(previouslyForgedTransactions?: Interfaces.ITransaction[]): Promise<void>;
     removeTransaction(transaction: Interfaces.ITransaction): Promise<void>;
     removeForgedTransaction(transaction: Interfaces.ITransaction): Promise<void>;

--- a/packages/kernel/src/contracts/pool/storage.ts
+++ b/packages/kernel/src/contracts/pool/storage.ts
@@ -1,6 +1,7 @@
 export type StoredTransaction = {
     height: number;
     id: string;
+    recipientId: string;
     senderId: string;
     serialised: Buffer;
 };

--- a/packages/kernel/src/contracts/pool/worker.ts
+++ b/packages/kernel/src/contracts/pool/worker.ts
@@ -1,18 +1,18 @@
-import { Enums, Interfaces } from "@solar-network/crypto";
+import { Interfaces } from "@solar-network/crypto";
 
 import { IpcSubprocess } from "../../utils/ipc-subprocess";
 
 export type SerialisedTransaction = {
+    addresses: Interfaces.IDeserialiseAddresses;
     id: string;
     serialised: string;
     isVerified: boolean;
 };
 
 export interface WorkerScriptHandler {
-    loadCryptoPackage(packageName: string): void;
     setConfig(networkConfig: any): void;
     setHeight(height: number): void;
-    getTransactionFromData(transactionData: Interfaces.ITransactionData | string): Promise<SerialisedTransaction>;
+    getTransaction(transactionData: Interfaces.ITransactionData | string): Promise<SerialisedTransaction>;
 }
 
 export type WorkerIpcSubprocess = IpcSubprocess<WorkerScriptHandler>;
@@ -21,13 +21,11 @@ export type WorkerIpcSubprocessFactory = () => WorkerIpcSubprocess;
 
 export interface Worker {
     getQueueSize(): number;
-    loadCryptoPackage(packageName: string): void;
-    getTransactionFromData(transactionData: Interfaces.ITransactionData | Buffer): Promise<Interfaces.ITransaction>;
+    getTransaction(transactionData: Interfaces.ITransactionData | Buffer): Promise<Interfaces.ITransaction>;
 }
 
 export type WorkerFactory = () => Worker;
 
 export interface WorkerPool {
-    isTypeGroupSupported(typeGroup: Enums.TransactionTypeGroup): boolean;
-    getTransactionFromData(transactionData: Interfaces.ITransactionData | Buffer): Promise<Interfaces.ITransaction>;
+    getTransaction(transactionData: Interfaces.ITransactionData | Buffer): Promise<Interfaces.ITransaction>;
 }

--- a/packages/kernel/src/contracts/state/transaction-validator.ts
+++ b/packages/kernel/src/contracts/state/transaction-validator.ts
@@ -1,7 +1,7 @@
 import { Interfaces } from "@solar-network/crypto";
 
 export interface TransactionValidator {
-    validate(transaction: Interfaces.ITransaction): Promise<void>;
+    validate(transaction: Interfaces.ITransaction): Promise<Interfaces.ITransaction>;
 }
 
 export type TransactionValidatorFactory = () => TransactionValidator;

--- a/packages/kernel/src/contracts/state/wallets.ts
+++ b/packages/kernel/src/contracts/state/wallets.ts
@@ -12,7 +12,7 @@ export interface WalletBasic {
 export interface WalletIndex {
     readonly indexer: WalletIndexer;
     readonly autoIndex: boolean;
-    index(wallet: Wallet): void;
+    index(wallet: Wallet, blockchainWallet?: Wallet): void;
     has(key: string): boolean;
     get(key: string): Wallet | undefined;
     set(key: string, wallet: Wallet): void;
@@ -25,7 +25,7 @@ export interface WalletIndex {
     clear(): void;
 }
 
-export type WalletIndexer = (index: WalletIndex, wallet: Wallet) => void;
+export type WalletIndexer = (index: WalletIndex, wallet: Wallet, blockchainWallet?: Wallet) => void;
 
 export type WalletIndexerIndex = { name: string; indexer: WalletIndexer; autoIndex: boolean };
 
@@ -245,7 +245,7 @@ export interface WalletRepository {
 
     getNonce(publicKey: string): Utils.BigNumber;
 
-    index(wallet: Wallet): void;
+    index(wallet: Wallet, blockchainWallet?: Wallet): void;
 
     setOnIndex(index: string, key: string, wallet: Wallet): void;
 

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/logger",
-    "version": "4.1.2-next.0",
+    "version": "4.1.2",
     "description": "Webhooks for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/nes/package.json
+++ b/packages/nes/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/nes",
-    "version": "4.1.2-next.0",
+    "version": "4.1.2",
     "description": "Websocket client and server for Solar Core",
     "license": "BSD-3-Clause",
     "contributors": [

--- a/packages/p2p/package.json
+++ b/packages/p2p/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/p2p",
-    "version": "4.1.2-next.0",
+    "version": "4.1.2",
     "description": "P2P API for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/p2p/src/network-monitor.ts
+++ b/packages/p2p/src/network-monitor.ts
@@ -3,7 +3,7 @@ import { Container, Contracts, Enums, Providers, Services, Utils } from "@solar-
 import delay from "delay";
 import { readJsonSync } from "fs-extra";
 import prettyMs from "pretty-ms";
-import { gt, lt, satisfies } from "semver";
+import { gt, lt } from "semver";
 
 import { NetworkState } from "./network-state";
 import { Peer } from "./peer";
@@ -666,9 +666,7 @@ export class NetworkMonitor implements Contracts.P2P.NetworkMonitor {
     public async downloadTransactions(exclude: string[]): Promise<Buffer[]> {
         const transactions: Set<String> = new Set();
 
-        const peers: Contracts.P2P.Peer[] = this.repository
-            .getPeers()
-            .filter((peer) => satisfies(peer.version!, ">=4.1.0"));
+        const peers: Contracts.P2P.Peer[] = this.repository.getPeers();
 
         const peersThatWouldThrottle: boolean[] = await Promise.all(
             peers.map((peer) => this.communicator.wouldThrottleOnFetchingTransactions(peer)),

--- a/packages/p2p/src/peer-communicator.ts
+++ b/packages/p2p/src/peer-communicator.ts
@@ -226,22 +226,24 @@ export class PeerCommunicator implements Contracts.P2P.PeerCommunicator {
                         }
                         if (this.walletRepository.hasByPublicKey(publicKey)) {
                             const delegateWallet = this.walletRepository.findByPublicKey(publicKey);
-                            if (!delegatePeer) {
-                                peer.publicKeys.push(publicKey);
-                                delegateWallet.setAttribute("delegate.version", pingResponse.config.version);
-                            } else if (!peer.isForked()) {
-                                if (
-                                    delegatePeer.isForked() ||
-                                    (peer.state.header.height === lastBlock.data.height &&
-                                        peer.state.header.id === lastBlock.data.id) ||
-                                    (peer.state.header.height >= delegatePeer.state.header.height &&
-                                        delegatePeer.state.header.id !== lastBlock.data.id)
-                                ) {
+                            if (delegateWallet.isDelegate()) {
+                                if (!delegatePeer) {
                                     peer.publicKeys.push(publicKey);
                                     delegateWallet.setAttribute("delegate.version", pingResponse.config.version);
-                                    delegatePeer.publicKeys = delegatePeer.publicKeys.filter(
-                                        (peerPublicKey) => peerPublicKey !== publicKey,
-                                    );
+                                } else if (!peer.isForked()) {
+                                    if (
+                                        delegatePeer.isForked() ||
+                                        (peer.state.header.height === lastBlock.data.height &&
+                                            peer.state.header.id === lastBlock.data.id) ||
+                                        (peer.state.header.height >= delegatePeer.state.header.height &&
+                                            delegatePeer.state.header.id !== lastBlock.data.id)
+                                    ) {
+                                        peer.publicKeys.push(publicKey);
+                                        delegateWallet.setAttribute("delegate.version", pingResponse.config.version);
+                                        delegatePeer.publicKeys = delegatePeer.publicKeys.filter(
+                                            (peerPublicKey) => peerPublicKey !== publicKey,
+                                        );
+                                    }
                                 }
                             }
                         }

--- a/packages/pool/package.json
+++ b/packages/pool/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/pool",
-    "version": "4.1.2-next.0",
+    "version": "4.1.2",
     "description": "Pool Manager for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/pool/src/collator.ts
+++ b/packages/pool/src/collator.ts
@@ -71,14 +71,16 @@ export class Collator implements Contracts.Pool.Collator {
                     break;
                 }
 
+                let candidateTransaction: Interfaces.ITransaction;
                 if (validate) {
-                    await validator.validate(transaction);
+                    candidateTransaction = await validator.validate(transaction);
+                } else {
+                    candidateTransaction = transaction;
                 }
-
-                candidateTransactions.push(transaction);
+                candidateTransactions.push(candidateTransaction);
 
                 bytesLeft -= 4;
-                bytesLeft -= transaction.serialised.length;
+                bytesLeft -= candidateTransaction.serialised.length;
             } catch (error) {
                 this.logger.warning(`${transaction} failed to collate: ${error.message} :warning:`);
                 failedTransactions.push(transaction);

--- a/packages/pool/src/defaults.ts
+++ b/packages/pool/src/defaults.ts
@@ -38,6 +38,5 @@ export const defaults = {
     },
     workerPool: {
         workerCount,
-        cryptoPackages: [],
     },
 };

--- a/packages/pool/src/errors.ts
+++ b/packages/pool/src/errors.ts
@@ -10,12 +10,6 @@ export class AlreadyTriedTransactionError extends Contracts.Pool.PoolError {
     }
 }
 
-export class AlreadyForgedTransactionError extends Contracts.Pool.PoolError {
-    public constructor(transaction: Interfaces.ITransaction) {
-        super(`${transaction} was already forged`, "ERR_FORGED");
-    }
-}
-
 export class RetryTransactionError extends Contracts.Pool.PoolError {
     public constructor(transaction: Interfaces.ITransaction) {
         super(`${transaction} cannot be added to the pool, please retry`, "ERR_RETRY");
@@ -94,15 +88,6 @@ export class TransactionFailedToApplyError extends Contracts.Pool.PoolError {
 export class TransactionFailedToVerifyError extends Contracts.Pool.PoolError {
     public constructor(transaction: Interfaces.ITransaction) {
         super(`${transaction} failed signature verification check`, "ERR_BAD_DATA");
-    }
-}
-
-export class TransactionFromFutureError extends Contracts.Pool.PoolError {
-    public secondsInFuture: number;
-
-    public constructor(transaction: Interfaces.ITransaction, secondsInFuture: number) {
-        super(`${transaction} is ${Pool.pluralise("second", secondsInFuture, true)} in future`, "ERR_FROM_FUTURE");
-        this.secondsInFuture = secondsInFuture;
     }
 }
 

--- a/packages/pool/src/mempool.ts
+++ b/packages/pool/src/mempool.ts
@@ -3,9 +3,6 @@ import { Container, Contracts, Utils as AppUtils } from "@solar-network/kernel";
 
 @Container.injectable()
 export class Mempool implements Contracts.Pool.Mempool {
-    @Container.inject(Container.Identifiers.LogService)
-    private readonly logger!: Contracts.Kernel.Logger;
-
     @Container.inject(Container.Identifiers.PoolSenderMempoolFactory)
     private readonly createSenderMempool!: Contracts.Pool.SenderMempoolFactory;
 
@@ -39,7 +36,6 @@ export class Mempool implements Contracts.Pool.Mempool {
             senderMempool = this.createSenderMempool();
             senderMempool.setAddress(transaction.data.senderId);
             this.senderMempools.set(transaction.data.senderId, senderMempool);
-            this.logger.debug(`${transaction.data.senderId} state created`);
         }
 
         try {
@@ -47,7 +43,6 @@ export class Mempool implements Contracts.Pool.Mempool {
         } finally {
             if (senderMempool.isDisposable()) {
                 this.senderMempools.delete(transaction.data.senderId);
-                this.logger.debug(`${transaction.data.senderId} state disposed`);
             }
         }
     }
@@ -63,7 +58,6 @@ export class Mempool implements Contracts.Pool.Mempool {
         } finally {
             if (senderMempool.isDisposable()) {
                 this.senderMempools.delete(senderId);
-                this.logger.debug(`${senderId} state disposed`);
             }
         }
     }
@@ -79,7 +73,6 @@ export class Mempool implements Contracts.Pool.Mempool {
         } finally {
             if (senderMempool.isDisposable()) {
                 this.senderMempools.delete(senderId);
-                this.logger.debug(`${senderId} state disposed`);
             }
         }
     }

--- a/packages/pool/src/mempool.ts
+++ b/packages/pool/src/mempool.ts
@@ -37,6 +37,7 @@ export class Mempool implements Contracts.Pool.Mempool {
         let senderMempool = this.senderMempools.get(transaction.data.senderId);
         if (!senderMempool) {
             senderMempool = this.createSenderMempool();
+            senderMempool.setAddress(transaction.data.senderId);
             this.senderMempools.set(transaction.data.senderId, senderMempool);
             this.logger.debug(`${transaction.data.senderId} state created`);
         }

--- a/packages/pool/src/sender-mempool.ts
+++ b/packages/pool/src/sender-mempool.ts
@@ -12,6 +12,7 @@ export class SenderMempool implements Contracts.Pool.SenderMempool {
     @Container.inject(Container.Identifiers.PoolSenderState)
     private readonly senderState!: Contracts.Pool.SenderState;
 
+    private address!: string;
     private concurrency: number = 0;
 
     private readonly lock: AppUtils.Lock = new AppUtils.Lock();
@@ -101,5 +102,13 @@ export class SenderMempool implements Contracts.Pool.SenderMempool {
         } finally {
             this.concurrency--;
         }
+    }
+
+    public setAddress(address: string): void {
+        this.address = address;
+    }
+
+    public getWallet(): Contracts.State.Wallet | undefined {
+        return this.senderState.getWallet(this.address);
     }
 }

--- a/packages/pool/src/sender-state.ts
+++ b/packages/pool/src/sender-state.ts
@@ -1,4 +1,4 @@
-import { Crypto, Interfaces, Managers } from "@solar-network/crypto";
+import { Interfaces, Managers } from "@solar-network/crypto";
 import { Container, Contracts, Enums, Providers, Services } from "@solar-network/kernel";
 import { Handlers } from "@solar-network/transactions";
 
@@ -7,7 +7,6 @@ import {
     TransactionExceedsMaximumByteSizeError,
     TransactionFailedToApplyError,
     TransactionFailedToVerifyError,
-    TransactionFromFutureError,
     TransactionFromWrongNetworkError,
     TransactionHasExpiredError,
 } from "./errors";
@@ -42,12 +41,6 @@ export class SenderState implements Contracts.Pool.SenderState {
         const currentNetwork: number = Managers.configManager.get<number>("network.pubKeyHash");
         if (transaction.data.network && transaction.data.network !== currentNetwork) {
             throw new TransactionFromWrongNetworkError(transaction, currentNetwork);
-        }
-
-        const now: number = Crypto.Slots.getTime();
-        if (transaction.timestamp > now + 3600) {
-            const secondsInFuture: number = transaction.timestamp - now;
-            throw new TransactionFromFutureError(transaction, secondsInFuture);
         }
 
         if (this.expirationService.isExpired(transaction)) {

--- a/packages/pool/src/sender-state.ts
+++ b/packages/pool/src/sender-state.ts
@@ -88,4 +88,8 @@ export class SenderState implements Contracts.Pool.SenderState {
             throw error;
         }
     }
+
+    public getWallet(address: string): Contracts.State.Wallet | undefined {
+        return this.handlerRegistry.getRegisteredHandlers()[0].getWallet(address);
+    }
 }

--- a/packages/pool/src/service-provider.ts
+++ b/packages/pool/src/service-provider.ts
@@ -83,14 +83,6 @@ export class ServiceProvider extends Providers.ServiceProvider {
             }).required(),
             workerPool: Joi.object({
                 workerCount: Joi.number().integer().min(1).required(),
-                cryptoPackages: Joi.array()
-                    .items(
-                        Joi.object({
-                            typeGroup: Joi.number().integer().min(3),
-                            packageName: Joi.string(),
-                        }),
-                    )
-                    .required(),
             }).required(),
         }).unknown(true);
     }

--- a/packages/pool/src/service.ts
+++ b/packages/pool/src/service.ts
@@ -38,9 +38,10 @@ export class Service implements Contracts.Pool.Service {
     private disposed = false;
 
     public async boot(): Promise<void> {
-        this.events.listen(Enums.StateEvent.BuilderFinished, this);
-        this.events.listen(Enums.CryptoEvent.MilestoneChanged, this);
         this.events.listen(Enums.BlockEvent.Applied, this);
+        this.events.listen(Enums.CryptoEvent.MilestoneChanged, this);
+        this.events.listen(Enums.QueueEvent.Finished, this);
+        this.events.listen(Enums.RoundEvent.Applied, this);
 
         if (process.env.CORE_RESET_DATABASE || process.env.CORE_RESET_POOL) {
             await this.flush();
@@ -48,9 +49,10 @@ export class Service implements Contracts.Pool.Service {
     }
 
     public dispose(): void {
-        this.events.forget(Enums.CryptoEvent.MilestoneChanged, this);
-        this.events.forget(Enums.StateEvent.BuilderFinished, this);
         this.events.forget(Enums.BlockEvent.Applied, this);
+        this.events.forget(Enums.CryptoEvent.MilestoneChanged, this);
+        this.events.forget(Enums.QueueEvent.Finished, this);
+        this.events.forget(Enums.RoundEvent.Applied, this);
 
         this.disposed = true;
     }
@@ -58,14 +60,21 @@ export class Service implements Contracts.Pool.Service {
     public async handle({ name }: { name: string; data: object }): Promise<void> {
         try {
             switch (name) {
-                case Enums.StateEvent.BuilderFinished:
-                    await this.readdTransactions();
-                    break;
-                case Enums.CryptoEvent.MilestoneChanged:
-                    await this.readdTransactions();
-                    break;
                 case Enums.BlockEvent.Applied:
                     await this.cleanUp();
+                    break;
+                case Enums.CryptoEvent.MilestoneChanged:
+                    await this.readdTransactions([], true);
+                    break;
+                case Enums.QueueEvent.Finished:
+                    if (this.getPoolSize() <= 7500) {
+                        await this.readdTransactions([], true);
+                    }
+                    break;
+                case Enums.RoundEvent.Applied:
+                    if (this.getPoolSize() > 7500) {
+                        await this.readdTransactions([], true);
+                    }
                     break;
             }
         } catch (error) {
@@ -94,6 +103,7 @@ export class Service implements Contracts.Pool.Service {
             this.storage.addTransaction({
                 height: this.stateStore.getLastHeight(),
                 id: transaction.id,
+                recipientId: (transaction.addresses.recipientId || []).join(","),
                 senderId: transaction.data.senderId,
                 serialised: transaction.serialised,
             });
@@ -101,11 +111,11 @@ export class Service implements Contracts.Pool.Service {
             try {
                 await this.dynamicFeeMatcher.throwIfCannotEnterPool(transaction);
                 await this.addTransactionToMempool(transaction);
-                this.logger.debug(`${transaction} added to pool`);
+                this.logger.debug(`${transaction} added to the pool`);
                 this.events.dispatch(Enums.TransactionEvent.AddedToPool, transaction.data);
             } catch (error) {
                 this.storage.removeTransaction(transaction.id);
-                this.logger.warning(`${transaction} failed to enter pool: ${error.message} :warning:`);
+                this.logger.warning(`${transaction} failed to enter the pool: ${error.message} :warning:`);
                 this.events.dispatch(Enums.TransactionEvent.RejectedByPool, transaction.data);
 
                 throw error instanceof Contracts.Pool.PoolError
@@ -115,7 +125,10 @@ export class Service implements Contracts.Pool.Service {
         });
     }
 
-    public async readdTransactions(previouslyForgedTransactions: Interfaces.ITransaction[] = []): Promise<void> {
+    public async readdTransactions(
+        previouslyForgedTransactions: Interfaces.ITransaction[] = [],
+        recheckValidity: boolean = false,
+    ): Promise<void> {
         await this.lock.runExclusive(async () => {
             if (this.disposed) {
                 return;
@@ -131,9 +144,13 @@ export class Service implements Contracts.Pool.Service {
 
             const previouslyForgedStoredIds: string[] = [];
 
-            for (const { id, serialised } of previouslyForgedTransactions) {
+            for (const { addresses, id, serialised } of previouslyForgedTransactions) {
                 try {
-                    const previouslyForgedTransaction = Transactions.TransactionFactory.fromBytes(serialised);
+                    const previouslyForgedTransaction = Transactions.TransactionFactory.fromBytesUnsafe(
+                        serialised,
+                        id,
+                        addresses,
+                    );
 
                     AppUtils.assert.defined<string>(previouslyForgedTransaction.id);
                     AppUtils.assert.defined<string>(previouslyForgedTransaction.data.senderId);
@@ -143,6 +160,7 @@ export class Service implements Contracts.Pool.Service {
                     this.storage.addTransaction({
                         height: this.stateStore.getLastHeight(),
                         id: previouslyForgedTransaction.id,
+                        recipientId: (previouslyForgedTransaction.addresses.recipientId || []).join(","),
                         senderId: previouslyForgedTransaction.data.senderId,
                         serialised: previouslyForgedTransaction.serialised,
                     });
@@ -152,7 +170,7 @@ export class Service implements Contracts.Pool.Service {
                     previouslyForgedSuccesses++;
                 } catch (error) {
                     this.logger.debug(
-                        `Failed to re-add previously forged transaction ${id}: ${error.message} :warning:`,
+                        `Failed to re-add previously forged transaction ${id} to the pool: ${error.message} :warning:`,
                     );
                     previouslyForgedFailures++;
                 }
@@ -162,52 +180,96 @@ export class Service implements Contracts.Pool.Service {
             const lastHeight: number = this.stateStore.getLastHeight();
             const expiredHeight: number = lastHeight - maxTransactionAge;
 
-            for (const { height, id, serialised } of this.storage.getAllTransactions()) {
+            for (const { height, id, recipientId, senderId, serialised } of this.storage.getAllTransactions()) {
                 if (previouslyForgedStoredIds.includes(id)) {
                     continue;
                 }
 
                 if (height > expiredHeight) {
                     try {
-                        const previouslyStoredTransaction = Transactions.TransactionFactory.fromBytes(serialised);
+                        const addresses: Interfaces.IDeserialiseAddresses = {
+                            senderId,
+                            recipientId: (recipientId || "").split(","),
+                        };
+                        if (addresses.recipientId![0].length === 0) {
+                            delete addresses.recipientId;
+                        }
+
+                        const previouslyStoredTransaction = Transactions.TransactionFactory.fromBytesUnsafe(
+                            serialised,
+                            id,
+                            addresses,
+                        );
                         await this.addTransactionToMempool(previouslyStoredTransaction);
                         previouslyStoredSuccesses++;
                     } catch (error) {
                         this.storage.removeTransaction(id);
-                        this.logger.debug(
-                            `Failed to re-add previously stored transaction ${id}: ${error.message} :warning:`,
-                        );
+                        if (!recheckValidity) {
+                            this.logger.debug(
+                                `Failed to re-add previously stored transaction ${id} to the pool: ${error.message} :warning:`,
+                            );
+                        }
                         previouslyStoredFailures++;
                     }
                 } else {
                     this.storage.removeTransaction(id);
-                    this.logger.debug(`Not re-adding previously stored expired transaction ${id}`);
+                    this.logger.debug(`Not re-adding previously stored expired transaction to the pool: ${id}`);
                     previouslyStoredExpirations++;
                 }
             }
 
-            if (previouslyForgedSuccesses >= 1) {
+            if (!recheckValidity && previouslyForgedSuccesses >= 1) {
                 this.logger.info(
-                    `${previouslyForgedSuccesses} previously forged transactions re-added :money_with_wings:`,
+                    `${AppUtils.pluralise(
+                        "previously forged transaction",
+                        previouslyForgedSuccesses,
+                        true,
+                    )} re-added to the pool :money_with_wings:`,
                 );
             }
             if (previouslyForgedFailures >= 1) {
                 this.logger.warning(
-                    `${previouslyForgedFailures} previously forged transactions failed re-adding :warning:`,
+                    `${AppUtils.pluralise(
+                        "previously forged transaction",
+                        previouslyForgedFailures,
+                        true,
+                    )} could not be re-added to the pool :warning:`,
                 );
             }
-            if (previouslyStoredSuccesses >= 1) {
+            if (!recheckValidity && previouslyStoredSuccesses >= 1) {
                 this.logger.info(
-                    `${previouslyStoredSuccesses} previously stored transactions re-added :money_with_wings:`,
+                    `${AppUtils.pluralise(
+                        "previously stored transaction",
+                        previouslyStoredSuccesses,
+                        true,
+                    )} re-added to the pool :money_with_wings:`,
                 );
             }
             if (previouslyStoredExpirations >= 1) {
-                this.logger.info(`${previouslyStoredExpirations} previously stored transactions expired :zap:`);
+                this.logger.info(
+                    `${AppUtils.pluralise("transaction", previouslyStoredExpirations, true)} in the pool expired :zap:`,
+                );
             }
             if (previouslyStoredFailures >= 1) {
-                this.logger.warning(
-                    `${previouslyStoredFailures} previously stored transactions failed re-adding :warning:`,
-                );
+                if (recheckValidity) {
+                    this.logger.warning(
+                        `${AppUtils.pluralise(
+                            "transaction",
+                            previouslyStoredFailures,
+                            true,
+                        )} removed from the pool as ${
+                            previouslyStoredFailures !== 1 ? "they are" : "it is"
+                        } no longer valid :zap:`,
+                    );
+                } else {
+                    this.logger.warning(
+                        `${AppUtils.pluralise(
+                            "previously stored transaction",
+                            previouslyStoredFailures,
+                            true,
+                        )} could not be re-added to the pool :warning:`,
+                    );
+                }
             }
         });
     }
@@ -222,7 +284,6 @@ export class Service implements Contracts.Pool.Service {
             AppUtils.assert.defined<string>(transaction.data.senderId);
 
             if (!this.storage.hasTransaction(transaction.id)) {
-                this.logger.error(`Failed to remove ${transaction} that isn't in pool :warning:`);
                 return;
             }
 
@@ -231,13 +292,12 @@ export class Service implements Contracts.Pool.Service {
             for (const removedTransaction of removedTransactions) {
                 AppUtils.assert.defined<string>(removedTransaction.id);
                 this.storage.removeTransaction(removedTransaction.id);
-                this.logger.debug(`Removed ${removedTransaction}`);
+                this.logger.debug(`Removed ${removedTransaction} from the pool`);
                 this.events.dispatch(Enums.TransactionEvent.RemovedFromPool, removedTransaction.data);
             }
 
             if (!removedTransactions.find((t) => t.id === transaction.id)) {
                 this.storage.removeTransaction(transaction.id);
-                this.logger.error(`Removed ${transaction} from storage`);
                 this.events.dispatch(Enums.TransactionEvent.RemovedFromPool, transaction.data);
             }
         });
@@ -264,12 +324,12 @@ export class Service implements Contracts.Pool.Service {
             for (const removedTransaction of removedTransactions) {
                 AppUtils.assert.defined<string>(removedTransaction.id);
                 this.storage.removeTransaction(removedTransaction.id);
-                this.logger.debug(`Removed forged ${removedTransaction}`);
+                this.logger.debug(`Removed forged ${removedTransaction} from the pool`);
             }
 
             if (!removedTransactions.find((t) => t.id === transaction.id)) {
                 this.storage.removeTransaction(transaction.id);
-                this.logger.error(`Removed forged ${transaction} from storage`);
+                this.logger.error(`Removed forged ${transaction} from the pool storage`);
             }
         });
     }
@@ -316,7 +376,7 @@ export class Service implements Contracts.Pool.Service {
             for (const removedTransaction of removedTransactions) {
                 AppUtils.assert.defined<string>(removedTransaction.id);
                 this.storage.removeTransaction(removedTransaction.id);
-                this.logger.info(`Removed old ${removedTransaction}`);
+                this.logger.info(`Removed old ${removedTransaction} from the pool`);
                 this.events.dispatch(Enums.TransactionEvent.Expired, removedTransaction.data);
             }
         }
@@ -336,7 +396,7 @@ export class Service implements Contracts.Pool.Service {
                 for (const removedTransaction of removedTransactions) {
                     AppUtils.assert.defined<string>(removedTransaction.id);
                     this.storage.removeTransaction(removedTransaction.id);
-                    this.logger.info(`Removed expired ${removedTransaction}`);
+                    this.logger.info(`Removed expired ${removedTransaction} from the pool`);
                     this.events.dispatch(Enums.TransactionEvent.Expired, removedTransaction.data);
                 }
             }
@@ -358,7 +418,7 @@ export class Service implements Contracts.Pool.Service {
         for (const removedTransaction of removedTransactions) {
             AppUtils.assert.defined<string>(removedTransaction.id);
             this.storage.removeTransaction(removedTransaction.id);
-            this.logger.info(`Removed lowest priority ${removedTransaction}`);
+            this.logger.info(`Removed lowest priority ${removedTransaction} from the pool`);
             this.events.dispatch(Enums.TransactionEvent.RemovedFromPool, removedTransaction.data);
         }
     }

--- a/packages/pool/src/service.ts
+++ b/packages/pool/src/service.ts
@@ -297,6 +297,14 @@ export class Service implements Contracts.Pool.Service {
         });
     }
 
+    public getPoolWallet(address: string): Contracts.State.Wallet | undefined {
+        if (!this.mempool.hasSenderMempool(address)) {
+            return undefined;
+        }
+
+        return this.mempool.getSenderMempool(address).getWallet();
+    }
+
     private async removeOldTransactions(): Promise<void> {
         const maxTransactionAge: number = this.configuration.getRequired<number>("maxTransactionAge");
         const lastHeight: number = this.stateStore.getLastHeight();

--- a/packages/pool/src/worker-pool.ts
+++ b/packages/pool/src/worker-pool.ts
@@ -1,9 +1,5 @@
-import { Enums, Interfaces } from "@solar-network/crypto";
+import { Interfaces } from "@solar-network/crypto";
 import { Container, Contracts, Providers } from "@solar-network/kernel";
-
-import { defaults } from "./defaults";
-
-type CryptoPackagesConfig = typeof defaults.workerPool.cryptoPackages;
 
 @Container.injectable()
 export class WorkerPool implements Contracts.Pool.WorkerPool {
@@ -14,42 +10,17 @@ export class WorkerPool implements Contracts.Pool.WorkerPool {
     @Container.tagged("plugin", "@solar-network/pool")
     private readonly pluginConfiguration!: Providers.PluginConfiguration;
 
-    @Container.inject(Container.Identifiers.PluginDiscoverer)
-    private readonly pluginDiscoverer!: Providers.PluginDiscoverer;
-
     private workers: Contracts.Pool.Worker[] = [];
 
     @Container.postConstruct()
     public initialise(): void {
         const workerCount: number = this.pluginConfiguration.getRequired("workerPool.workerCount");
-        const cryptoPackages: CryptoPackagesConfig = this.pluginConfiguration.getOptional(
-            "workerPool.cryptoPackages",
-            [],
-        );
-
         for (let i = 0; i < workerCount; i++) {
-            const worker = this.createWorker();
-            for (const { packageName } of cryptoPackages) {
-                const packageId = this.pluginDiscoverer.get(packageName).packageId;
-                worker.loadCryptoPackage(packageId);
-            }
-            this.workers.push(worker);
+            this.workers.push(this.createWorker());
         }
     }
 
-    public isTypeGroupSupported(typeGroup: Enums.TransactionTypeGroup): boolean {
-        if (typeGroup === Enums.TransactionTypeGroup.Core || typeGroup === Enums.TransactionTypeGroup.Solar) {
-            return true;
-        }
-
-        const cryptoPackages: CryptoPackagesConfig = this.pluginConfiguration.getOptional(
-            "workerPool.cryptoPackages",
-            [],
-        );
-        return cryptoPackages.some((p: any) => p.typeGroup === typeGroup);
-    }
-
-    public async getTransactionFromData(
+    public async getTransaction(
         transactionData: Interfaces.ITransactionData | Buffer,
     ): Promise<Interfaces.ITransaction> {
         const worker: Contracts.Pool.Worker = this.workers.reduce((prev, next) => {
@@ -60,6 +31,6 @@ export class WorkerPool implements Contracts.Pool.WorkerPool {
             }
         });
 
-        return worker.getTransactionFromData(transactionData);
+        return worker.getTransaction(transactionData);
     }
 }

--- a/packages/pool/src/worker-script-handler.ts
+++ b/packages/pool/src/worker-script-handler.ts
@@ -2,13 +2,6 @@ import { Interfaces, Managers, Transactions } from "@solar-network/crypto";
 import { Contracts } from "@solar-network/kernel";
 
 export class WorkerScriptHandler implements Contracts.Pool.WorkerScriptHandler {
-    public loadCryptoPackage(packageName: string): void {
-        const pkgTransactions = require(packageName).Transactions;
-        for (const txConstructor of Object.values(pkgTransactions)) {
-            Transactions.TransactionRegistry.registerTransactionType(txConstructor as any);
-        }
-    }
-
     public setConfig(networkConfig: Interfaces.NetworkConfig): void {
         Managers.configManager.setConfig(networkConfig);
     }
@@ -17,13 +10,19 @@ export class WorkerScriptHandler implements Contracts.Pool.WorkerScriptHandler {
         Managers.configManager.setHeight(height);
     }
 
-    public async getTransactionFromData(
+    public async getTransaction(
         transactionData: Interfaces.ITransactionData | string,
     ): Promise<Contracts.Pool.SerialisedTransaction> {
         const tx =
             typeof transactionData === "string"
                 ? Transactions.TransactionFactory.fromBytes(Buffer.from(transactionData, "hex"))
                 : Transactions.TransactionFactory.fromData(transactionData);
-        return { id: tx.id!, serialised: tx.serialised.toString("hex"), isVerified: tx.isVerified };
+
+        return {
+            addresses: tx.addresses,
+            id: tx.id!,
+            serialised: tx.serialised.toString("hex"),
+            isVerified: tx.isVerified,
+        };
     }
 }

--- a/packages/pool/src/worker-script.ts
+++ b/packages/pool/src/worker-script.ts
@@ -3,7 +3,6 @@ import { Utils as AppUtils } from "@solar-network/kernel";
 import { WorkerScriptHandler } from "./worker-script-handler";
 
 const ipcHandler = new AppUtils.IpcHandler(new WorkerScriptHandler());
-ipcHandler.handleAction("loadCryptoPackage");
 ipcHandler.handleAction("setConfig");
 ipcHandler.handleAction("setHeight");
-ipcHandler.handleRequest("getTransactionFromData");
+ipcHandler.handleRequest("getTransaction");

--- a/packages/pool/src/worker.ts
+++ b/packages/pool/src/worker.ts
@@ -18,11 +18,7 @@ export class Worker implements Contracts.Pool.Worker {
         return this.ipcSubprocess.getQueueSize();
     }
 
-    public loadCryptoPackage(packageName: string): void {
-        this.ipcSubprocess.sendAction("loadCryptoPackage", packageName);
-    }
-
-    public async getTransactionFromData(
+    public async getTransaction(
         transactionData: Interfaces.ITransactionData | Buffer,
     ): Promise<Interfaces.ITransaction> {
         const currentHeight = Managers.configManager.getHeight()!;
@@ -32,13 +28,17 @@ export class Worker implements Contracts.Pool.Worker {
             this.ipcSubprocess.sendAction("setHeight", currentHeight);
         }
 
-        const { id, serialised, isVerified } = await this.ipcSubprocess.sendRequest(
-            "getTransactionFromData",
+        const { addresses, id, serialised, isVerified } = await this.ipcSubprocess.sendRequest(
+            "getTransaction",
             transactionData instanceof Buffer ? transactionData.toString("hex") : transactionData,
         );
-        const transaction = Transactions.TransactionFactory.fromBytesUnsafe(Buffer.from(serialised, "hex"), id);
-        transaction.isVerified = isVerified;
 
+        const transaction = Transactions.TransactionFactory.fromBytesUnsafe(
+            Buffer.from(serialised, "hex"),
+            id,
+            addresses,
+        );
+        transaction.isVerified = isVerified;
         return transaction;
     }
 }

--- a/packages/snapshots/package.json
+++ b/packages/snapshots/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/snapshots",
-    "version": "4.1.2-next.0",
+    "version": "4.1.2",
     "description": "Provides live local streamed snapshots functionality for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/snapshots/src/contracts/worker.ts
+++ b/packages/snapshots/src/contracts/worker.ts
@@ -9,7 +9,6 @@ export interface WorkerAction {
 export interface WorkerData {
     actionOptions: ActionOptions;
     networkConfig: Interfaces.NetworkConfig;
-    cryptoPackages: string[];
     connection?: any;
 }
 

--- a/packages/snapshots/src/database-service.ts
+++ b/packages/snapshots/src/database-service.ts
@@ -22,9 +22,6 @@ export class SnapshotDatabaseService implements Database.DatabaseService {
     @Container.tagged("plugin", "@solar-network/database")
     private readonly coreDatabaseConfiguration!: Providers.PluginConfiguration;
 
-    @Container.inject(Container.Identifiers.PluginDiscoverer)
-    private readonly pluginDiscoverer!: Providers.PluginDiscoverer;
-
     @Container.inject(Container.Identifiers.LogService)
     private readonly logger!: Contracts.Kernel.Logger;
 
@@ -379,11 +376,6 @@ export class SnapshotDatabaseService implements Database.DatabaseService {
     }
 
     private prepareWorkerData(action: string, table: string, meta: Meta.MetaData): any {
-        const cryptoPackages: string[] = [];
-        for (const packageName of this.configuration.getOptional<string[]>("cryptoPackages", [])) {
-            cryptoPackages.push(this.pluginDiscoverer.get(packageName).packageId);
-        }
-
         return {
             actionOptions: {
                 action: action,
@@ -397,7 +389,6 @@ export class SnapshotDatabaseService implements Database.DatabaseService {
                 updateStep: this.configuration.getOptional("updateStep", 1000),
             },
             networkConfig: Managers.configManager.all()!,
-            cryptoPackages,
             connection: this.coreDatabaseConfiguration.getRequired("connection"),
         };
     }

--- a/packages/snapshots/src/service-provider.ts
+++ b/packages/snapshots/src/service-provider.ts
@@ -32,7 +32,6 @@ export class ServiceProvider extends Providers.ServiceProvider {
     public configSchema(): object {
         return Joi.object({
             updateStep: Joi.number().integer().min(1).max(2000).required(),
-            cryptoPackages: Joi.array().items(Joi.string()),
         }).unknown(true);
     }
 

--- a/packages/snapshots/src/snapshot-service.ts
+++ b/packages/snapshots/src/snapshot-service.ts
@@ -143,7 +143,7 @@ export class SnapshotService implements Contracts.Snapshot.SnapshotService {
 
             if (height >= currentHeight) {
                 this.logger.error(
-                    `Rollback height ${height.toLocaleString()} is greater than the current height ${currentHeight.toLocaleString()}`,
+                    `Rollback height ${height.toLocaleString()} is not less than the current height ${currentHeight.toLocaleString()}`,
                 );
                 return;
             }

--- a/packages/snapshots/src/workers/worker.ts
+++ b/packages/snapshots/src/workers/worker.ts
@@ -1,4 +1,4 @@
-import { Managers, Transactions } from "@solar-network/crypto";
+import { Managers } from "@solar-network/crypto";
 import { Models, Utils } from "@solar-network/database";
 import { Container } from "@solar-network/kernel";
 import { Readable } from "stream";
@@ -28,13 +28,6 @@ const connect = async (options: any): Promise<Connection> => {
 export const init = async (): Promise<void> => {
     Managers.configManager.setConfig(_workerData.networkConfig);
 
-    for (const cryptoPackage of _workerData.cryptoPackages) {
-        const transactions = require(cryptoPackage).Transactions;
-
-        for (const transaction of Object.values(transactions)) {
-            Transactions.TransactionRegistry.registerTransactionType(transaction as typeof Transactions.Transaction);
-        }
-    }
     app = new Application(new Container.Container());
 
     if (_workerData.connection) {

--- a/packages/state/package.json
+++ b/packages/state/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/state",
-    "version": "4.1.2-next.0",
+    "version": "4.1.2",
     "description": "State Management for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [
@@ -29,5 +29,5 @@
         "semver": "6.3.0",
         "xstate": "4.23.4"
     },
-    "minimumSavedStateVersion": "4.1.0-next.5"
+    "minimumSavedStateVersion": "4.1.0"
 }

--- a/packages/state/src/transaction-validator.ts
+++ b/packages/state/src/transaction-validator.ts
@@ -9,10 +9,11 @@ export class TransactionValidator implements Contracts.State.TransactionValidato
     @Container.tagged("state", "clone")
     private readonly handlerRegistry!: Handlers.Registry;
 
-    public async validate(transaction: Interfaces.ITransaction): Promise<void> {
+    public async validate(transaction: Interfaces.ITransaction): Promise<Interfaces.ITransaction> {
         const deserialised: Interfaces.ITransaction = Transactions.TransactionFactory.fromBytes(transaction.serialised);
         strictEqual(transaction.id, deserialised.id);
-        const handler = await this.handlerRegistry.getActivatedHandlerForData(transaction.data);
-        await handler.apply(transaction);
+        const handler = await this.handlerRegistry.getActivatedHandlerForData(deserialised.data);
+        await handler.apply(deserialised);
+        return deserialised;
     }
 }

--- a/packages/state/src/wallets/indexers/indexers.ts
+++ b/packages/state/src/wallets/indexers/indexers.ts
@@ -10,32 +10,63 @@ const isIndexable = (wallet: Contracts.State.Wallet): boolean => {
     );
 };
 
-export const addressesIndexer = (index: Contracts.State.WalletIndex, wallet: Contracts.State.Wallet): void => {
-    if (wallet.getAddress() && isIndexable(wallet)) {
+const shouldBeIndexed = (wallet: Contracts.State.Wallet, blockchainWallet?: Contracts.State.Wallet): boolean => {
+    const blockchainWalletIsIndexable = blockchainWallet && isIndexable(blockchainWallet);
+    const walletIsIndexable = isIndexable(wallet);
+
+    if (!walletIsIndexable && blockchainWalletIsIndexable) {
+        return true;
+    }
+
+    return walletIsIndexable;
+};
+
+export const addressesIndexer = (
+    index: Contracts.State.WalletIndex,
+    wallet: Contracts.State.Wallet,
+    blockchainWallet?: Contracts.State.Wallet,
+): void => {
+    if (wallet.getAddress() && shouldBeIndexed(wallet, blockchainWallet)) {
         index.set(wallet.getAddress(), wallet);
     }
 };
 
-export const publicKeysIndexer = (index: Contracts.State.WalletIndex, wallet: Contracts.State.Wallet): void => {
-    if (wallet.getPublicKey() && isIndexable(wallet)) {
+export const publicKeysIndexer = (
+    index: Contracts.State.WalletIndex,
+    wallet: Contracts.State.Wallet,
+    blockchainWallet?: Contracts.State.Wallet,
+): void => {
+    if (wallet.getPublicKey() && shouldBeIndexed(wallet, blockchainWallet)) {
         index.set(wallet.getPublicKey()!, wallet);
     }
 };
 
-export const usernamesIndexer = (index: Contracts.State.WalletIndex, wallet: Contracts.State.Wallet): void => {
-    if (wallet.isDelegate() && isIndexable(wallet)) {
+export const usernamesIndexer = (
+    index: Contracts.State.WalletIndex,
+    wallet: Contracts.State.Wallet,
+    blockchainWallet?: Contracts.State.Wallet,
+): void => {
+    if (wallet.isDelegate() && shouldBeIndexed(wallet, blockchainWallet)) {
         index.set(wallet.getAttribute("delegate.username"), wallet);
     }
 };
 
-export const resignationsIndexer = (index: Contracts.State.WalletIndex, wallet: Contracts.State.Wallet): void => {
-    if (wallet.isDelegate() && wallet.hasAttribute("delegate.resigned") && isIndexable(wallet)) {
+export const resignationsIndexer = (
+    index: Contracts.State.WalletIndex,
+    wallet: Contracts.State.Wallet,
+    blockchainWallet?: Contracts.State.Wallet,
+): void => {
+    if (wallet.isDelegate() && wallet.hasAttribute("delegate.resigned") && shouldBeIndexed(wallet, blockchainWallet)) {
         index.set(wallet.getAttribute("delegate.username"), wallet);
     }
 };
 
-export const locksIndexer = (index: Contracts.State.WalletIndex, wallet: Contracts.State.Wallet): void => {
-    if (wallet.hasAttribute("htlc.locks") && isIndexable(wallet)) {
+export const locksIndexer = (
+    index: Contracts.State.WalletIndex,
+    wallet: Contracts.State.Wallet,
+    blockchainWallet?: Contracts.State.Wallet,
+): void => {
+    if (wallet.hasAttribute("htlc.locks") && shouldBeIndexed(wallet, blockchainWallet)) {
         const locks: object = wallet.getAttribute("htlc.locks");
 
         for (const lockId of Object.keys(locks)) {
@@ -44,8 +75,12 @@ export const locksIndexer = (index: Contracts.State.WalletIndex, wallet: Contrac
     }
 };
 
-export const ipfsIndexer = (index: Contracts.State.WalletIndex, wallet: Contracts.State.Wallet): void => {
-    if (wallet.hasAttribute("ipfs.hashes") && isIndexable(wallet)) {
+export const ipfsIndexer = (
+    index: Contracts.State.WalletIndex,
+    wallet: Contracts.State.Wallet,
+    blockchainWallet?: Contracts.State.Wallet,
+): void => {
+    if (wallet.hasAttribute("ipfs.hashes") && shouldBeIndexed(wallet, blockchainWallet)) {
         const hashes: object = wallet.getAttribute("ipfs.hashes");
 
         for (const hash of Object.keys(hashes)) {

--- a/packages/state/src/wallets/wallet-index.ts
+++ b/packages/state/src/wallets/wallet-index.ts
@@ -27,8 +27,8 @@ export class WalletIndex implements Contracts.State.WalletIndex {
         return [...this.walletByKey.values()];
     }
 
-    public index(wallet: Contracts.State.Wallet): void {
-        this.indexer(this, wallet);
+    public index(wallet: Contracts.State.Wallet, blockchainWallet?: Contracts.State.Wallet): void {
+        this.indexer(this, wallet, blockchainWallet);
     }
 
     public has(key: string): boolean {

--- a/packages/state/src/wallets/wallet-repository-clone.ts
+++ b/packages/state/src/wallets/wallet-repository-clone.ts
@@ -49,14 +49,17 @@ export class WalletRepositoryClone extends WalletRepository {
         }
 
         let wallet;
+        let blockchainWallet;
+
         if (this.blockchainWalletRepository.hasByAddress(address)) {
             const walletToClone = this.blockchainWalletRepository.findByAddress(address);
+            blockchainWallet = walletToClone;
             wallet = this.cloneWallet(this.blockchainWalletRepository, walletToClone);
         } else {
             wallet = this.createWallet(address);
         }
 
-        super.index(wallet);
+        super.index(wallet, blockchainWallet);
 
         return wallet;
     }
@@ -65,7 +68,11 @@ export class WalletRepositoryClone extends WalletRepository {
         if (!super.hasByIndex(Contracts.State.WalletIndexes.PublicKeys, publicKey)) {
             const wallet = this.findByAddress(Identities.Address.fromPublicKey(publicKey));
             wallet.setPublicKey(publicKey);
-            super.index(wallet);
+            let blockchainWallet;
+            if (this.blockchainWalletRepository.hasByPublicKey(publicKey)) {
+                blockchainWallet = this.blockchainWalletRepository.findByPublicKey(publicKey);
+            }
+            super.index(wallet, blockchainWallet);
         }
 
         return super.findByIndex(Contracts.State.WalletIndexes.PublicKeys, publicKey);
@@ -144,7 +151,12 @@ export class WalletRepositoryClone extends WalletRepository {
             indexKeys[indexName] = this.getIndex(indexName).walletKeys(wallet);
         }
 
-        super.indexWallet(wallet);
+        let blockchainWallet;
+        const address = wallet.getAddress();
+        if (this.blockchainWalletRepository.hasByAddress(address)) {
+            blockchainWallet = this.blockchainWalletRepository.findByAddress(address);
+        }
+        super.indexWallet(wallet, blockchainWallet);
 
         for (const indexName of this.getIndexNames()) {
             const walletKeys = this.getIndex(indexName).walletKeys(wallet);

--- a/packages/state/src/wallets/wallet-repository.ts
+++ b/packages/state/src/wallets/wallet-repository.ts
@@ -126,12 +126,15 @@ export class WalletRepository implements Contracts.State.WalletRepository {
         return Utils.BigNumber.ZERO;
     }
 
-    public index(wallets: Contracts.State.Wallet | Contracts.State.Wallet[]): void {
-        if (!Array.isArray(wallets)) {
-            this.indexWallet(wallets);
-        } else {
-            for (const wallet of wallets) {
-                this.indexWallet(wallet);
+    public index(
+        wallets: Contracts.State.Wallet | Contracts.State.Wallet[],
+        blockchainWallets?: Contracts.State.Wallet | Contracts.State.Wallet[],
+    ): void {
+        if (!Array.isArray(wallets) && !Array.isArray(blockchainWallets)) {
+            this.indexWallet(wallets, blockchainWallets);
+        } else if (Array.isArray(wallets) && Array.isArray(blockchainWallets)) {
+            for (let i = 0; i < wallets.length; i++) {
+                this.indexWallet(wallets[i], blockchainWallets[i]);
             }
         }
     }
@@ -168,10 +171,10 @@ export class WalletRepository implements Contracts.State.WalletRepository {
         return walletClone;
     }
 
-    protected indexWallet(wallet: Contracts.State.Wallet): void {
+    protected indexWallet(wallet: Contracts.State.Wallet, blockchainWallet?: Contracts.State.Wallet): void {
         for (const index of Object.values(this.indexes).filter((index) => index.autoIndex)) {
             index.forgetWallet(wallet);
-            index.index(wallet);
+            index.index(wallet, blockchainWallet);
         }
     }
 }

--- a/packages/state/src/wallets/wallet.ts
+++ b/packages/state/src/wallets/wallet.ts
@@ -206,7 +206,7 @@ export class Wallet implements Contracts.State.Wallet {
      * @memberof Wallet
      */
     public isDelegate(): boolean {
-        return this.hasAttribute("delegate");
+        return this.hasAttribute("delegate.username");
     }
 
     /**

--- a/packages/transactions/package.json
+++ b/packages/transactions/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/transactions",
-    "version": "4.1.2-next.0",
+    "version": "4.1.2",
     "description": "Transaction Services for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/transactions/src/errors.ts
+++ b/packages/transactions/src/errors.ts
@@ -164,6 +164,13 @@ export class SecondSignatureAlreadyRegisteredError extends TransactionError {
         super("Failed to apply transaction, because a second signature is already enabled on this wallet");
     }
 }
+
+export class PublicKeyAlreadyAssociatedWithWalletError extends TransactionError {
+    public constructor() {
+        super("Failed to apply transaction, because that public key is already associated with this wallet");
+    }
+}
+
 export class NotSupportedForMultiSignatureWalletError extends TransactionError {
     public constructor() {
         super("Failed to apply transaction, because multisignature is enabled");

--- a/packages/transactions/src/errors.ts
+++ b/packages/transactions/src/errors.ts
@@ -204,12 +204,6 @@ export class VotedForNonDelegateError extends TransactionError {
     }
 }
 
-export class VotedForResignedDelegateError extends TransactionError {
-    public constructor(vote: string) {
-        super(`Failed to apply transaction, because '${vote}' is a resigned delegate`);
-    }
-}
-
 export class VotedForTooManyDelegatesError extends TransactionError {
     public constructor(maximumVotes: number) {
         super(`Failed to apply transaction, because there are more than ${maximumVotes.toLocaleString()} votes`);

--- a/packages/transactions/src/handlers/core/second-signature-registration.ts
+++ b/packages/transactions/src/handlers/core/second-signature-registration.ts
@@ -1,7 +1,11 @@
 import { Enums, Interfaces, Transactions } from "@solar-network/crypto";
 import { Container, Contracts, Utils } from "@solar-network/kernel";
 
-import { NotSupportedForMultiSignatureWalletError, SecondSignatureAlreadyRegisteredError } from "../../errors";
+import {
+    NotSupportedForMultiSignatureWalletError,
+    PublicKeyAlreadyAssociatedWithWalletError,
+    SecondSignatureAlreadyRegisteredError,
+} from "../../errors";
 import { TransactionHandler, TransactionHandlerConstructor } from "../transaction";
 
 @Container.injectable()
@@ -66,6 +70,10 @@ export class SecondSignatureRegistrationTransactionHandler extends TransactionHa
 
         if (senderWallet.hasMultiSignature()) {
             throw new NotSupportedForMultiSignatureWalletError();
+        }
+
+        if (senderWallet.getPublicKey() === transaction.data.asset.signature.publicKey) {
+            throw new PublicKeyAlreadyAssociatedWithWalletError();
         }
 
         return super.throwIfCannotBeApplied(transaction, wallet);

--- a/packages/transactions/src/handlers/core/vote.ts
+++ b/packages/transactions/src/handlers/core/vote.ts
@@ -51,8 +51,9 @@ export class LegacyVoteTransactionHandler extends TransactionHandler {
                 const votingFor: string = Object.keys(walletVote)[0];
 
                 if (delegateVote.length === 66) {
-                    const delegateWallet: Contracts.State.Wallet = this.walletRepository.findByPublicKey(delegateVote);
-                    delegateVote = delegateWallet.getAttribute("delegate.username");
+                    delegateVote = this.walletRepository
+                        .findByPublicKey(delegateVote)
+                        .getAttribute("delegate.username");
                 }
 
                 if (vote.startsWith("+")) {
@@ -93,10 +94,9 @@ export class LegacyVoteTransactionHandler extends TransactionHandler {
 
         for (const vote of transaction.data.asset.votes) {
             let delegateVote: string = vote.slice(1);
-            let delegateWallet: Contracts.State.Wallet;
 
             if (delegateVote.length === 66) {
-                delegateWallet = this.walletRepository.findByPublicKey(delegateVote);
+                const delegateWallet: Contracts.State.Wallet = this.walletRepository.findByPublicKey(delegateVote);
 
                 if (!delegateWallet.isDelegate()) {
                     throw new VotedForNonDelegateError();
@@ -107,7 +107,6 @@ export class LegacyVoteTransactionHandler extends TransactionHandler {
                 if (!this.walletRepository.hasByUsername(delegateVote)) {
                     throw new VotedForNonDelegateError(delegateVote);
                 }
-                delegateWallet = this.walletRepository.findByUsername(delegateVote);
             }
 
             if (vote.startsWith("+")) {
@@ -137,8 +136,11 @@ export class LegacyVoteTransactionHandler extends TransactionHandler {
         for (let voteAsset of transaction.data.asset.votes) {
             const delegateVote: string = voteAsset.slice(1);
             if (delegateVote.length === 66) {
-                const delegateWallet: Contracts.State.Wallet = this.walletRepository.findByPublicKey(delegateVote);
-                voteAsset = voteAsset[0] + Object.keys(delegateWallet.getAttribute("delegate.username"))[0];
+                voteAsset =
+                    voteAsset[0] +
+                    Object.keys(
+                        this.walletRepository.findByPublicKey(delegateVote).getAttribute("delegate.username"),
+                    )[0];
             }
 
             if (voteAsset.startsWith("-")) {
@@ -183,13 +185,9 @@ export class LegacyVoteTransactionHandler extends TransactionHandler {
         let walletVote!: { [vote: string]: number };
 
         for (const vote of transaction.data.asset.votes) {
-            let delegateWallet: Contracts.State.Wallet;
             let delegateVote: string = vote.slice(1);
             if (delegateVote.length === 66) {
-                delegateWallet = this.walletRepository.findByPublicKey(delegateVote);
-                delegateVote = delegateWallet.getAttribute("delegate.username");
-            } else {
-                delegateWallet = this.walletRepository.findByUsername(delegateVote);
+                delegateVote = this.walletRepository.findByPublicKey(delegateVote).getAttribute("delegate.username");
             }
 
             if (vote.startsWith("+")) {
@@ -217,13 +215,9 @@ export class LegacyVoteTransactionHandler extends TransactionHandler {
         Utils.assert.defined<Interfaces.ITransactionAsset>(transaction.data.asset?.votes);
 
         for (const vote of transaction.data.asset.votes.slice().reverse()) {
-            let delegateWallet: Contracts.State.Wallet;
             let delegateVote: string = vote.slice(1);
             if (delegateVote.length === 66) {
-                delegateWallet = this.walletRepository.findByPublicKey(delegateVote);
-                delegateVote = delegateWallet.getAttribute("delegate.username");
-            } else {
-                delegateWallet = this.walletRepository.findByUsername(delegateVote);
+                delegateVote = this.walletRepository.findByPublicKey(delegateVote).getAttribute("delegate.username");
             }
 
             if (vote.startsWith("+")) {

--- a/packages/transactions/src/handlers/solar/vote.ts
+++ b/packages/transactions/src/handlers/solar/vote.ts
@@ -5,7 +5,6 @@ import {
     AlreadyVotedForSameDelegatesError,
     NoVoteError,
     VotedForNonDelegateError,
-    VotedForResignedDelegateError,
     VotedForTooManyDelegatesError,
 } from "../../errors";
 import { DelegateRegistrationTransactionHandler } from "../core/delegate-registration";
@@ -64,7 +63,7 @@ export class VoteTransactionHandler extends TransactionHandler {
     ): Promise<void> {
         AppUtils.assert.defined<string[]>(transaction.data.asset?.votes);
 
-        const { activeDelegates, canVoteForResignedDelegates } = Managers.configManager.getMilestone();
+        const { activeDelegates } = Managers.configManager.getMilestone();
         const votes = Object.keys(transaction.data.asset.votes);
 
         if (votes.length > activeDelegates) {
@@ -81,12 +80,6 @@ export class VoteTransactionHandler extends TransactionHandler {
         for (const delegate of votes) {
             if (!this.walletRepository.hasByUsername(delegate)) {
                 throw new VotedForNonDelegateError(delegate);
-            }
-
-            if (!canVoteForResignedDelegates) {
-                if (this.walletRepository.findByUsername(delegate).hasAttribute("delegate.resigned")) {
-                    throw new VotedForResignedDelegateError(delegate);
-                }
             }
         }
 

--- a/packages/transactions/src/handlers/transaction.ts
+++ b/packages/transactions/src/handlers/transaction.ts
@@ -217,6 +217,14 @@ export abstract class TransactionHandler {
         );
     }
 
+    public getWallet(address: string): Contracts.State.Wallet | undefined {
+        if (this.walletRepository.hasByAddress(address)) {
+            return this.walletRepository.findByAddress(address);
+        }
+
+        return undefined;
+    }
+
     protected async performGenericWalletChecks(
         transaction: Interfaces.ITransaction,
         sender: Contracts.State.Wallet,

--- a/packages/webhooks/package.json
+++ b/packages/webhooks/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/webhooks",
-    "version": "4.1.2-next.0",
+    "version": "4.1.2",
     "description": "Webhooks for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/webhooks/src/service-provider.ts
+++ b/packages/webhooks/src/service-provider.ts
@@ -27,8 +27,10 @@ export class ServiceProvider extends Providers.ServiceProvider {
 
         this.app.get<Server>(Identifiers.Server).register(this.config().get<Types.JsonObject>("server")!);
 
-        // Setup Listeners...
-        this.startListeners();
+        if (!!this.config().get("enabled")) {
+            // Setup Listeners...
+            this.startListeners();
+        }
     }
 
     /**

--- a/packages/webhooks/src/service-provider.ts
+++ b/packages/webhooks/src/service-provider.ts
@@ -27,7 +27,7 @@ export class ServiceProvider extends Providers.ServiceProvider {
 
         this.app.get<Server>(Identifiers.Server).register(this.config().get<Types.JsonObject>("server")!);
 
-        if (!!this.config().get("enabled")) {
+        if (this.config().get("enabled")) {
             // Setup Listeners...
             this.startListeners();
         }

--- a/plugins/sxp-swap/src/sxp-swap.ts
+++ b/plugins/sxp-swap/src/sxp-swap.ts
@@ -447,13 +447,14 @@ export class SXPSwap {
             }
         };
 
-        TransactionValidator.prototype.validate = async function (transaction: Interfaces.ITransaction): Promise<void> {
+        TransactionValidator.prototype.validate = async function (transaction: Interfaces.ITransaction): Promise<Interfaces.ITransaction> {
             const deserialised: Interfaces.ITransaction = Transactions.TransactionFactory.fromBytes(
                 transaction.serialised,
             );
             assert.strictEqual(transaction.id, deserialised.id);
-            const handler = await (this as any).handlerRegistry.getActivatedHandlerForData(transaction.data);
-            await handler.apply(transaction, "validate");
+            const handler = await (this as any).handlerRegistry.getActivatedHandlerForData(deserialised.data);
+            await handler.apply(deserialised, "validate");
+            return deserialised;
         };
 
         this.app.get<Services.Triggers.Triggers>(Container.Identifiers.TriggerService).unbind("applyTransaction");


### PR DESCRIPTION
This PR releases Solar Core 4.1.2 for mainnet.

Changes since 4.1.1:

### Bug Fixes
\- include legacy votes when getting previous vote
\- webhook listeners only activate when webhooks are enabled
\- ensure a wallet belongs to a registered delegate before adding delegate attributes
\- index cloned wallets if the blockchain wallet for the same address is indexed
### Maintenance
\- unnecessary variables have been removed and legacy upstream code has been removed
\- new method added to get pool wallet
\- multiple performance optimisations when handling transactions
\- transitional code has been removed and milestones have been updated
\- ensure the second public key is different to the wallet public key 
