### PR TITLE
refactor: no cross-chain check for old swaps and add second signature to swap wallet

### DIFF
--- a/packages/crypto/src/networks/mainnet/milestones.json
+++ b/packages/crypto/src/networks/mainnet/milestones.json
@@ -155,5 +155,10 @@
                 "purpose": "foundation"
             }
         }
+    },
+    {
+        "height": 2750000,
+        "swapWalletSecondPublicKey": "0210caa3c13c5fef3a28a27202373dfc7fd584c122d18d83c980586358a5f76a0e",
+        "verifySwap": true
     }
 ]

--- a/plugins/sxp-swap/src/defaults.ts
+++ b/plugins/sxp-swap/src/defaults.ts
@@ -281,8 +281,8 @@ export const defaults = {
         eth: 35,
     },
     peers: {
-        bsc: ["https://bsc1.mainnet.sh", "https://bsc2.mainnet.sh", "https://bsc3.mainnet.sh"],
-        eth: ["https://eth1.mainnet.sh", "https://eth2.mainnet.sh", "https://eth3.mainnet.sh"],
+        bsc: ["https://bsc1.solar.org", "https://bsc2.solar.org", "https://bsc3.solar.org"],
+        eth: ["https://eth1.solar.org", "https://eth2.solar.org", "https://eth3.solar.org"],
     },
     sxpTokenContracts: {
         bsc: "0x47bead2563dcbf3bf2c9407fea4dc236faba485a",

--- a/plugins/sxp-swap/src/errors.ts
+++ b/plugins/sxp-swap/src/errors.ts
@@ -103,3 +103,9 @@ export class WrongTokenError extends Error {
         super("The swap transaction was not for the SXP token");
     }
 }
+
+export class WrongSecondSignaturePublicKeyError extends Error {
+    public constructor() {
+        super("The public key of the second signature registration for the swap source wallet is incorrect");
+    }
+}


### PR DESCRIPTION
This PR modifies the `sxp-swap` plugin in the following ways:

1. The nodes used for ETH and BSC cross-chain verification have been changed to be under the solar.org domain.
2. All swaps before height 2,750,000 do not require cross-chain verification anymore as they are already well confirmed, which speeds up sync.
3. The swap wallet can now register a second signature with a pre-defined public key.