### PR TITLE
refactor: rename passphrase to mnemonic

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ bash install.sh
 
 Choose whether you want to run on `Mainnet` (which installs the latest stable release) or `Testnet` (which installs the latest development release) and then wait for the installation to complete.
 
-When it has finished, run `solar` to interact with the command-line interface. If you are a registered delegate, configure the node with your passphrase with `solar config:forger`. To start the relay, run `solar relay:start` and, if you are a delegate, also start the forger process with `solar forger:start`.
+When it has finished, run `solar` to interact with the command-line interface. If you are a registered delegate, configure the node with your mnemonic with `solar config:forger`. To start the relay, run `solar relay:start` and, if you are a delegate, also start the forger process with `solar forger:start`.
 
 You can check that everything is working correctly by reading the logs with `pm2 logs`.
 

--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -129,7 +129,7 @@ export class Server {
     public async boot(): Promise<void> {
         try {
             const swaggerJson = readJsonSync(`${__dirname}/www/api.json`);
-            const dummyAddress = Identities.Address.fromPassphrase("");
+            const dummyAddress = Identities.Address.fromMnemonic("");
             const networkCharacter = dummyAddress.slice(0, 1);
             swaggerJson.servers.push({ url: this.configuration.getRequired<string>("options.basePath") });
             swaggerJson.info.version = this.app.version();

--- a/packages/core/src/commands/config-forger-bip39.ts
+++ b/packages/core/src/commands/config-forger-bip39.ts
@@ -46,7 +46,7 @@ export class Command extends Commands.Command {
         this.definition
             .setFlag("token", "The name of the token", Joi.string().default("solar"))
             .setFlag("network", "The name of the network", Joi.string().valid(...Object.keys(Networks)))
-            .setFlag("bip39", "A delegate plain text passphrase, referred to as BIP39", Joi.string())
+            .setFlag("bip39", "A delegate plain text mnemonic, referred to as BIP39", Joi.string())
             .setFlag("skipValidation", "Skip BIP39 mnemonic validation", Joi.boolean().default(false));
     }
 
@@ -65,10 +65,10 @@ export class Command extends Commands.Command {
             {
                 type: "password",
                 name: "bip39",
-                message: "Please enter your delegate plain text passphrase. Referred to as BIP39",
+                message: "Please enter your delegate plain text mnemonic. Referred to as BIP39",
                 validate: (value: string) =>
                     !validateMnemonic(value) && !this.getFlag("skipValidation")
-                        ? `Failed to verify the given passphrase as BIP39 compliant`
+                        ? `Failed to verify the given mnemonic as BIP39 compliant`
                         : true,
             },
             {
@@ -92,20 +92,20 @@ export class Command extends Commands.Command {
     private async performConfiguration(flags: Contracts.AnyObject): Promise<void> {
         await this.components.taskList([
             {
-                title: "Validating passphrase is BIP39 compliant",
+                title: "Validating mnemonic is BIP39 compliant",
                 task: () => {
                     if (!flags.bip39 || (!validateMnemonic(flags.bip39) && !flags.skipValidation)) {
-                        throw new Error("Failed to verify the given passphrase as BIP39 compliant");
+                        throw new Error("Failed to verify the given mnemonic as BIP39 compliant");
                     }
                 },
             },
             {
-                title: "Writing BIP39 passphrase to configuration",
+                title: "Writing BIP39 mnemonic to configuration",
                 task: () => {
                     const delegatesConfig = this.app.getCorePath("config", "delegates.json");
 
                     const delegates: Record<string, string | string[]> = require(delegatesConfig);
-                    delegates.keys = [Identities.PrivateKey.fromPassphrase(flags.bip39)];
+                    delegates.keys = [Identities.PrivateKey.fromMnemonic(flags.bip39)];
 
                     writeJsonSync(delegatesConfig, delegates, { spaces: 4 });
                 },

--- a/packages/core/src/commands/config-forger.ts
+++ b/packages/core/src/commands/config-forger.ts
@@ -38,7 +38,7 @@ export class Command extends Commands.Command {
         this.definition
             .setFlag("token", "The name of the token", Joi.string().default("solar"))
             .setFlag("network", "The name of the network", Joi.string().valid(...Object.keys(Networks)))
-            .setFlag("bip39", "A delegate plain text passphrase, referred to as BIP39", Joi.string())
+            .setFlag("bip39", "A delegate plain text mnemonic, referred to as BIP39", Joi.string())
             .setFlag("privateKey", "A 64 character hexadecimal delegate private key", Joi.string().hex().length(64))
             .setFlag("skipValidation", "Skip BIP39 mnemonic validation", Joi.boolean().default(false))
             .setFlag(
@@ -70,7 +70,7 @@ export class Command extends Commands.Command {
                 message: "Please select how you wish to enter your delegate private key?",
                 choices: [
                     { title: "Hexadecimal private key", value: "privateKey" },
-                    { title: "BIP39 passphrase (Deprecated)", value: "bip39" },
+                    { title: "BIP39 mnemonic (Deprecated)", value: "bip39" },
                 ],
             },
         ]);

--- a/packages/core/src/commands/core-run.ts
+++ b/packages/core/src/commands/core-run.ts
@@ -2,7 +2,7 @@ import { Commands, Container, Contracts, Utils } from "@solar-network/cli";
 import { Networks } from "@solar-network/crypto";
 import Joi from "joi";
 
-import { checkForPassphrase } from "../internal/crypto";
+import { checkForPrivateKeys } from "../internal/crypto";
 
 /**
  * @export
@@ -56,7 +56,7 @@ export class Command extends Commands.Command {
         const flags: Contracts.AnyObject = { ...this.getFlags() };
         flags.processType = "core";
 
-        checkForPassphrase(this.app.getCorePath("config"));
+        checkForPrivateKeys(this.app.getCorePath("config"));
 
         await Utils.buildApplication({
             flags,

--- a/packages/core/src/commands/core-start.ts
+++ b/packages/core/src/commands/core-start.ts
@@ -3,7 +3,7 @@ import { Networks } from "@solar-network/crypto";
 import Joi from "joi";
 import { resolve } from "path";
 
-import { checkForPassphrase } from "../internal/crypto";
+import { checkForPrivateKeys } from "../internal/crypto";
 
 /**
  * @export
@@ -60,7 +60,7 @@ export class Command extends Commands.Command {
         this.actions.abortRunningProcess(`${flags.token}-forger`);
         this.actions.abortRunningProcess(`${flags.token}-relay`);
 
-        checkForPassphrase(this.app.getCorePath("config"));
+        checkForPrivateKeys(this.app.getCorePath("config"));
 
         await this.actions.daemoniseProcess(
             {

--- a/packages/core/src/commands/forger-run.ts
+++ b/packages/core/src/commands/forger-run.ts
@@ -2,7 +2,7 @@ import { Commands, Container, Contracts, Utils } from "@solar-network/cli";
 import { Networks } from "@solar-network/crypto";
 import Joi from "joi";
 
-import { checkForPassphrase } from "../internal/crypto";
+import { checkForPrivateKeys } from "../internal/crypto";
 
 /**
  * @export
@@ -51,7 +51,7 @@ export class Command extends Commands.Command {
         const flags: Contracts.AnyObject = { ...this.getFlags() };
         flags.processType = "forger";
 
-        checkForPassphrase(this.app.getCorePath("config"));
+        checkForPrivateKeys(this.app.getCorePath("config"));
 
         await Utils.buildApplication({
             flags,

--- a/packages/core/src/commands/forger-start.ts
+++ b/packages/core/src/commands/forger-start.ts
@@ -3,7 +3,7 @@ import { Networks } from "@solar-network/crypto";
 import Joi from "joi";
 import { resolve } from "path";
 
-import { checkForPassphrase } from "../internal/crypto";
+import { checkForPrivateKeys } from "../internal/crypto";
 
 /**
  * @export
@@ -58,7 +58,7 @@ export class Command extends Commands.Command {
         const flags: Contracts.AnyObject = { ...this.getFlags() };
         this.actions.abortRunningProcess(`${flags.token}-core`);
 
-        checkForPassphrase(this.app.getCorePath("config"));
+        checkForPrivateKeys(this.app.getCorePath("config"));
 
         await this.actions.daemoniseProcess(
             {

--- a/packages/core/src/internal/crypto.ts
+++ b/packages/core/src/internal/crypto.ts
@@ -3,7 +3,7 @@ import { join } from "path";
 
 import { KeysNotDetected, MissingConfigFile } from "../exceptions/crypto";
 
-export const checkForPassphrase = (config?: string): void => {
+export const checkForPrivateKeys = (config?: string): void => {
     if (!config && process.env.CORE_PATH_CONFIG) {
         config = process.env.CORE_PATH_CONFIG;
     }

--- a/packages/crypto/src/crypto/hdwallet.ts
+++ b/packages/crypto/src/crypto/hdwallet.ts
@@ -8,13 +8,13 @@ import { configManager } from "../managers";
 
 export class HDWallet {
     /**
-     * Get root node from the given mnemonic with an optional passphrase.
+     * Get root node from the given mnemonic.
      */
-    public static fromMnemonic(mnemonic: string, account: number, slip44?: number, passphrase?: string): HDKey {
+    public static fromMnemonic(mnemonic: string, account: number, slip44?: number): HDKey {
         if (slip44 === undefined) {
             slip44 = configManager.get("network.slip44");
         }
-        return HDKey.fromMasterSeed(mnemonicToSeedSync(mnemonic, passphrase)).derive(`m/44'/${slip44}'/${account}'/0`);
+        return HDKey.fromMasterSeed(mnemonicToSeedSync(mnemonic)).derive(`m/44'/${slip44}'/${account}'/0`);
     }
 
     /**

--- a/packages/crypto/src/crypto/message.ts
+++ b/packages/crypto/src/crypto/message.ts
@@ -6,8 +6,8 @@ import { Hash } from "./hash";
 import { HashAlgorithms } from "./hash-algorithms";
 
 export class Message {
-    public static sign(message: string, passphrase: string): IMessage {
-        const keys: IKeyPair = Keys.fromPassphrase(passphrase);
+    public static sign(message: string, mnemonic: string): IMessage {
+        const keys: IKeyPair = Keys.fromMnemonic(mnemonic);
 
         return {
             publicKey: keys.publicKey.secp256k1,

--- a/packages/crypto/src/identities/address.ts
+++ b/packages/crypto/src/identities/address.ts
@@ -6,8 +6,8 @@ import { Base58 } from "../utils";
 import { PublicKey } from "./public-key";
 
 export class Address {
-    public static fromPassphrase(passphrase: string, networkVersion?: number): string {
-        return Address.fromPublicKey(PublicKey.fromPassphrase(passphrase), networkVersion);
+    public static fromMnemonic(mnemonic: string, networkVersion?: number): string {
+        return Address.fromPublicKey(PublicKey.fromMnemonic(mnemonic), networkVersion);
     }
 
     public static fromPublicKey(publicKey: string, networkVersion?: number): string {

--- a/packages/crypto/src/identities/keys.ts
+++ b/packages/crypto/src/identities/keys.ts
@@ -9,8 +9,8 @@ import { Network } from "../interfaces/networks";
 import { configManager } from "../managers";
 
 export class Keys {
-    public static fromPassphrase(passphrase: string, compressed = true): IKeyPair {
-        return Keys.fromPrivateKey(HashAlgorithms.sha256(Buffer.from(passphrase, "utf8")), compressed);
+    public static fromMnemonic(mnemonic: string, compressed = true): IKeyPair {
+        return Keys.fromPrivateKey(HashAlgorithms.sha256(Buffer.from(mnemonic, "utf8")), compressed);
     }
 
     public static fromPrivateKey(privateKey: Buffer | string, compressed = true): IKeyPair {

--- a/packages/crypto/src/identities/private-key.ts
+++ b/packages/crypto/src/identities/private-key.ts
@@ -2,8 +2,8 @@ import { NetworkType } from "../types";
 import { Keys } from "./keys";
 
 export class PrivateKey {
-    public static fromPassphrase(passphrase: string): string {
-        return Keys.fromPassphrase(passphrase).privateKey;
+    public static fromMnemonic(mnemonic: string): string {
+        return Keys.fromMnemonic(mnemonic).privateKey;
     }
 
     public static fromWIF(wif: string, network?: NetworkType): string {

--- a/packages/crypto/src/identities/public-key.ts
+++ b/packages/crypto/src/identities/public-key.ts
@@ -4,8 +4,8 @@ import { NetworkType } from "../types";
 import { Keys } from "./keys";
 
 export class PublicKey {
-    public static fromPassphrase(passphrase: string): string {
-        return Keys.fromPassphrase(passphrase).publicKey.secp256k1;
+    public static fromMnemonic(mnemonic: string): string {
+        return Keys.fromMnemonic(mnemonic).publicKey.secp256k1;
     }
 
     public static fromWIF(wif: string, network?: NetworkType): string {

--- a/packages/crypto/src/identities/wif.ts
+++ b/packages/crypto/src/identities/wif.ts
@@ -6,8 +6,8 @@ import { configManager } from "../managers";
 import { Keys } from "./keys";
 
 export class WIF {
-    public static fromPassphrase(passphrase: string, network?: Network): string {
-        const keys: IKeyPair = Keys.fromPassphrase(passphrase);
+    public static fromMnemonic(mnemonic: string, network?: Network): string {
+        const keys: IKeyPair = Keys.fromMnemonic(mnemonic);
 
         if (!network) {
             network = configManager.get("network");

--- a/packages/crypto/src/transactions/builders/transactions/core/extra-signature.ts
+++ b/packages/crypto/src/transactions/builders/transactions/core/extra-signature.ts
@@ -13,9 +13,9 @@ export class ExtraSignatureBuilder extends TransactionBuilder<ExtraSignatureBuil
         this.data.asset = { signature: {} } as ITransactionAsset;
     }
 
-    public signatureAsset(extraPassphrase: string): ExtraSignatureBuilder {
+    public signatureAsset(extraMnemonic: string): ExtraSignatureBuilder {
         if (this.data.asset && this.data.asset.signature) {
-            this.data.asset.signature.publicKey = Keys.fromPassphrase(extraPassphrase).publicKey.secp256k1;
+            this.data.asset.signature.publicKey = Keys.fromMnemonic(extraMnemonic).publicKey.secp256k1;
         }
 
         return this;

--- a/packages/crypto/src/transactions/builders/transactions/transaction.ts
+++ b/packages/crypto/src/transactions/builders/transactions/transaction.ts
@@ -96,8 +96,8 @@ export abstract class TransactionBuilder<TBuilder extends TransactionBuilder<TBu
         return this.memo(memo);
     }
 
-    public sign(passphrase: string): TBuilder {
-        const keys: IKeyPair = Keys.fromPassphrase(passphrase);
+    public sign(mnemonic: string): TBuilder {
+        const keys: IKeyPair = Keys.fromMnemonic(mnemonic);
         return this.signWithKeyPair(keys);
     }
 
@@ -109,8 +109,8 @@ export abstract class TransactionBuilder<TBuilder extends TransactionBuilder<TBu
         return this.signWithKeyPair(keys);
     }
 
-    public extraSign(passphrase: string): TBuilder {
-        return this.extraSignWithKeyPair(Keys.fromPassphrase(passphrase));
+    public extraSign(mnemonic: string): TBuilder {
+        return this.extraSignWithKeyPair(Keys.fromMnemonic(mnemonic));
     }
 
     public extraSignWithWif(wif: string, networkWif?: number): TBuilder {

--- a/packages/kernel/src/services/config/drivers/local.ts
+++ b/packages/kernel/src/services/config/drivers/local.ts
@@ -177,7 +177,7 @@ export class LocalConfigLoader implements ConfigLoader {
         const secrets: Set<string> = new Set(delegates.secrets || []);
 
         for (const secret of secrets) {
-            keys.add(Identities.PrivateKey.fromPassphrase(secret));
+            keys.add(Identities.PrivateKey.fromMnemonic(secret));
         }
 
         if (delegates.secrets || secrets.size > 0) {


### PR DESCRIPTION
Until now, Core has referred to seed phrases as "passphrases", since that is how upstream does it. This PR changes that to use the more industry standard "mnemonic" term instead, since "passphrase" has a different meaning in the wider crypto space.