### PR TITLE
release: mainnet 4.2.0

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/api",
-    "version": "4.1.3",
+    "version": "4.2.0-next.0",
     "description": "Public API for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/api",
-    "version": "4.2.0-next.0",
+    "version": "4.2.0",
     "description": "Public API for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/blockchain/package.json
+++ b/packages/blockchain/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/blockchain",
-    "version": "4.2.0-next.0",
+    "version": "4.2.0",
     "description": "Blockchain Manager for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/blockchain/package.json
+++ b/packages/blockchain/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/blockchain",
-    "version": "4.1.3",
+    "version": "4.2.0-next.0",
     "description": "Blockchain Manager for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/cli",
-    "version": "4.1.3",
+    "version": "4.2.0-next.0",
     "description": "Command Line Interface to manage the Core of the Solar Network Blockchain",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/cli",
-    "version": "4.2.0-next.0",
+    "version": "4.2.0",
     "description": "Command Line Interface to manage the Core of the Solar Network Blockchain",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core",
-    "version": "4.1.3",
+    "version": "4.2.0-next.0",
     "description": "Core of the Solar Network Blockchain",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core",
-    "version": "4.2.0-next.0",
+    "version": "4.2.0",
     "description": "Core of the Solar Network Blockchain",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/crypto",
-    "version": "4.1.3",
+    "version": "4.2.0-next.0",
     "description": "Crypto utilities for the Solar Network Blockchain",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/crypto",
-    "version": "4.2.0-next.0",
+    "version": "4.2.0",
     "description": "Crypto utilities for the Solar Network Blockchain",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/crypto/src/networks/mainnet/milestones.json
+++ b/packages/crypto/src/networks/mainnet/milestones.json
@@ -155,5 +155,10 @@
                 "purpose": "foundation"
             }
         }
+    },
+    {
+        "height": 2750000,
+        "swapWalletSecondPublicKey": "0210caa3c13c5fef3a28a27202373dfc7fd584c122d18d83c980586358a5f76a0e",
+        "verifySwap": true
     }
 ]

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/database",
-    "version": "4.1.3",
+    "version": "4.2.0-next.0",
     "description": "Database Interface for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/database",
-    "version": "4.2.0-next.0",
+    "version": "4.2.0",
     "description": "Database Interface for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/forger/package.json
+++ b/packages/forger/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/forger",
-    "version": "4.2.0-next.0",
+    "version": "4.2.0",
     "description": "Forger for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/forger/package.json
+++ b/packages/forger/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/forger",
-    "version": "4.1.3",
+    "version": "4.2.0-next.0",
     "description": "Forger for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/kernel/package.json
+++ b/packages/kernel/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/kernel",
-    "version": "4.2.0-next.0",
+    "version": "4.2.0",
     "description": "Kernel of Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/kernel/package.json
+++ b/packages/kernel/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/kernel",
-    "version": "4.1.3",
+    "version": "4.2.0-next.0",
     "description": "Kernel of Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/logger",
-    "version": "4.2.0-next.0",
+    "version": "4.2.0",
     "description": "Webhooks for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/logger",
-    "version": "4.1.3",
+    "version": "4.2.0-next.0",
     "description": "Webhooks for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/nes/package.json
+++ b/packages/nes/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/nes",
-    "version": "4.1.3",
+    "version": "4.2.0-next.0",
     "description": "Websocket client and server for Solar Core",
     "license": "BSD-3-Clause",
     "contributors": [

--- a/packages/nes/package.json
+++ b/packages/nes/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/nes",
-    "version": "4.2.0-next.0",
+    "version": "4.2.0",
     "description": "Websocket client and server for Solar Core",
     "license": "BSD-3-Clause",
     "contributors": [

--- a/packages/p2p/package.json
+++ b/packages/p2p/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/p2p",
-    "version": "4.1.3",
+    "version": "4.2.0-next.0",
     "description": "P2P API for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/p2p/package.json
+++ b/packages/p2p/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/p2p",
-    "version": "4.2.0-next.0",
+    "version": "4.2.0",
     "description": "P2P API for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/pool/package.json
+++ b/packages/pool/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/pool",
-    "version": "4.2.0-next.0",
+    "version": "4.2.0",
     "description": "Pool Manager for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/pool/package.json
+++ b/packages/pool/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/pool",
-    "version": "4.1.3",
+    "version": "4.2.0-next.0",
     "description": "Pool Manager for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/snapshots/package.json
+++ b/packages/snapshots/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/snapshots",
-    "version": "4.1.3",
+    "version": "4.2.0-next.0",
     "description": "Provides live local streamed snapshots functionality for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/snapshots/package.json
+++ b/packages/snapshots/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/snapshots",
-    "version": "4.2.0-next.0",
+    "version": "4.2.0",
     "description": "Provides live local streamed snapshots functionality for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/state/package.json
+++ b/packages/state/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/state",
-    "version": "4.1.3",
+    "version": "4.2.0-next.0",
     "description": "State Management for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/state/package.json
+++ b/packages/state/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/state",
-    "version": "4.2.0-next.0",
+    "version": "4.2.0",
     "description": "State Management for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/transactions/package.json
+++ b/packages/transactions/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/transactions",
-    "version": "4.2.0-next.0",
+    "version": "4.2.0",
     "description": "Transaction Services for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/transactions/package.json
+++ b/packages/transactions/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/transactions",
-    "version": "4.1.3",
+    "version": "4.2.0-next.0",
     "description": "Transaction Services for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/webhooks/package.json
+++ b/packages/webhooks/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/webhooks",
-    "version": "4.2.0-next.0",
+    "version": "4.2.0",
     "description": "Webhooks for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/webhooks/package.json
+++ b/packages/webhooks/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/webhooks",
-    "version": "4.1.3",
+    "version": "4.2.0-next.0",
     "description": "Webhooks for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/plugins/sxp-swap/src/defaults.ts
+++ b/plugins/sxp-swap/src/defaults.ts
@@ -281,8 +281,8 @@ export const defaults = {
         eth: 35,
     },
     peers: {
-        bsc: ["https://bsc1.mainnet.sh", "https://bsc2.mainnet.sh", "https://bsc3.mainnet.sh"],
-        eth: ["https://eth1.mainnet.sh", "https://eth2.mainnet.sh", "https://eth3.mainnet.sh"],
+        bsc: ["https://bsc1.solar.org", "https://bsc2.solar.org", "https://bsc3.solar.org"],
+        eth: ["https://eth1.solar.org", "https://eth2.solar.org", "https://eth3.solar.org"],
     },
     sxpTokenContracts: {
         bsc: "0x47bead2563dcbf3bf2c9407fea4dc236faba485a",

--- a/plugins/sxp-swap/src/errors.ts
+++ b/plugins/sxp-swap/src/errors.ts
@@ -103,3 +103,9 @@ export class WrongTokenError extends Error {
         super("The swap transaction was not for the SXP token");
     }
 }
+
+export class WrongSecondSignaturePublicKeyError extends Error {
+    public constructor() {
+        super("The public key of the second signature registration for the swap source wallet is incorrect");
+    }
+}


### PR DESCRIPTION
This PR releases Solar Core 4.2.0 for mainnet.

Changes since 4.1.3:

### Maintenance
\- performance and security improvements for the `sxp-swap` plugin