### PR TITLE
release: mainnet 4.1.3

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/api",
-    "version": "4.1.2",
+    "version": "4.1.3",
     "description": "Public API for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/blockchain/package.json
+++ b/packages/blockchain/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/blockchain",
-    "version": "4.1.2",
+    "version": "4.1.3",
     "description": "Blockchain Manager for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/blockchain/src/blockchain.ts
+++ b/packages/blockchain/src/blockchain.ts
@@ -88,6 +88,8 @@ export class Blockchain implements Contracts.Blockchain.Blockchain {
         );
 
         this.queue.on("drain", async () => {
+            this.updateProductivity(false);
+            this.pool.readdTransactions(undefined, true);
             await stateSaver.run();
             this.dispatch("PROCESSFINISHED");
         });
@@ -160,8 +162,6 @@ export class Blockchain implements Contracts.Blockchain.Blockchain {
         this.events.listen(Enums.ForgerEvent.Missing, { handle: this.checkMissingBlocks });
 
         this.events.listen(Enums.RoundEvent.Applied, { handle: this.resetMissedBlocks });
-
-        this.events.listen(Enums.QueueEvent.Finished, { handle: () => this.updateProductivity(false) });
 
         this.updateProductivity(true);
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/cli",
-    "version": "4.1.2",
+    "version": "4.1.3",
     "description": "Command Line Interface to manage the Core of the Solar Network Blockchain",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core",
-    "version": "4.1.2",
+    "version": "4.1.3",
     "description": "Core of the Solar Network Blockchain",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/crypto",
-    "version": "4.1.2",
+    "version": "4.1.3",
     "description": "Crypto utilities for the Solar Network Blockchain",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/database",
-    "version": "4.1.2",
+    "version": "4.1.3",
     "description": "Database Interface for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/forger/package.json
+++ b/packages/forger/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/forger",
-    "version": "4.1.2",
+    "version": "4.1.3",
     "description": "Forger for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/kernel/package.json
+++ b/packages/kernel/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/kernel",
-    "version": "4.1.2",
+    "version": "4.1.3",
     "description": "Kernel of Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/kernel/src/contracts/pool/service.ts
+++ b/packages/kernel/src/contracts/pool/service.ts
@@ -7,7 +7,10 @@ export interface Service {
 
     addTransaction(transaction: Interfaces.ITransaction): Promise<void>;
     getPoolWallet(address: string): Wallet | undefined;
-    readdTransactions(previouslyForgedTransactions?: Interfaces.ITransaction[]): Promise<void>;
+    readdTransactions(
+        previouslyForgedTransactions?: Interfaces.ITransaction[],
+        recheckValidity?: boolean,
+    ): Promise<void>;
     removeTransaction(transaction: Interfaces.ITransaction): Promise<void>;
     removeForgedTransaction(transaction: Interfaces.ITransaction): Promise<void>;
     cleanUp(): Promise<void>;

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/logger",
-    "version": "4.1.2",
+    "version": "4.1.3",
     "description": "Webhooks for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/nes/package.json
+++ b/packages/nes/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/nes",
-    "version": "4.1.2",
+    "version": "4.1.3",
     "description": "Websocket client and server for Solar Core",
     "license": "BSD-3-Clause",
     "contributors": [

--- a/packages/p2p/package.json
+++ b/packages/p2p/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/p2p",
-    "version": "4.1.2",
+    "version": "4.1.3",
     "description": "P2P API for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/pool/package.json
+++ b/packages/pool/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/pool",
-    "version": "4.1.2",
+    "version": "4.1.3",
     "description": "Pool Manager for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/snapshots/package.json
+++ b/packages/snapshots/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/snapshots",
-    "version": "4.1.2",
+    "version": "4.1.3",
     "description": "Provides live local streamed snapshots functionality for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/state/package.json
+++ b/packages/state/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/state",
-    "version": "4.1.2",
+    "version": "4.1.3",
     "description": "State Management for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/transactions/package.json
+++ b/packages/transactions/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/transactions",
-    "version": "4.1.2",
+    "version": "4.1.3",
     "description": "Transaction Services for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/webhooks/package.json
+++ b/packages/webhooks/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/webhooks",
-    "version": "4.1.2",
+    "version": "4.1.3",
     "description": "Webhooks for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [


### PR DESCRIPTION
This PR releases Solar Core 4.1.3 for mainnet.

Changes since 4.1.2:

### Bug Fixes
\- listen to queue drain event for the block processing queue only rather than the global `QueueEvent.Finished` event