### PR TITLE
refactor(crypto): merge schnorr hash methods

### DIFF
--- a/packages/crypto/src/crypto/hash.ts
+++ b/packages/crypto/src/crypto/hash.ts
@@ -35,10 +35,12 @@ export class Hash {
 
     public static signSchnorr(hash: Buffer, keys: IKeyPair, bip340?: boolean, aux?: Buffer): string {
         if (!bip340) {
-            return Hash.signSchnorrLegacy(hash, keys);
+            return secp256k1.schnorrSign(hash, Buffer.from(keys.privateKey, "hex")).toString("hex");
         }
 
-        return Hash.signSchnorrBip340(hash, keys, aux);
+        const digest: Buffer = hash.length !== 32 ? HashAlgorithms.sha256(hash) : hash;
+
+        return schnorr.sign(digest, Buffer.from(keys.privateKey, "hex"), aux).toString("hex");
     }
 
     public static verifySchnorr(
@@ -48,31 +50,13 @@ export class Hash {
         bip340?: boolean,
     ): boolean {
         if (!bip340) {
-            return Hash.verifySchnorrLegacy(hash, signature, publicKey);
+            return secp256k1.schnorrVerify(
+                hash,
+                signature instanceof Buffer ? signature : Buffer.from(signature, "hex"),
+                publicKey instanceof Buffer ? publicKey : Buffer.from(publicKey, "hex"),
+            );
         }
 
-        return Hash.verifySchnorrBip340(hash, signature, publicKey);
-    }
-
-    public static signSchnorrLegacy(hash: Buffer, keys: IKeyPair): string {
-        return secp256k1.schnorrSign(hash, Buffer.from(keys.privateKey, "hex")).toString("hex");
-    }
-
-    public static verifySchnorrLegacy(hash: Buffer, signature: Buffer | string, publicKey: Buffer | string): boolean {
-        return secp256k1.schnorrVerify(
-            hash,
-            signature instanceof Buffer ? signature : Buffer.from(signature, "hex"),
-            publicKey instanceof Buffer ? publicKey : Buffer.from(publicKey, "hex"),
-        );
-    }
-
-    public static signSchnorrBip340(hash: Buffer, keys: IKeyPair, aux?: Buffer): string {
-        const digest: Buffer = hash.length !== 32 ? HashAlgorithms.sha256(hash) : hash;
-
-        return schnorr.sign(digest, Buffer.from(keys.privateKey, "hex"), aux).toString("hex");
-    }
-
-    public static verifySchnorrBip340(hash: Buffer, signature: Buffer | string, publicKey: Buffer | string): boolean {
         const digest: Buffer = hash.length !== 32 ? HashAlgorithms.sha256(hash) : hash;
 
         let key: Buffer = publicKey instanceof Buffer ? publicKey : Buffer.from(publicKey, "hex");


### PR DESCRIPTION
This PR combines the multiple signing and verifying methods for the different types of Schnorr signatures into just one signing function (`signSchnorr`) and one verifying function (`verifySchnorr`).