### PR TITLE
refactor: logging performance and cleanup

### DIFF
--- a/packages/blockchain/src/blockchain.ts
+++ b/packages/blockchain/src/blockchain.ts
@@ -373,7 +373,7 @@ export class Blockchain implements Contracts.Blockchain.Blockchain {
 
                 const lastBlock: Interfaces.IBlock = this.stateStore.getLastBlock();
 
-                this.logger.info(`Undoing block ${lastBlock.data.height.toLocaleString()}`, "🗑️");
+                this.logger.info(`Undoing block ${lastBlock.data.height.toLocaleString()}`, "🧹");
 
                 await revertLastBlock();
                 await __removeBlocks(numberOfBlocks - 1);
@@ -573,7 +573,7 @@ export class Blockchain implements Contracts.Blockchain.Blockchain {
                 this.stateStore.setLastDownloadedBlock(lastStoredBlock.data);
 
                 this.stateStore.setNumberOfBlocksToRollback(0);
-                this.logger.info(`Removed ${Utils.pluralise("block", rollbackBlocks, true)}`, "🗑️");
+                this.logger.info(`Removed ${Utils.pluralise("block", rollbackBlocks, true)}`, "🧹");
 
                 await this.roundState.restore();
 

--- a/packages/blockchain/src/state-machine/actions/start-fork-recovery.ts
+++ b/packages/blockchain/src/state-machine/actions/start-fork-recovery.ts
@@ -46,7 +46,7 @@ export class StartForkRecovery implements Action {
             this.stateStore.setLastDownloadedBlock(lastStoredBlock.data);
 
             this.stateStore.setNumberOfBlocksToRollback(0);
-            this.logger.info(`Removed ${AppUtils.pluralise("block", blocksToRemove, true)}`, "🗑️");
+            this.logger.info(`Removed ${AppUtils.pluralise("block", blocksToRemove, true)}`, "🧹");
 
             await this.roundState.restore();
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -26,6 +26,7 @@
         "boxen": "5.1.2",
         "cli-table3": "0.6.0",
         "colorette": "2.0.19",
+        "dateformat": "4.5.1",
         "dayjs": "1.10.7",
         "delay": "5.0.0",
         "env-paths": "2.2.1",

--- a/packages/cli/src/action-factory.ts
+++ b/packages/cli/src/action-factory.ts
@@ -83,13 +83,15 @@ export class ActionFactory {
     }
 
     /**
+     * @param {string} token
+     * @param {string} network
      * @param {string[]} processNames
      * @param {number} lines
      * @returns {void}
      * @memberof ActionFactory
      */
-    public logProcesses(processNames: string[], lines: number): Promise<void> {
-        return this.app.get<LogProcess>(Identifiers.LogProcess).execute(processNames, lines);
+    public logProcesses(token: string, network: string, processNames: string[], lines: number): Promise<void> {
+        return this.app.get<LogProcess>(Identifiers.LogProcess).execute(token, network, processNames, lines);
     }
 
     /**

--- a/packages/cli/src/actions/log-process.ts
+++ b/packages/cli/src/actions/log-process.ts
@@ -1,22 +1,48 @@
-import { createColors } from "colorette";
+import { Services, Utils } from "@solar-network/kernel";
+import { bold, cyan, gray, magenta } from "colorette";
+import dateformat from "dateformat";
+import { parseFileSync } from "envfile";
 import { existsSync, readFileSync, statSync } from "fs";
-import { homedir } from "os";
+import { join } from "path";
 import { Tail } from "tail";
 
-import { injectable } from "../ioc";
-
-const { bold, gray, magenta, red } = createColors({ useColor: true });
+import { Application } from "../application";
+import { Identifiers, inject, injectable } from "../ioc";
+import { Environment } from "../services";
 
 @injectable()
 export class LogProcess {
+    @inject(Identifiers.Application)
+    private readonly app!: Application;
+
+    @inject(Identifiers.Environment)
+    private readonly environment!: Environment;
+
+    private levels: Record<string, number> = {};
+
+    private logLevel: number = this.levels["debug"];
+
     /**
      * @param {string[]} processes
      * @param {number} lines
      * @returns {Promise<void>}
      * @memberof Log
      */
-    public async execute(processes: string[], lines: number): Promise<void> {
-        const logPath: string = `${homedir()}/.pm2/logs`;
+    public async execute(token: string, network: string, processes: string[], lines: number): Promise<void> {
+        for (const [key, value] of Object.entries(Services.Log.LogLevel)) {
+            if (!isNaN(+value)) {
+                this.levels[key.toLowerCase()] = +value;
+            }
+        }
+
+        try {
+            const env: Record<string, string> = parseFileSync(this.app.getCorePath("config", ".env"));
+            this.logLevel = this.levels[env.CORE_LOG_LEVEL] ?? this.logLevel;
+        } catch {
+            //
+        }
+
+        const logPath: string = join(this.environment.getPaths(token, network).log);
         if (!existsSync(logPath) || !statSync(logPath).isDirectory()) {
             throw new Error(`The ${logPath} directory is not valid`);
         }
@@ -24,26 +50,7 @@ export class LogProcess {
         const tails: Record<string, Tail>[] = [];
 
         for (const proc of processes) {
-            const errFile = `${logPath}/${proc}-error.log`;
-            const outFile = `${logPath}/${proc}-out.log`;
-            if (existsSync(errFile) && statSync(errFile).isFile()) {
-                const lastLines = this.readLastLines(proc, errFile, lines);
-                if (lastLines) {
-                    console.error(
-                        gray(
-                            `Showing the last ${lines} lines of the ${bold(
-                                proc,
-                            )} error log (change the number of lines with the --lines option):`,
-                        ),
-                    );
-                    console.error();
-                    console.error(red(lastLines));
-                    console.error();
-                }
-
-                tails.push({ process: proc, tail: new Tail(errFile) });
-            }
-
+            const outFile = `${logPath}/${token}-${network}-${proc}-current.log`;
             if (existsSync(outFile) && statSync(outFile).isFile()) {
                 const lastLines = this.readLastLines(proc, outFile, lines);
                 if (lastLines) {
@@ -69,17 +76,34 @@ export class LogProcess {
 
             for (const { process, tail } of tails) {
                 tail.on("line", (line: string) => {
-                    console.error(this.addProcessName(process, line));
+                    const output: string | undefined = this.parse(line);
+                    if (output) {
+                        console.error(this.addProcessName(process, output));
+                    }
                 });
                 tail.watch();
             }
         } else {
-            throw new Error("No log files were found");
+            throw new Error(`No ${processes.join(", ")} log files were found in ${logPath}`);
         }
     }
 
     private addProcessName(process: string, line: string): string {
         return `${magenta(process.padEnd(9))}${line}`;
+    }
+
+    private parse(line: string): string | undefined {
+        const { emoji, level, message, time } = JSON.parse(line);
+
+        if (this.levels[level] > this.logLevel) {
+            return;
+        }
+
+        const colour = Utils.logColour(level);
+
+        return `${cyan(dateformat(new Date(time), "yyyy-mm-dd HH:MM:ss.l"))} ${colour(
+            `[${level.toUpperCase().slice(0, 1)}]`,
+        )} ${emoji}\t${colour(message)}`;
     }
 
     private readLastLines(process: string, file: string, lines: number): string {
@@ -89,7 +113,14 @@ export class LogProcess {
                 .split("\n")
                 .slice(lines * -1 - 1)
                 .filter((line) => line.length > 0)
-                .map((line) => this.addProcessName(process, line))
+                .map((line) => {
+                    const output: string | undefined = this.parse(line);
+                    if (output) {
+                        return this.addProcessName(process, output);
+                    }
+                    return undefined;
+                })
+                .filter((line) => line)
                 .join("\n")
                 .trim();
         } catch {

--- a/packages/core/src/commands/all-log.ts
+++ b/packages/core/src/commands/all-log.ts
@@ -1,4 +1,5 @@
 import { Commands, Container } from "@solar-network/cli";
+import { Networks } from "@solar-network/crypto";
 import Joi from "joi";
 
 /**
@@ -41,6 +42,7 @@ export class Command extends Commands.Command {
     public configure(): void {
         this.definition
             .setFlag("token", "The name of the token", Joi.string().default("solar"))
+            .setFlag("network", "The name of the network", Joi.string().valid(...Object.keys(Networks)))
             .setFlag("lines", "The number of lines to output", Joi.number().default(15));
     }
 
@@ -53,6 +55,11 @@ export class Command extends Commands.Command {
     public async execute(): Promise<void> {
         await this.app
             .get<any>(Container.Identifiers.LogProcess)
-            .execute(["core", "forger", "relay"], this.getFlag("lines"));
+            .execute(
+                this.getFlag("token"),
+                this.getFlag("network"),
+                ["core", "forger", "relay"],
+                this.getFlag("lines"),
+            );
     }
 }

--- a/packages/core/src/commands/core-log.ts
+++ b/packages/core/src/commands/core-log.ts
@@ -1,4 +1,5 @@
 import { Commands, Container } from "@solar-network/cli";
+import { Networks } from "@solar-network/crypto";
 import Joi from "joi";
 
 /**
@@ -41,6 +42,7 @@ export class Command extends Commands.Command {
     public configure(): void {
         this.definition
             .setFlag("token", "The name of the token", Joi.string().default("solar"))
+            .setFlag("network", "The name of the network", Joi.string().valid(...Object.keys(Networks)))
             .setFlag("lines", "The number of lines to output", Joi.number().default(15));
     }
 
@@ -51,6 +53,8 @@ export class Command extends Commands.Command {
      * @memberof Command
      */
     public async execute(): Promise<void> {
-        await this.app.get<any>(Container.Identifiers.LogProcess).execute(["core"], this.getFlag("lines"));
+        await this.app
+            .get<any>(Container.Identifiers.LogProcess)
+            .execute(this.getFlag("token"), this.getFlag("network"), ["core"], this.getFlag("lines"));
     }
 }

--- a/packages/core/src/commands/forger-log.ts
+++ b/packages/core/src/commands/forger-log.ts
@@ -1,4 +1,5 @@
 import { Commands, Container } from "@solar-network/cli";
+import { Networks } from "@solar-network/crypto";
 import Joi from "joi";
 
 /**
@@ -41,6 +42,7 @@ export class Command extends Commands.Command {
     public configure(): void {
         this.definition
             .setFlag("token", "The name of the token", Joi.string().default("solar"))
+            .setFlag("network", "The name of the network", Joi.string().valid(...Object.keys(Networks)))
             .setFlag("lines", "The number of lines to output", Joi.number().default(15));
     }
 
@@ -51,6 +53,8 @@ export class Command extends Commands.Command {
      * @memberof Command
      */
     public async execute(): Promise<void> {
-        await this.app.get<any>(Container.Identifiers.LogProcess).execute(["forger"], this.getFlag("lines"));
+        await this.app
+            .get<any>(Container.Identifiers.LogProcess)
+            .execute(this.getFlag("token"), this.getFlag("network"), ["forger"], this.getFlag("lines"));
     }
 }

--- a/packages/core/src/commands/relay-log.ts
+++ b/packages/core/src/commands/relay-log.ts
@@ -1,4 +1,5 @@
 import { Commands, Container } from "@solar-network/cli";
+import { Networks } from "@solar-network/crypto";
 import Joi from "joi";
 
 /**
@@ -41,6 +42,7 @@ export class Command extends Commands.Command {
     public configure(): void {
         this.definition
             .setFlag("token", "The name of the token", Joi.string().default("solar"))
+            .setFlag("network", "The name of the network", Joi.string().valid(...Object.keys(Networks)))
             .setFlag("lines", "The number of lines to output", Joi.number().default(15));
     }
 
@@ -51,6 +53,8 @@ export class Command extends Commands.Command {
      * @memberof Command
      */
     public async execute(): Promise<void> {
-        await this.app.get<any>(Container.Identifiers.LogProcess).execute(["relay"], this.getFlag("lines"));
+        await this.app
+            .get<any>(Container.Identifiers.LogProcess)
+            .execute(this.getFlag("token"), this.getFlag("network"), ["relay"], this.getFlag("lines"));
     }
 }

--- a/packages/database/src/repositories/block-repository.ts
+++ b/packages/database/src/repositories/block-repository.ts
@@ -300,7 +300,7 @@ export class BlockRepository extends AbstractRepository<Block> {
 
             app.get<Contracts.Kernel.Logger>(Container.Identifiers.LogService).info(
                 `Removing the latest ${Utils.pluralise("block", blockIdRows.length, true)}`,
-                "🗑️",
+                "🧹",
             );
 
             await manager

--- a/packages/database/src/service-provider.ts
+++ b/packages/database/src/service-provider.ts
@@ -22,8 +22,6 @@ export class ServiceProvider extends Providers.ServiceProvider {
     public async register(): Promise<void> {
         this.logger = this.app.get(Container.Identifiers.LogService);
 
-        this.logger.info(`Connecting to database: ${(this.config().all().connection as any).database}`, "⏳");
-
         this.app.bind(Container.Identifiers.DatabaseConnection).toConstantValue(await this.connect());
 
         this.app.bind(Container.Identifiers.DatabaseRoundRepository).toConstantValue(this.getRoundRepository());

--- a/packages/forger/src/forger-service.ts
+++ b/packages/forger/src/forger-service.ts
@@ -377,13 +377,9 @@ export class ForgerService {
                     } else if (timeLeftInMs > 0) {
                         this.logger.warning(
                             `Failed to forge new block by ${prettyName}, because there were ${timeLeftInMs}ms left in the current slot (less than ${minimumMs}ms)`,
-                            "❗",
                         );
                     } else {
-                        this.logger.warning(
-                            `Failed to forge new block by ${prettyName}, because already in next slot`,
-                            "❗",
-                        );
+                        this.logger.warning(`Failed to forge new block by ${prettyName}, because already in next slot`);
                     }
                 }
             } catch (error) {
@@ -431,7 +427,7 @@ export class ForgerService {
         this.logger.debug(
             `Received ${AppUtils.pluralise("transaction", transactions.length, true)} ` +
                 `from the pool containing ${AppUtils.pluralise("transaction", response.poolSize, true)}`,
-            "👛",
+            "🪣",
         );
         return transactions;
     }

--- a/packages/kernel/package.json
+++ b/packages/kernel/package.json
@@ -23,6 +23,7 @@
         "@hapi/bourne": "2.0.0",
         "@pm2/io": "5.0.0",
         "@solar-network/crypto": "workspace:*",
+        "colorette": "2.0.19",
         "cron": "1.8.2",
         "dayjs": "1.10.7",
         "deepmerge": "4.2.2",

--- a/packages/kernel/src/contracts/kernel/log.ts
+++ b/packages/kernel/src/contracts/kernel/log.ts
@@ -9,30 +9,29 @@ export interface Logger {
     /**
      * Create a new instance of the logger.
      *
-     * @param {*} [options]
      * @returns {Promise<Logger>}
      * @memberof Logger
      */
-    make(options?: any): Promise<Logger>;
+    make(): Promise<Logger>;
 
     /**
      * Critical conditions.
      *
      * Example: Application component unavailable, unexpected exception.
      *
-     * @param {*} message
+     * @param {object | string | undefined} message
      * @memberof Logger
      */
-    critical(message: any, emoji?: string): void;
+    critical(message: object | string | undefined, emoji?: string): void;
 
     /**
      * Runtime errors that do not require immediate action but should typically
      * be logged and monitored.
      *
-     * @param {*} message
+     * @param {object | string | undefined} message
      * @memberof Logger
      */
-    error(message: any, emoji?: string): void;
+    error(message: object | string | undefined, emoji?: string): void;
 
     /**
      * Exceptional occurrences that are not errors.
@@ -40,54 +39,34 @@ export interface Logger {
      * Example: Use of deprecated APIs, poor use of an API, undesirable things
      * that are not necessarily wrong.
      *
-     * @param {*} message
+     * @param {object | string | undefined} message
      * @memberof Logger
      */
-    warning(message: any, emoji?: string): void;
+    warning(message: object | string | undefined, emoji?: string): void;
 
     /**
      * Interesting events.
      *
      * Example: User logs in, SQL logs.
      *
-     * @param {*} message
+     * @param {object | string | undefined} message
      * @memberof Logger
      */
-    info(message: any, emoji?: string): void;
+    info(message: object | string | undefined, emoji?: string): void;
 
     /**
      * Detailed debug information.
      *
-     * @param {*} message
+     * @param {object | string | undefined} message
      * @memberof Logger
      */
-    debug(message: any, emoji?: string): void;
+    debug(message: object | string | undefined, emoji?: string): void;
 
     /**
      * Detailed trace information.
      *
-     * @param {*} message
+     * @param {object | string | undefined} message
      * @memberof Logger
      */
-    trace(message: any, emoji?: string): void;
-
-    /**
-     * @param {boolean} suppress
-     * @memberof Logger
-     */
-    suppressConsoleOutput(suppress: boolean): void;
-
-    /**
-     * Dispose logger.
-     *
-     * @returns {Promise<void>}
-     * @memberof Logger
-     */
-    dispose(): Promise<void>;
-
-    // /**
-    //  * @param {Record<string,string>} levels
-    //  * @memberof Logger
-    //  */
-    // setLevels(levels: Record<string, string>): void;
+    trace(message: object | string | undefined, emoji?: string): void;
 }

--- a/packages/kernel/src/services/log/enums.ts
+++ b/packages/kernel/src/services/log/enums.ts
@@ -1,17 +1,12 @@
-/**
- * @remarks
- * Log levels as defined by {@link https://tools.ietf.org/html/rfc5424 | RFC 5424}
- *
+/*
  * @export
  * @enum {number}
  */
 export enum LogLevel {
-    Emergency = 0,
-    Alert = 1,
-    Critical = 2,
-    Error = 3,
-    Warning = 4,
-    Notice = 5,
-    Informational = 6,
-    Debug = 7,
+    Critical = 0,
+    Error = 1,
+    Warning = 2,
+    Info = 3,
+    Debug = 4,
+    Trace = 5,
 }

--- a/packages/kernel/src/services/queue/drivers/memory.ts
+++ b/packages/kernel/src/services/queue/drivers/memory.ts
@@ -2,7 +2,6 @@ import { EventEmitter } from "events";
 import { performance } from "perf_hooks";
 
 import { EventDispatcher } from "../../../contracts/kernel/events";
-import { Logger } from "../../../contracts/kernel/log";
 import { Queue, QueueJob } from "../../../contracts/kernel/queue";
 import { QueueEvent } from "../../../enums";
 import { decorateInjectable, Identifiers, inject, injectable } from "../../../ioc";
@@ -18,9 +17,6 @@ decorateInjectable(EventEmitter);
 export class MemoryQueue extends EventEmitter implements Queue {
     @inject(Identifiers.EventDispatcherService)
     private readonly events!: EventDispatcher;
-
-    @inject(Identifiers.LogService)
-    private readonly logger!: Logger;
 
     /**
      * @private
@@ -227,8 +223,6 @@ export class MemoryQueue extends EventEmitter implements Queue {
                     executionTime: performance.now() - start,
                     error: error,
                 });
-
-                this.logger.warning(`Queue error occurs when handling job: ${job}`);
 
                 this.emit("jobError", job, error);
             }

--- a/packages/kernel/src/utils/index.ts
+++ b/packages/kernel/src/utils/index.ts
@@ -136,6 +136,7 @@ export * from "./last-map-entry";
 export * from "./last-map-key";
 export * from "./last-map-value";
 export * from "./last";
+export * from "./log-colour";
 export * from "./lower-case";
 export * from "./lower-first";
 export * from "./map-array";

--- a/packages/kernel/src/utils/log-colour.ts
+++ b/packages/kernel/src/utils/log-colour.ts
@@ -1,0 +1,20 @@
+import { bgRed, blue, gray, green, red, reset, white, yellow } from "colorette";
+export const logColour = (level: string): Function => {
+    switch (level) {
+        case "info":
+            return green;
+        case "debug":
+            return blue;
+        case "trace":
+            return gray;
+        case "warning":
+            return yellow;
+        case "error":
+            return red;
+        case "critical":
+            return (output: string | number) => {
+                return bgRed(white(output));
+            };
+    }
+    return reset;
+};

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -19,19 +19,11 @@
     },
     "dependencies": {
         "@solar-network/kernel": "workspace:*",
-        "colorette": "2.0.19",
-        "joi": "17.6.0",
         "pino": "8.5.0",
-        "pino-pretty": "9.1.0",
         "pump": "3.0.0",
-        "readable-stream": "3.6.0",
-        "rotating-file-stream": "2.1.5",
         "split2": "3.2.2"
     },
     "devDependencies": {
-        "@types/pino": "7.0.5",
-        "@types/pump": "1.1.1",
-        "@types/readable-stream": "2.3.11",
-        "@types/split2": "2.1.6"
+        "@types/pino": "7.0.5"
     }
 }

--- a/packages/logger/src/defaults.ts
+++ b/packages/logger/src/defaults.ts
@@ -1,6 +1,0 @@
-export const defaults = {
-    logLevel: process.env.CORE_LOG_LEVEL || "debug",
-    fileRotator: {
-        interval: "1d",
-    },
-};

--- a/packages/logger/src/driver.ts
+++ b/packages/logger/src/driver.ts
@@ -1,257 +1,141 @@
-import { Container, Contracts, Utils } from "@solar-network/kernel";
-import { createColors } from "colorette";
-import * as console from "console";
+import { Container, Contracts, Services, Utils } from "@solar-network/kernel";
 import pino from "pino";
-import { prettyFactory } from "pino-pretty";
 import pump from "pump";
-import { createStream } from "rotating-file-stream";
 import split from "split2";
-import { PassThrough, Transform, Writable } from "stream";
+import { PassThrough, Transform } from "stream";
 import { inspect } from "util";
-const { bgRed, blue, cyan, gray, green, red, white, yellow } = createColors({ useColor: true });
 
-/**
- * @export
- * @class PinoLogger
- * @implements {Contracts.Kernel.Logger}
- */
 @Container.injectable()
 export class PinoLogger implements Contracts.Kernel.Logger {
-    /**
-     * @private
-     * @type {Contracts.Kernel.Application}
-     * @memberof PinoLogger
-     */
     @Container.inject(Container.Identifiers.Application)
     private readonly app!: Contracts.Kernel.Application;
 
     @Container.inject(Container.Identifiers.ConfigFlags)
     private readonly configFlags!: { processType: string };
 
-    /**
-     * @private
-     * @type {PassThrough}
-     * @memberof PinoLogger
-     */
-    private stream!: PassThrough;
-
-    /**
-     * @private
-     * @type {Writable}
-     * @memberof PinoLogger
-     */
-    private combinedFileStream?: Writable;
-
-    /**
-     * @private
-     * @type {pino.Logger}
-     * @memberof PinoLogger
-     */
     private logger!: pino.Logger;
 
-    /**
-     * @private
-     * @type {boolean}
-     * @memberof PinoLogger
-     */
-    private silentConsole: boolean = false;
+    public async make(): Promise<Contracts.Kernel.Logger> {
+        let stream: PassThrough | undefined;
+        let transport: pino.TransportSingleOptions<Record<string, any>> | undefined;
+        if (["core", "forger", "relay"].includes(this.configFlags.processType)) {
+            transport = {
+                target: "pino/file",
+                options: {
+                    destination: `${this.app.logPath()}/${this.app.namespace()}-${
+                        this.configFlags.processType
+                    }-current.log`,
+                },
+            };
+        } else {
+            stream = new PassThrough();
+        }
 
-    /**
-     * @param {*} options
-     * @returns {Promise<Contracts.Kernel.Logger>}
-     * @memberof PinoLogger
-     */
-    public async make(options?: any): Promise<Contracts.Kernel.Logger> {
-        this.stream = new PassThrough();
+        const customLevels: Record<string, number> = {};
+        for (const [key, value] of Object.entries(Services.Log.LogLevel)) {
+            if (!isNaN(+value)) {
+                customLevels[key.toLowerCase()] = +value;
+            }
+        }
+
         this.logger = pino(
             {
                 base: undefined,
-                customLevels: {
-                    critical: 0,
-                    error: 1,
-                    warning: 2,
-                    info: 3,
-                    debug: 4,
-                    trace: 5,
-                },
+                customLevels,
                 level: "critical",
                 formatters: {
                     level(level) {
                         return { level };
                     },
                 },
+                transport,
                 useOnlyCustomLevels: true,
             },
-            this.stream,
+            stream!,
         );
 
-        if (this.isValidLevel(options.logLevel)) {
-            const prettyPinoFactory = prettyFactory({
-                translateTime: "yyyy-mm-dd HH:MM:ss.l",
-                include: "level,time",
-                messageFormat: (log) => {
-                    let colour!: Function;
-                    let emoji: string = log.emoji as string;
-
-                    const level: string = log.level as string;
-
-                    switch (level) {
-                        case "info":
-                            colour = green;
-                            if (!emoji) {
-                                emoji = "ℹ️";
-                            }
-                            break;
-                        case "debug":
-                            colour = blue;
-                            if (!emoji) {
-                                emoji = "🐛";
-                            }
-                            break;
-                        case "trace":
-                            colour = gray;
-                            if (!emoji) {
-                                emoji = "📌";
-                            }
-                            break;
-                        case "warning":
-                            colour = yellow;
-                            if (!emoji) {
-                                emoji = "⚠️";
-                            }
-                            break;
-                        case "error":
-                            colour = red;
-                            if (!emoji) {
-                                emoji = "🛑";
-                            }
-                            break;
-                        case "critical":
-                            colour = (output: string | number) => {
-                                return bgRed(white(output));
-                            };
-                            if (!emoji) {
-                                emoji = "🚨";
-                            }
-                            break;
-                    }
-                    return `\b\b ${colour(`[${level.toUpperCase().slice(0, 1)}]`)} ${emoji}\t${colour(log.msg)}`;
-                },
-                customPrettifiers: {
-                    level: (): string => "",
-                    time: (timestamp): string => cyan(timestamp as string),
-                },
+        if (stream) {
+            pump(stream, split(), this.createPrettyTransport(), process.stdout, (err) => {
+                console.error("Output stream closed due to an error:", err);
             });
-
-            pump(
-                this.stream,
-                split(),
-                this.createPrettyTransport(options.logLevel, prettyPinoFactory),
-                process.stdout,
-                (err) => {
-                    console.error("Output stream closed due to an error:", err);
+        } else {
+            console = {
+                ...console,
+                assert: (value, message) => {
+                    if (!value) {
+                        this.error(message ? "Assertion failed: " + message : "Assertion failed");
+                    }
                 },
-            );
+                error: (message) => this.error(message),
+                warn: (message) => this.warning(message),
+                info: (message) => this.info(message),
+                log: (message) => this.info(message),
+                debug: (message) => this.debug(message),
+                trace: (message) => this.trace(message),
+            };
         }
-
-        this.combinedFileStream = this.getFileStream(options.fileRotator);
-
-        this.combinedFileStream!.on("error", (err) => {
-            console.error("File stream closed due to an error:", err);
-        });
-
-        this.stream.pipe(this.combinedFileStream!);
 
         return this;
     }
 
-    public critical(message: object, emoji?: string): void {
+    public critical(message: object | string | undefined, emoji?: string): void {
+        if (!emoji) {
+            emoji = "🚨";
+        }
         this.log("critical", message, emoji);
     }
 
-    public error(message: object, emoji?: string): void {
+    public error(message: object | string | undefined, emoji?: string): void {
+        if (!emoji) {
+            emoji = "🛑";
+        }
         this.log("error", message, emoji);
     }
 
-    public warning(message: object, emoji?: string): void {
+    public warning(message: object | string | undefined, emoji?: string): void {
+        if (!emoji) {
+            emoji = "⚠️";
+        }
         this.log("warning", message, emoji);
     }
 
-    public info(message: object, emoji?: string): void {
+    public info(message: object | string | undefined, emoji?: string): void {
+        if (!emoji) {
+            emoji = "ℹ️";
+        }
         this.log("info", message, emoji);
     }
 
-    public debug(message: object, emoji?: string): void {
+    public debug(message: object | string | undefined, emoji?: string): void {
+        if (!emoji) {
+            emoji = "🐛";
+        }
         this.log("debug", message, emoji);
     }
 
-    public trace(message: object, emoji?: string): void {
+    public trace(message: object | string | undefined, emoji?: string): void {
+        if (!emoji) {
+            emoji = "📌";
+        }
         this.log("trace", message, emoji);
     }
 
-    /**
-     * @param {boolean} suppress
-     * @memberof PinoLogger
-     */
-    public suppressConsoleOutput(suppress: boolean): void {
-        this.silentConsole = suppress;
-    }
-
-    public async dispose(): Promise<void> {
-        if (this.combinedFileStream) {
-            this.stream.unpipe(this.combinedFileStream);
-
-            if (!this.combinedFileStream.destroyed) {
-                this.combinedFileStream.end();
-
-                return new Promise((resolve) => {
-                    this.combinedFileStream!.on("finish", () => {
-                        resolve();
-                    });
-                });
-            }
-        }
-    }
-
-    /**
-     * @private
-     * @param {string} level
-     * @param {PrettyOptions} [prettyOptions]
-     * @returns {Transform}
-     * @memberof PinoLogger
-     */
-    private createPrettyTransport(level: string, prettyFactory: Function): Transform {
-        const getLevel = (level: string): number => this.logger.levels.values[level];
-
+    private createPrettyTransport(): Transform {
         return new Transform({
             transform(chunk, enc, cb) {
                 try {
-                    const json = JSON.parse(chunk);
-
-                    if (getLevel(json.level) <= getLevel(level)) {
-                        const line: string | undefined = prettyFactory(json);
-                        if (line !== undefined) {
-                            return cb(undefined, line);
-                        }
-                    }
-                } catch {}
+                    const { emoji, level, message } = JSON.parse(chunk);
+                    return cb(undefined, `${emoji} ${Utils.logColour(level)(message)}\n`);
+                } catch {
+                    //
+                }
 
                 return cb();
             },
         });
     }
 
-    /**
-     * @param {string} level
-     * @param {*} message
-     * @returns {boolean}
-     * @memberof Logger
-     */
-    private log(level: string, message: string | object, emoji?: string): void {
-        if (this.silentConsole) {
-            return;
-        }
-
+    private log(level: string, message: object | string | undefined, emoji?: string): void {
         if (Utils.isEmpty(message)) {
             return;
         }
@@ -260,54 +144,6 @@ export class PinoLogger implements Contracts.Kernel.Logger {
             message = inspect(message, { depth: 1 });
         }
 
-        this.logger.child({ emoji })[level](message);
-    }
-
-    /**
-     * @private
-     * @param {{ interval: string }} options
-     * @returns {Writable}
-     * @memberof PinoLogger
-     */
-    private getFileStream(options: { interval: string }): Writable {
-        return createStream(
-            (time: number | Date, index?: number): string => {
-                if (!time) {
-                    return `${this.app.namespace()}-${this.configFlags.processType}-current.log`;
-                }
-
-                if (typeof time === "number") {
-                    time = new Date(time);
-                }
-
-                let filename: string = time.toISOString().slice(0, 10);
-
-                if (index && index > 1) {
-                    filename += `.${index}`;
-                }
-
-                return `${this.app.namespace()}-${this.configFlags.processType}-${filename}.log.gz`;
-            },
-            {
-                path: this.app.logPath(),
-                initialRotation: true,
-                interval: options.interval,
-                maxSize: "100M",
-                maxFiles: 10,
-                compress: "gzip",
-            },
-        );
-    }
-
-    /**
-     * @private
-     * @param {string} level
-     * @returns {boolean}
-     * @memberof PinoLogger
-     */
-    private isValidLevel(level: string): boolean {
-        return ["emergency", "alert", "critical", "error", "warning", "notice", "info", "debug", "trace"].includes(
-            level,
-        );
+        this.logger[level]({ emoji, message });
     }
 }

--- a/packages/logger/src/service-provider.ts
+++ b/packages/logger/src/service-provider.ts
@@ -1,5 +1,4 @@
 import { Container, Contracts, Providers, Services } from "@solar-network/kernel";
-import Joi from "joi";
 
 import { PinoLogger } from "./driver";
 
@@ -9,23 +8,8 @@ export class ServiceProvider extends Providers.ServiceProvider {
             Container.Identifiers.LogManager,
         );
 
-        await logManager.extend("pino", async () =>
-            this.app.resolve<Contracts.Kernel.Logger>(PinoLogger).make(this.config().all()),
-        );
+        await logManager.extend("pino", async () => this.app.resolve<Contracts.Kernel.Logger>(PinoLogger).make());
 
         logManager.setDefaultDriver("pino");
-    }
-
-    public async dispose(): Promise<void> {
-        await this.app.get<Contracts.Kernel.Logger>(Container.Identifiers.LogService).dispose();
-    }
-
-    public configSchema(): object {
-        return Joi.object({
-            logLevel: Joi.string().required(),
-            fileRotator: Joi.object({
-                interval: Joi.string().required(),
-            }).required(),
-        }).unknown(true);
     }
 }

--- a/packages/p2p/src/network-monitor.ts
+++ b/packages/p2p/src/network-monitor.ts
@@ -503,7 +503,7 @@ export class NetworkMonitor implements Contracts.P2P.NetworkMonitor {
 
         if (peersAll.length === 0) {
             if (!silent) {
-                this.logger.error(`Could not download blocks: we have 0 peers`, "❗");
+                this.logger.error("Could not download blocks: we have 0 peers");
             }
             return [];
         }
@@ -636,7 +636,7 @@ export class NetworkMonitor implements Contracts.P2P.NetworkMonitor {
         for (i = 0; i < chunksToDownload; i++) {
             if (downloadResults[i] === undefined) {
                 if (!silent) {
-                    this.logger.error(`${firstFailureMessage}`, "❗");
+                    this.logger.error(`${firstFailureMessage}`);
                 }
                 break;
             }
@@ -807,7 +807,7 @@ export class NetworkMonitor implements Contracts.P2P.NetworkMonitor {
         try {
             await checkDNS(this.app, options);
         } catch (error) {
-            this.logger.error(`${error.message}`, "❗");
+            this.logger.error(`${error.message}`);
         }
     }
 
@@ -819,7 +819,7 @@ export class NetworkMonitor implements Contracts.P2P.NetworkMonitor {
                 "⏰",
             );
         } catch (error) {
-            this.logger.error(`${error.message}`, "❗");
+            this.logger.error(`${error.message}`);
         }
     }
 

--- a/packages/snapshots/package.json
+++ b/packages/snapshots/package.json
@@ -23,6 +23,7 @@
         "@solar-network/crypto": "workspace:*",
         "@solar-network/database": "workspace:*",
         "@solar-network/kernel": "workspace:*",
+        "colorette": "2.0.19",
         "fs-extra": "8.1.0",
         "joi": "17.6.0",
         "msgpack-lite": "0.1.26",

--- a/packages/snapshots/src/database-service.ts
+++ b/packages/snapshots/src/database-service.ts
@@ -51,13 +51,13 @@ export class SnapshotDatabaseService implements Database.DatabaseService {
     }
 
     public async truncate(): Promise<void> {
-        this.logger.info(
+        this.logger.debug(
             `Clearing ${Utils.pluralise("block", await this.blockRepository.fastCount(), true)}, ${Utils.pluralise(
                 "transaction",
                 await this.transactionRepository.fastCount(),
                 true,
             )}, ${Utils.pluralise("round", await this.roundRepository.fastCount(), true)}`,
-            "🗑️",
+            "🧹",
         );
 
         await this.blockRepository.truncate();
@@ -68,7 +68,7 @@ export class SnapshotDatabaseService implements Database.DatabaseService {
 
         Utils.assert.defined<Models.Block>(lastBlock);
 
-        this.logger.info(`Last block height is: ${lastBlock.height.toLocaleString()}`, "🕸️");
+        this.logger.debug(`Last block height is: ${lastBlock.height.toLocaleString()}`, "🕸️");
 
         await this.blockRepository.rollback(roundInfo);
 
@@ -77,12 +77,12 @@ export class SnapshotDatabaseService implements Database.DatabaseService {
 
     public async dump(options: Options.DumpOptions): Promise<void> {
         try {
-            this.logger.info("Started counting blocks, rounds and transactions", "🧮");
+            this.logger.debug("Started counting blocks, rounds and transactions", "🧮");
 
             const dumpRange = await this.getDumpRange(options.start, options.end);
             const meta = this.prepareMetaData(options, dumpRange);
 
-            this.logger.info(
+            this.logger.debug(
                 `Started running dump for ${Utils.pluralise("block", dumpRange.blocksCount, true)}, ${Utils.pluralise(
                     "round",
                     dumpRange.roundsCount,

--- a/packages/snapshots/src/progress-renderer.ts
+++ b/packages/snapshots/src/progress-renderer.ts
@@ -1,5 +1,6 @@
 import ora from "@alessiodf/ora";
 import { Container, Contracts } from "@solar-network/kernel";
+import { magenta } from "colorette";
 
 import { SnapshotApplicationEvents } from "./events";
 
@@ -75,12 +76,16 @@ export class ProgressRenderer {
 
     private calculatePercentage(count: number, value: number): string {
         const percent: string = ((value / count) * 100).toFixed(2);
-
-        // Append spaces to match ---.-- pattern
-        return `${" ".repeat(6 - percent.length)}${percent}`;
+        try {
+            return `${" ".repeat(6 - percent.length)}${percent}`;
+        } catch {
+            return "";
+        }
     }
 
     private render(): void {
-        this.spinner.text = `Blocks: ${this.progress.blocks} % Transactions: ${this.progress.transactions} % Rounds: ${this.progress.rounds} %`;
+        this.spinner.text = magenta(
+            ` Blocks: ${this.progress.blocks} % Transactions: ${this.progress.transactions} % Rounds: ${this.progress.rounds} %`,
+        );
     }
 }

--- a/packages/snapshots/src/snapshot-service.ts
+++ b/packages/snapshots/src/snapshot-service.ts
@@ -27,7 +27,7 @@ export class SnapshotService implements Contracts.Snapshot.SnapshotService {
         try {
             Utils.assert.defined<string>(options.network);
 
-            this.logger.info(`Saving snapshot for ${options.network}`, "💾");
+            this.logger.debug(`Saving snapshot for ${options.network}`, "💾");
 
             this.database.init(options.codec, options.skipCompression);
 
@@ -66,7 +66,7 @@ export class SnapshotService implements Contracts.Snapshot.SnapshotService {
                 return;
             }
 
-            this.logger.info(`Restoring from snapshot for ${options.network}`, "💾");
+            this.logger.debug(`Restoring from snapshot for ${options.network}`, "💾");
 
             this.database.init(meta!.codec, meta!.skipCompression, options.verify);
 
@@ -78,14 +78,10 @@ export class SnapshotService implements Contracts.Snapshot.SnapshotService {
 
             this.logger.info(
                 `Successfully restored ${Utils.pluralise("block", meta!.blocks.count, true)}, ${Utils.pluralise(
-                    "missed block",
-                    meta!.missedBlocks.count,
+                    "transaction",
+                    meta!.transactions.count,
                     true,
-                )}, ${Utils.pluralise("transaction", meta!.transactions.count, true)}, ${Utils.pluralise(
-                    "round",
-                    meta!.rounds.count,
-                    true,
-                )}`,
+                )}, ${Utils.pluralise("round", meta!.rounds.count, true)}`,
                 "🏁",
             );
         } catch (err) {
@@ -98,7 +94,7 @@ export class SnapshotService implements Contracts.Snapshot.SnapshotService {
         const renderer = new ProgressRenderer(this.app);
 
         try {
-            this.logger.info("Verifying snapshot", "🕵️");
+            this.logger.debug("Verifying snapshot", "🕵️");
 
             Utils.assert.defined<string>(options.network);
             Utils.assert.defined<string>(options.blocks);
@@ -153,7 +149,7 @@ export class SnapshotService implements Contracts.Snapshot.SnapshotService {
 
             const roundInfo = Utils.roundCalculator.calculateRound(height);
 
-            this.logger.info("Rollback in progress", "⏪");
+            this.logger.debug("Rollback in progress", "⏪");
 
             const newLastBlock = await this.database.rollback(roundInfo);
 
@@ -177,7 +173,7 @@ export class SnapshotService implements Contracts.Snapshot.SnapshotService {
 
     public async truncate(): Promise<void> {
         try {
-            this.logger.info("Wiping the database", "🧻");
+            this.logger.debug("Wiping the database", "🧻");
 
             await this.database.truncate();
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -189,6 +189,7 @@ importers:
       boxen: 5.1.2
       cli-table3: 0.6.0
       colorette: 2.0.19
+      dateformat: 4.5.1
       dayjs: 1.10.7
       delay: 5.0.0
       env-paths: 2.2.1
@@ -217,6 +218,7 @@ importers:
       boxen: 5.1.2
       cli-table3: 0.6.0
       colorette: 2.0.19
+      dateformat: 4.5.1
       dayjs: 1.10.7
       delay: 5.0.0
       env-paths: 2.2.1
@@ -449,6 +451,7 @@ importers:
       '@types/got': 9.6.12
       '@types/log-process-errors': 4.1.0
       '@types/semver': 6.2.3
+      colorette: 2.0.19
       cron: 1.8.2
       dayjs: 1.10.7
       deepmerge: 4.2.2
@@ -473,6 +476,7 @@ importers:
       '@hapi/bourne': 2.0.0
       '@pm2/io': 5.0.0
       '@solar-network/crypto': link:../crypto
+      colorette: 2.0.19
       cron: 1.8.2
       dayjs: 1.10.7
       deepmerge: 4.2.2
@@ -505,32 +509,16 @@ importers:
     specifiers:
       '@solar-network/kernel': workspace:*
       '@types/pino': 7.0.5
-      '@types/pump': 1.1.1
-      '@types/readable-stream': 2.3.11
-      '@types/split2': 2.1.6
-      colorette: 2.0.19
-      joi: 17.6.0
       pino: 8.5.0
-      pino-pretty: 9.1.0
       pump: 3.0.0
-      readable-stream: 3.6.0
-      rotating-file-stream: 2.1.5
       split2: 3.2.2
     dependencies:
       '@solar-network/kernel': link:../kernel
-      colorette: 2.0.19
-      joi: 17.6.0
       pino: 8.5.0
-      pino-pretty: 9.1.0
       pump: 3.0.0
-      readable-stream: 3.6.0
-      rotating-file-stream: 2.1.5
       split2: 3.2.2
     devDependencies:
       '@types/pino': 7.0.5
-      '@types/pump': 1.1.1
-      '@types/readable-stream': 2.3.11
-      '@types/split2': 2.1.6
 
   packages/nes:
     specifiers:
@@ -644,6 +632,7 @@ importers:
       '@solar-network/database': workspace:*
       '@solar-network/kernel': workspace:*
       '@types/fs-extra': 8.1.2
+      colorette: 2.0.19
       fs-extra: 8.1.0
       joi: 17.6.0
       msgpack-lite: 0.1.26
@@ -657,6 +646,7 @@ importers:
       '@solar-network/crypto': link:../crypto
       '@solar-network/database': link:../database
       '@solar-network/kernel': link:../kernel
+      colorette: 2.0.19
       fs-extra: 8.1.0
       joi: 17.6.0
       msgpack-lite: 0.1.26
@@ -783,7 +773,6 @@ packages:
       strip-ansi: 6.0.1
     transitivePeerDependencies:
       - zen-observable
-      - zenObservable
     dev: false
 
   /@alessiodf/ora/0.0.2:
@@ -3927,8 +3916,6 @@ packages:
       promise-retry: 2.0.1
       semver: 7.3.7
       which: 2.0.2
-    transitivePeerDependencies:
-      - bluebird
     dev: true
 
   /@npmcli/installed-package-contents/1.0.7:
@@ -4354,10 +4341,8 @@ packages:
       zen-observable:
         optional: true
     dependencies:
-      any-observable: 0.3.0_rxjs@7.5.5
+      any-observable: 0.3.0
       rxjs: 7.5.5
-    transitivePeerDependencies:
-      - zenObservable
     dev: false
 
   /@scure/base/1.1.1:
@@ -4794,21 +4779,8 @@ packages:
     resolution: {integrity: sha512-Fo79ojj3vdEZOHg3wR9ksAMRz4P3S5fDB5e/YWZiFnyFQI1WY2Vftu9XoXVVtJfxB7Bpce/QTqWSSntkz2Znrw==}
     dev: true
 
-  /@types/pump/1.1.1:
-    resolution: {integrity: sha512-wpRerjHDxFBQ4r8XNv3xHJZeuqrBBoeQ/fhgkooV2F7KsPIYRROb/+f9ODgZfOEyO5/w2ej4YQdpPPXipT8DAA==}
-    dependencies:
-      '@types/node': 18.7.14
-    dev: true
-
   /@types/qs/6.9.7:
     resolution: {integrity: sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==}
-    dev: true
-
-  /@types/readable-stream/2.3.11:
-    resolution: {integrity: sha512-0z+/apYJwKFz/RHp6mOMxz/y7xOvWPYPevuCEyAY3gXsjtaac02E26RvxA+I96rfvmVH/dEMGXNvyJfViR1FSQ==}
-    dependencies:
-      '@types/node': 18.7.14
-      safe-buffer: 5.2.1
     dev: true
 
   /@types/request/2.48.8:
@@ -4850,12 +4822,6 @@ packages:
 
   /@types/semver/7.3.12:
     resolution: {integrity: sha512-WwA1MW0++RfXmCr12xeYOOC5baSC9mSb0ZqCquFzKhcoF4TvHu5MKOuXsncgZcpVFhB1pXd5hZmM0ryAoCp12A==}
-    dev: true
-
-  /@types/split2/2.1.6:
-    resolution: {integrity: sha512-ddaFSOMuy2Rp97l6q/LEteQygvTQJuEZ+SRhxFKR0uXGsdbFDqX/QF2xoGcOqLQ8XV91v01SnAv2vpgihNgW/Q==}
-    dependencies:
-      '@types/node': 18.7.14
     dev: true
 
   /@types/tough-cookie/4.0.2:
@@ -5410,19 +5376,9 @@ packages:
     resolution: {integrity: sha512-QXu7BPrP29VllRxH8GwB7x5iX5qWKAAMLqKQGWTeLWVlNHNOpVMJ91dsxQAIWXpjuW5wqvxu3Jd/nRjrJ+0pqg==}
     dev: true
 
-  /any-observable/0.3.0_rxjs@7.5.5:
+  /any-observable/0.3.0:
     resolution: {integrity: sha512-/FQM1EDkTsf63Ub2C6O7GuYFDsSXUwsaZDurV0np41ocwq0jthUAYCmhBX9f+KwlaCgIuWyr/4WlUQUBfKfZog==}
     engines: {node: '>=6'}
-    peerDependencies:
-      rxjs: '*'
-      zenObservable: '*'
-    peerDependenciesMeta:
-      rxjs:
-        optional: true
-      zenObservable:
-        optional: true
-    dependencies:
-      rxjs: 7.5.5
     dev: false
 
   /any-promise/1.3.0:
@@ -5887,8 +5843,6 @@ packages:
       raw-body: 2.5.1
       type-is: 1.6.18
       unpipe: 1.0.0
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /boxen/5.1.2:
@@ -5914,6 +5868,7 @@ packages:
     resolution: {integrity: sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==}
     dependencies:
       balanced-match: 1.0.2
+    dev: true
 
   /braces/3.0.2:
     resolution: {integrity: sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==}
@@ -6103,8 +6058,6 @@ packages:
       ssri: 8.0.1
       tar: 6.1.11
       unique-filename: 1.1.1
-    transitivePeerDependencies:
-      - bluebird
     dev: true
 
   /cache-base/1.0.1:
@@ -6766,8 +6719,8 @@ packages:
     dependencies:
       assert-plus: 1.0.0
 
-  /dateformat/4.6.3:
-    resolution: {integrity: sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==}
+  /dateformat/4.5.1:
+    resolution: {integrity: sha512-OD0TZ+B7yP7ZgpJf5K2DIbj3FZvFvxgFUuaqA/V5zTjAtAAXZ1E8bktHxmAGs4x5b7PflqA9LeQ84Og7wYtF7Q==}
     dev: false
 
   /dayjs/1.10.7:
@@ -6776,11 +6729,6 @@ packages:
 
   /debug/2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
     dependencies:
       ms: 2.0.0
     dev: false
@@ -7466,10 +7414,6 @@ packages:
       servify: 0.1.12
       ws: 3.3.3
       xhr-request-promise: 0.1.3
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
     dev: false
 
   /eth-lib/0.2.8:
@@ -7694,8 +7638,6 @@ packages:
       type-is: 1.6.18
       utils-merge: 1.0.1
       vary: 1.1.2
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /ext/1.7.0:
@@ -7735,10 +7677,6 @@ packages:
     resolution: {integrity: sha512-j4VxAVJsu9NHveYrIj0+nJxXe2lOlibKTlyy0jH8DBwcuV6QyXTy0zTqZhmMKo7EYvuaUk/BFj/o6NU6grE5ag==}
     dev: false
 
-  /fast-copy/2.1.3:
-    resolution: {integrity: sha512-LDzYKNTHhD+XOp8wGMuCkY4eTxFZOOycmpwLBiuF3r3OjOmZnURRD8t2dUAbmKuXGbo/MGggwbSjcBdp8QT0+g==}
-    dev: false
-
   /fast-deep-equal/3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -7773,10 +7711,6 @@ packages:
   /fast-redact/3.1.2:
     resolution: {integrity: sha512-+0em+Iya9fKGfEQGcd62Yv6onjBmmhV1uh86XVfOU8VwAe6kaFdQCWI9s0/Nnugx5Vd9tdbZ7e6gE2tR9dzXdw==}
     engines: {node: '>=6'}
-
-  /fast-safe-stringify/2.1.1:
-    resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
-    dev: false
 
   /fast-sort/2.2.0:
     resolution: {integrity: sha512-W7zqnn2zsYoQA87FKmYtgOsbJohOrh7XrtZrCVHN5XZKqTBTv5UG+rSS3+iWbg/nepRQUOu+wnas8BwtK8kiCg==}
@@ -7838,8 +7772,6 @@ packages:
       parseurl: 1.3.3
       statuses: 2.0.1
       unpipe: 1.0.0
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /find-cache-dir/3.3.2:
@@ -8197,6 +8129,7 @@ packages:
       inherits: 2.0.4
       minimatch: 5.1.0
       once: 1.4.0
+    dev: true
 
   /global-dirs/0.1.1:
     resolution: {integrity: sha512-NknMLn7F2J7aflwFOlGdNIuCDpN3VGoSoB+aap3KABFWbHVn1TCgFC+np23J8W2BiZbjfEw3BFBycSMv1AFblg==}
@@ -8383,13 +8316,6 @@ packages:
     dependencies:
       inherits: 2.0.4
       minimalistic-assert: 1.0.1
-    dev: false
-
-  /help-me/4.1.0:
-    resolution: {integrity: sha512-5HMrkOks2j8Fpu2j5nTLhrBhT7VwHwELpqnSnx802ckofys5MO2SkLpgSz3dgNFHV7IYFX2igm5CM75SmuYidw==}
-    dependencies:
-      glob: 8.0.3
-      readable-stream: 3.6.0
     dev: false
 
   /highlight.js/10.7.3:
@@ -9057,11 +8983,6 @@ packages:
       '@sideway/formula': 3.0.0
       '@sideway/pinpoint': 2.0.0
 
-  /joycon/3.1.1:
-    resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
-    engines: {node: '>=10'}
-    dev: false
-
   /js-sha3/0.5.7:
     resolution: {integrity: sha512-GII20kjaPX0zJ8wzkTbNDYMY7msuZcTWk8S5UOh6806Jq/wz1J8/bnr8uGU0DAUmYDjj2Mr4X1cW8v/GLYnR+g==}
     dev: false
@@ -9491,7 +9412,6 @@ packages:
       socks-proxy-agent: 6.2.1
       ssri: 8.0.1
     transitivePeerDependencies:
-      - bluebird
       - supports-color
     dev: true
 
@@ -9665,6 +9585,7 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       brace-expansion: 2.0.1
+    dev: true
 
   /minimist-options/4.1.0:
     resolution: {integrity: sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A==}
@@ -9929,8 +9850,6 @@ packages:
       regex-not: 1.0.2
       snapdragon: 0.8.2
       to-regex: 3.0.2
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /napi-build-utils/1.0.2:
@@ -10154,7 +10073,6 @@ packages:
       spawn-please: 1.0.0
       update-notifier: 5.1.0
     transitivePeerDependencies:
-      - bluebird
       - supports-color
     dev: true
 
@@ -10209,7 +10127,6 @@ packages:
       minizlib: 2.1.2
       npm-package-arg: 8.1.5
     transitivePeerDependencies:
-      - bluebird
       - supports-color
     dev: true
 
@@ -10474,7 +10391,6 @@ packages:
       ssri: 8.0.1
       tar: 6.1.11
     transitivePeerDependencies:
-      - bluebird
       - supports-color
     dev: true
 
@@ -10715,26 +10631,6 @@ packages:
       readable-stream: 4.1.0
       split2: 4.1.0
 
-  /pino-pretty/9.1.0:
-    resolution: {integrity: sha512-IM6NY9LLo/dVgY7/prJhCh4rAJukafdt0ibxeNOWc2fxKMyTk90SOB9Ao2HfbtShT9QPeP0ePpJktksMhSQMYA==}
-    hasBin: true
-    dependencies:
-      colorette: 2.0.19
-      dateformat: 4.6.3
-      fast-copy: 2.1.3
-      fast-safe-stringify: 2.1.1
-      help-me: 4.1.0
-      joycon: 3.1.1
-      minimist: 1.2.6
-      on-exit-leak-free: 2.1.0
-      pino-abstract-transport: 1.0.0
-      pump: 3.0.0
-      readable-stream: 4.1.0
-      secure-json-parse: 2.5.0
-      sonic-boom: 3.2.0
-      strip-json-comments: 3.1.1
-    dev: false
-
   /pino-std-serializers/6.0.0:
     resolution: {integrity: sha512-mMMOwSKrmyl+Y12Ri2xhH1lbzQxwwpuru9VjyJpgFIH4asSj88F2csdMwN6+M5g1Ll4rmsYghHLQJw81tgZ7LQ==}
 
@@ -10880,11 +10776,6 @@ packages:
 
   /promise-inflight/1.0.1:
     resolution: {integrity: sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==}
-    peerDependencies:
-      bluebird: '*'
-    peerDependenciesMeta:
-      bluebird:
-        optional: true
     dev: true
 
   /promise-retry/2.0.1:
@@ -11483,11 +11374,6 @@ packages:
       fsevents: 2.3.2
     dev: true
 
-  /rotating-file-stream/2.1.5:
-    resolution: {integrity: sha512-wnYazkT8oD5HXTj44WhB030aKo74OyICrPz/QKCUah59QD7Np4OhdoTC0WNZfhMx1ClsZp4lYMlAdof+DIkZ1Q==}
-    engines: {node: '>=10.0'}
-    dev: false
-
   /run-parallel/1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
     dependencies:
@@ -11586,10 +11472,6 @@ packages:
       node-gyp-build: 4.5.0
     dev: false
 
-  /secure-json-parse/2.5.0:
-    resolution: {integrity: sha512-ZQruFgZnIWH+WyO9t5rWt4ZEGqCKPwhiw+YbzTwpmT9elgLrLcfuyUiSnwwjUiVy9r4VM3urtbNF1xmEh9IL2w==}
-    dev: false
-
   /semver-compare/1.0.0:
     resolution: {integrity: sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==}
     dev: true
@@ -11650,8 +11532,6 @@ packages:
       on-finished: 2.4.1
       range-parser: 1.2.1
       statuses: 2.0.1
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /serialize-javascript/6.0.0:
@@ -11668,8 +11548,6 @@ packages:
       escape-html: 1.0.3
       parseurl: 1.3.3
       send: 0.18.0
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /servify/0.1.12:
@@ -11681,8 +11559,6 @@ packages:
       express: 4.18.1
       request: 2.88.2
       xhr: 2.6.0
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /set-blocking/2.0.0:
@@ -11830,8 +11706,6 @@ packages:
       source-map: 0.5.7
       source-map-resolve: 0.5.3
       use: 3.1.1
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /socks-proxy-agent/6.2.1:
@@ -12111,6 +11985,7 @@ packages:
   /strip-json-comments/3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
+    dev: true
 
   /supports-color/2.0.0:
     resolution: {integrity: sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g==}
@@ -12161,10 +12036,6 @@ packages:
       setimmediate: 1.0.5
       tar: 4.4.19
       xhr-request: 1.1.0
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
     dev: false
 
   /tail/2.2.4:
@@ -12800,10 +12671,6 @@ packages:
       '@types/node': 12.20.55
       got: 11.8.5
       swarm-js: 0.1.40
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
     dev: false
 
   /web3-core-helpers/1.7.1:
@@ -12841,8 +12708,6 @@ packages:
       web3-providers-http: 1.7.1
       web3-providers-ipc: 1.7.1
       web3-providers-ws: 1.7.1
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /web3-core-subscriptions/1.7.1:
@@ -12864,8 +12729,6 @@ packages:
       web3-core-method: 1.7.1
       web3-core-requestmanager: 1.7.1
       web3-utils: 1.7.1
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /web3-eth-abi/1.7.1:
@@ -12891,8 +12754,6 @@ packages:
       web3-core-helpers: 1.7.1
       web3-core-method: 1.7.1
       web3-utils: 1.7.1
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /web3-eth-contract/1.7.1:
@@ -12907,8 +12768,6 @@ packages:
       web3-core-subscriptions: 1.7.1
       web3-eth-abi: 1.7.1
       web3-utils: 1.7.1
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /web3-eth-ens/1.7.1:
@@ -12923,8 +12782,6 @@ packages:
       web3-eth-abi: 1.7.1
       web3-eth-contract: 1.7.1
       web3-utils: 1.7.1
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /web3-eth-iban/1.7.1:
@@ -12945,8 +12802,6 @@ packages:
       web3-core-method: 1.7.1
       web3-net: 1.7.1
       web3-utils: 1.7.1
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /web3-eth/1.7.1:
@@ -12965,8 +12820,6 @@ packages:
       web3-eth-personal: 1.7.1
       web3-net: 1.7.1
       web3-utils: 1.7.1
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /web3-net/1.7.1:
@@ -12976,8 +12829,6 @@ packages:
       web3-core: 1.7.1
       web3-core-method: 1.7.1
       web3-utils: 1.7.1
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /web3-providers-http/1.7.1:
@@ -13003,8 +12854,6 @@ packages:
       eventemitter3: 4.0.4
       web3-core-helpers: 1.7.1
       websocket: 1.0.34
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /web3-shh/1.7.1:
@@ -13016,8 +12865,6 @@ packages:
       web3-core-method: 1.7.1
       web3-core-subscriptions: 1.7.1
       web3-net: 1.7.1
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /web3-utils/1.7.1:
@@ -13045,10 +12892,6 @@ packages:
       web3-net: 1.7.1
       web3-shh: 1.7.1
       web3-utils: 1.7.1
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
     dev: false
 
   /webidl-conversions/3.0.1:
@@ -13110,8 +12953,6 @@ packages:
       typedarray-to-buffer: 3.1.5
       utf-8-validate: 5.0.9
       yaeti: 0.0.6
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /whatwg-url/5.0.0:
@@ -13220,14 +13061,6 @@ packages:
 
   /ws/3.3.3:
     resolution: {integrity: sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==}
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: ^5.0.2
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
     dependencies:
       async-limiter: 1.0.1
       safe-buffer: 5.1.2


### PR DESCRIPTION
This PR optimises the performance of logging and cleans up some incorrect emoji and log levels.

During a sync from zero, or any operation with a lot of logging in a short period of time, the synchronous logger was causing a bottleneck. This has been revised now to be much more efficient by using a worker thread, with significantly faster sync from zero speeds as a result.

Additionally, output is no longer logged to stdout/stderr, so that means there are no more logs stored in `~/.pm2/logs` so the only saved logs are the NDJSON files in `~/.local/state/solar-core/{devnet|mainnet|testnet}`, and again this is for performance reasons. However, by using the `solar log:{all|core|forger|relay}` command, you can still see the logs in the prettified format as this command now parses the NDJSON logs in real time. This means that, moving forward, the only way to view logs will be via the `solar` CLI and not `pm2`.