### PR TITLE
fix: upstream database and api performance improvements

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -33,6 +33,7 @@
         "node-cache": "5.1.2",
         "qs": "6.10.3",
         "rate-limiter-flexible": "1.3.2",
+        "semaphore": "1.1.0",
         "semver": "6.3.0"
     },
     "devDependencies": {
@@ -42,6 +43,7 @@
         "@types/hapi__nes": "11.0.5",
         "@types/ip": "1.1.0",
         "@types/qs": "6.9.7",
+        "@types/semaphore": "1.1.1",
         "@types/semver": "6.2.3",
         "lodash.clonedeep": "4.5.0"
     }

--- a/packages/api/src/controllers/blockchain.ts
+++ b/packages/api/src/controllers/blockchain.ts
@@ -10,15 +10,18 @@ import { Controller } from "./controller";
 
 export class BlockchainController extends Controller {
     @Container.inject(Container.Identifiers.BlockHistoryService)
+    @Container.tagged("connection", "api")
     private readonly blockHistoryService!: Contracts.Shared.BlockHistoryService;
 
     @Container.inject(Container.Identifiers.StateStore)
     private readonly stateStore!: Contracts.State.StateStore;
 
     @Container.inject(Container.Identifiers.TransactionHistoryService)
+    @Container.tagged("connection", "api")
     private readonly transactionHistoryService!: Contracts.Shared.TransactionHistoryService;
 
     @Container.inject(Container.Identifiers.DatabaseTransactionRepository)
+    @Container.tagged("connection", "api")
     private readonly transactionRepository!: Repositories.TransactionRepository;
 
     @Container.inject(Container.Identifiers.WalletRepository)

--- a/packages/api/src/controllers/blocks.ts
+++ b/packages/api/src/controllers/blocks.ts
@@ -12,12 +12,15 @@ export class BlocksController extends Controller {
     private readonly blockchain!: Contracts.Blockchain.Blockchain;
 
     @Container.inject(Container.Identifiers.BlockHistoryService)
+    @Container.tagged("connection", "api")
     private readonly blockHistoryService!: Contracts.Shared.BlockHistoryService;
 
     @Container.inject(Container.Identifiers.MissedBlockHistoryService)
+    @Container.tagged("connection", "api")
     private readonly missedBlockHistoryService!: Contracts.Shared.MissedBlockHistoryService;
 
     @Container.inject(Container.Identifiers.TransactionHistoryService)
+    @Container.tagged("connection", "api")
     private readonly transactionHistoryService!: Contracts.Shared.TransactionHistoryService;
 
     public async index(request: Hapi.Request, h: Hapi.ResponseToolkit): Promise<object> {

--- a/packages/api/src/controllers/delegates.ts
+++ b/packages/api/src/controllers/delegates.ts
@@ -32,7 +32,10 @@ export class DelegatesController extends Controller {
     @Container.tagged("connection", "api")
     private readonly missedBlockHistoryService!: Contracts.Shared.MissedBlockHistoryService;
 
-    public index(request: Hapi.Request, h: Hapi.ResponseToolkit): Contracts.Search.ResultsPage<DelegateResource> {
+    public async index(
+        request: Hapi.Request,
+        h: Hapi.ResponseToolkit,
+    ): Promise<Contracts.Search.ResultsPage<DelegateResource>> {
         const pagination = this.getQueryPagination(request.query);
         const sorting = request.query.orderBy as Contracts.Search.Sorting;
         const criteria = this.getQueryCriteria(request.query, delegateCriteriaSchemaObject) as DelegateCriteria;
@@ -56,7 +59,10 @@ export class DelegatesController extends Controller {
         return { data: delegateResource };
     }
 
-    public voters(request: Hapi.Request, h: Hapi.ResponseToolkit): Contracts.Search.ResultsPage<WalletResource> | Boom {
+    public async voters(
+        request: Hapi.Request,
+        h: Hapi.ResponseToolkit,
+    ): Promise<Contracts.Search.ResultsPage<WalletResource> | Boom> {
         const walletId = request.params.id as string;
 
         const walletResource = this.walletSearchService.getWallet(walletId);

--- a/packages/api/src/controllers/delegates.ts
+++ b/packages/api/src/controllers/delegates.ts
@@ -25,9 +25,11 @@ export class DelegatesController extends Controller {
     private readonly walletSearchService!: WalletSearchService;
 
     @Container.inject(Container.Identifiers.BlockHistoryService)
+    @Container.tagged("connection", "api")
     private readonly blockHistoryService!: Contracts.Shared.BlockHistoryService;
 
     @Container.inject(Container.Identifiers.MissedBlockHistoryService)
+    @Container.tagged("connection", "api")
     private readonly missedBlockHistoryService!: Contracts.Shared.MissedBlockHistoryService;
 
     public index(request: Hapi.Request, h: Hapi.ResponseToolkit): Contracts.Search.ResultsPage<DelegateResource> {

--- a/packages/api/src/controllers/locks.ts
+++ b/packages/api/src/controllers/locks.ts
@@ -21,6 +21,7 @@ export class LocksController extends Controller {
     private readonly lockSearchService!: LockSearchService;
 
     @Container.inject(Container.Identifiers.TransactionHistoryService)
+    @Container.tagged("connection", "api")
     private readonly transactionHistoryService!: Contracts.Shared.TransactionHistoryService;
 
     public index(request: Hapi.Request, h: Hapi.ResponseToolkit): Contracts.Search.ResultsPage<LockResource> {

--- a/packages/api/src/controllers/locks.ts
+++ b/packages/api/src/controllers/locks.ts
@@ -24,7 +24,10 @@ export class LocksController extends Controller {
     @Container.tagged("connection", "api")
     private readonly transactionHistoryService!: Contracts.Shared.TransactionHistoryService;
 
-    public index(request: Hapi.Request, h: Hapi.ResponseToolkit): Contracts.Search.ResultsPage<LockResource> {
+    public async index(
+        request: Hapi.Request,
+        h: Hapi.ResponseToolkit,
+    ): Promise<Contracts.Search.ResultsPage<LockResource>> {
         const pagination = this.getQueryPagination(request.query);
         const sorting = request.query.orderBy as Contracts.Search.Sorting;
         const criteria = this.getQueryCriteria(request.query, lockCriteriaSchemaObject) as LockCriteria;

--- a/packages/api/src/controllers/node.ts
+++ b/packages/api/src/controllers/node.ts
@@ -27,6 +27,7 @@ export class NodeController extends Controller {
     private readonly networkMonitor!: Contracts.P2P.NetworkMonitor;
 
     @Container.inject(Container.Identifiers.DatabaseTransactionRepository)
+    @Container.tagged("connection", "api")
     private readonly transactionRepository!: Repositories.TransactionRepository;
 
     public async status(

--- a/packages/api/src/controllers/rounds.ts
+++ b/packages/api/src/controllers/rounds.ts
@@ -8,6 +8,7 @@ import { Controller } from "./controller";
 
 export class RoundsController extends Controller {
     @Container.inject(Container.Identifiers.DatabaseRoundRepository)
+    @Container.tagged("connection", "api")
     private readonly roundRepository!: Repositories.RoundRepository;
 
     public async delegates(request: Hapi.Request, h: Hapi.ResponseToolkit): Promise<object | Boom.Boom> {

--- a/packages/api/src/controllers/transactions.ts
+++ b/packages/api/src/controllers/transactions.ts
@@ -26,9 +26,11 @@ export class TransactionsController extends Controller {
     private readonly poolQuery!: Contracts.Pool.Query;
 
     @Container.inject(Container.Identifiers.TransactionHistoryService)
+    @Container.tagged("connection", "api")
     private readonly transactionHistoryService!: Contracts.Shared.TransactionHistoryService;
 
     @Container.inject(Container.Identifiers.BlockHistoryService)
+    @Container.tagged("connection", "api")
     private readonly blockHistoryService!: Contracts.Shared.BlockHistoryService;
 
     @Container.inject(Container.Identifiers.PoolProcessor)

--- a/packages/api/src/controllers/votes.ts
+++ b/packages/api/src/controllers/votes.ts
@@ -9,6 +9,7 @@ import { Controller } from "./controller";
 @Container.injectable()
 export class VotesController extends Controller {
     @Container.inject(Container.Identifiers.TransactionHistoryService)
+    @Container.tagged("connection", "api")
     private readonly transactionHistoryService!: Contracts.Shared.TransactionHistoryService;
 
     public async index(request: Hapi.Request, h: Hapi.ResponseToolkit): Promise<Contracts.Search.ResultsPage<object>> {

--- a/packages/api/src/controllers/wallets.ts
+++ b/packages/api/src/controllers/wallets.ts
@@ -28,6 +28,7 @@ export class WalletsController extends Controller {
     private readonly lockSearchService!: LockSearchService;
 
     @Container.inject(Container.Identifiers.TransactionHistoryService)
+    @Container.tagged("connection", "api")
     private readonly transactionHistoryService!: Contracts.Shared.TransactionHistoryService;
 
     public index(request: Hapi.Request, h: Hapi.ResponseToolkit): Contracts.Search.ResultsPage<WalletResource> {

--- a/packages/api/src/controllers/wallets.ts
+++ b/packages/api/src/controllers/wallets.ts
@@ -31,7 +31,10 @@ export class WalletsController extends Controller {
     @Container.tagged("connection", "api")
     private readonly transactionHistoryService!: Contracts.Shared.TransactionHistoryService;
 
-    public index(request: Hapi.Request, h: Hapi.ResponseToolkit): Contracts.Search.ResultsPage<WalletResource> {
+    public async index(
+        request: Hapi.Request,
+        h: Hapi.ResponseToolkit,
+    ): Promise<Contracts.Search.ResultsPage<WalletResource>> {
         const pagination = this.getQueryPagination(request.query);
         const sorting = request.query.orderBy as Contracts.Search.Sorting;
         const criteria = this.getQueryCriteria(request.query, walletCriteriaSchemaObject) as WalletCriteria;
@@ -39,7 +42,10 @@ export class WalletsController extends Controller {
         return this.walletSearchService.getWalletsPage(pagination, sorting, criteria);
     }
 
-    public top(request: Hapi.Request, h: Hapi.ResponseToolkit): Contracts.Search.ResultsPage<WalletResource> {
+    public async top(
+        request: Hapi.Request,
+        h: Hapi.ResponseToolkit,
+    ): Promise<Contracts.Search.ResultsPage<WalletResource>> {
         const pagination = this.getQueryPagination(request.query);
         const sorting = request.query.orderBy as Contracts.Search.Sorting;
         const criteria = this.getQueryCriteria(request.query, walletCriteriaSchemaObject) as WalletCriteria;
@@ -58,7 +64,10 @@ export class WalletsController extends Controller {
         return { data: walletResource };
     }
 
-    public locks(request: Hapi.Request, h: Hapi.ResponseToolkit): Contracts.Search.ResultsPage<LockResource> | Boom {
+    public async locks(
+        request: Hapi.Request,
+        h: Hapi.ResponseToolkit,
+    ): Promise<Contracts.Search.ResultsPage<LockResource> | Boom> {
         const walletId = request.params.id as string;
         const walletResource = this.walletSearchService.getWallet(walletId);
 

--- a/packages/api/src/defaults.ts
+++ b/packages/api/src/defaults.ts
@@ -27,6 +27,31 @@ export const defaults = {
             stdTTL: 8,
             checkperiod: 120,
         },
+        semaphore: {
+            enabled: !process.env.CORE_API_SEMAPHORE_DISABLED,
+            database: {
+                levelOne: {
+                    concurrency: 10,
+                    queueLimit: 100,
+                    maxOffset: 10000,
+                },
+                levelTwo: {
+                    concurrency: 1,
+                    queueLimit: 5,
+                },
+            },
+            memory: {
+                levelOne: {
+                    concurrency: 3,
+                    queueLimit: 30,
+                    maxOffset: 1000,
+                },
+                levelTwo: {
+                    concurrency: 1,
+                    queueLimit: 5,
+                },
+            },
+        },
         rateLimit: {
             enabled: !process.env.CORE_API_RATE_LIMIT_DISABLED,
             points: process.env.CORE_API_RATE_LIMIT_USER_LIMIT || 100,

--- a/packages/api/src/plugins/index.ts
+++ b/packages/api/src/plugins/index.ts
@@ -11,6 +11,7 @@ import { log } from "./log";
 import { pagination } from "./pagination";
 import { rateLimit } from "./rate-limit";
 import { responseHeaders } from "./response-headers";
+import { semaphore } from "./semaphore";
 import { whitelist } from "./whitelist";
 
 const isListed = (ip: string, patterns: string[]): boolean => {
@@ -79,6 +80,7 @@ export const preparePlugins = (config) => {
         },
         { plugin: commaArrayQuery },
         { plugin: dotSeparatedQuery },
+        { plugin: semaphore, options: config.semaphore },
         {
             plugin: cache,
             options: config.plugins.cache,

--- a/packages/api/src/plugins/semaphore.ts
+++ b/packages/api/src/plugins/semaphore.ts
@@ -1,0 +1,221 @@
+import Boom from "@hapi/boom";
+import Hapi from "@hapi/hapi";
+import makeSemaphore, { Semaphore } from "semaphore";
+
+type PluginOptions = {
+    enabled: boolean;
+    database: {
+        levelOne: LevelOneOptions;
+        levelTwo: LevelOptions;
+    };
+    memory: {
+        levelOne: LevelOneOptions;
+        levelTwo: LevelOptions;
+    };
+};
+
+type LevelOptions = {
+    concurrency: number;
+    queueLimit: number;
+};
+
+type LevelOneOptions = LevelOptions & {
+    maxOffset: number;
+};
+
+type QueryLevelOptions = {
+    field: string;
+    asc: boolean;
+    desc: boolean;
+    allowSecondOrderBy: boolean;
+    diverse: boolean;
+};
+
+type SemaphoreOptions = {
+    enabled: boolean;
+    type: "database" | "memory";
+    queryLevelOptions?: QueryLevelOptions[];
+};
+
+type FullSemaphoreOptions = Required<SemaphoreOptions>;
+
+enum Level {
+    One = 1,
+    Two = 2,
+}
+
+export const semaphore = {
+    name: "onPreHandler",
+    version: "1.0.0",
+    register(server: Hapi.Server, pluginOptions: PluginOptions): void {
+        if (!pluginOptions.enabled) {
+            return;
+        }
+
+        const semaphores = { database: new Map<Level, Semaphore>(), memory: new Map<Level, Semaphore>() };
+        semaphores.database.set(Level.One, makeSemaphore(pluginOptions.database.levelOne.concurrency));
+        semaphores.database.set(Level.Two, makeSemaphore(pluginOptions.database.levelTwo.concurrency));
+        semaphores.memory.set(Level.One, makeSemaphore(pluginOptions.memory.levelOne.concurrency));
+        semaphores.memory.set(Level.Two, makeSemaphore(pluginOptions.memory.levelTwo.concurrency));
+
+        const semaphoresConcurrency = { database: new Map<Level, number>(), memory: new Map<Level, number>() };
+        semaphoresConcurrency.database.set(Level.One, pluginOptions.database.levelOne.concurrency);
+        semaphoresConcurrency.database.set(Level.Two, pluginOptions.database.levelTwo.concurrency);
+        semaphoresConcurrency.memory.set(Level.One, pluginOptions.memory.levelOne.concurrency);
+        semaphoresConcurrency.memory.set(Level.Two, pluginOptions.memory.levelTwo.concurrency);
+
+        const semaphoresQueueLimit = { database: new Map<Level, number>(), memory: new Map<Level, number>() };
+        semaphoresQueueLimit.database.set(Level.One, pluginOptions.database.levelOne.queueLimit);
+        semaphoresQueueLimit.database.set(Level.Two, pluginOptions.database.levelTwo.queueLimit);
+        semaphoresQueueLimit.memory.set(Level.One, pluginOptions.memory.levelOne.queueLimit);
+        semaphoresQueueLimit.memory.set(Level.Two, pluginOptions.memory.levelTwo.queueLimit);
+
+        const requestLevels = new Map<Hapi.Request, Level>();
+
+        server.ext("onPreHandler", async (request: Hapi.Request, h: Hapi.ResponseToolkit) => {
+            const options = getRouteSemaphoreOptions(request);
+
+            if (options.enabled) {
+                const level = getLevel(request, options);
+                const sem = semaphores[options.type].get(level)!;
+
+                if (
+                    // @ts-ignore
+                    sem.queue.length(sem.current - semaphoresConcurrency[options.type].get(level)!) >=
+                    semaphoresQueueLimit[options.type].get(level)!
+                ) {
+                    return Boom.tooManyRequests();
+                }
+
+                requestLevels.set(request, level);
+
+                await new Promise<void>((resolve) => {
+                    sem.take(() => {
+                        resolve();
+                    });
+                });
+            }
+
+            return h.continue;
+        });
+
+        server.events.on("response", (request: Hapi.Request) => {
+            const options = getRouteSemaphoreOptions(request);
+
+            const level = requestLevels.get(request);
+
+            if (level) {
+                requestLevels.delete(request);
+                const sem = semaphores[options.type].get(level)!;
+
+                sem.leave();
+            }
+        });
+
+        const isFullSemaphoreOptions = (b: SemaphoreOptions): b is FullSemaphoreOptions => {
+            return !!b.queryLevelOptions;
+        };
+
+        const getLevel = (request: Hapi.Request, options: SemaphoreOptions): Level => {
+            if (isFullSemaphoreOptions(options)) {
+                if (usesDiverseIndex(request, options)) {
+                    return Level.One;
+                }
+
+                const levels = [
+                    orderByLevel(request, options),
+                    offsetLevel(request, options),
+                    queryLevel(request, options),
+                ];
+
+                return levels.includes(Level.Two) ? Level.Two : Level.One;
+            }
+
+            return offsetLevel(request, options);
+        };
+
+        const usesDiverseIndex = (request: Hapi.Request, options: FullSemaphoreOptions): boolean => {
+            const distributedIndices = options.queryLevelOptions
+                .filter((option) => option.diverse)
+                .map((option) => option.field);
+
+            for (const key of Object.keys(request.query)) {
+                if (distributedIndices.includes(key) && ["number", "string"].includes(typeof request.query[key])) {
+                    return true;
+                }
+            }
+
+            return false;
+        };
+
+        const orderByLevel = (request: Hapi.Request, options: FullSemaphoreOptions): Level => {
+            if (request.query.orderBy && request.query.orderBy.length) {
+                const orderBy = Array.isArray(request.query.orderBy) ? request.query.orderBy : [request.query.orderBy];
+
+                const [field, sortOrder]: [string, "asc" | "desc"] = orderBy[0].split(":");
+
+                const fieldOptions = options.queryLevelOptions.find((options) => options.field === field);
+
+                if (!fieldOptions) {
+                    return Level.Two;
+                }
+
+                if (!fieldOptions[sortOrder]) {
+                    return Level.Two;
+                }
+
+                if (!fieldOptions.allowSecondOrderBy && orderBy.length > 1) {
+                    return Level.Two;
+                }
+            }
+
+            return Level.One;
+        };
+
+        const offsetLevel = (request: Hapi.Request, options: SemaphoreOptions): Level => {
+            const offset = pluginOptions[options.type].levelOne.maxOffset;
+
+            if (request.query.offset && request.query.offset > offset) {
+                return Level.Two;
+            }
+
+            if (request.query.page && request.query.limit) {
+                if (request.query.page * request.query.limit > offset) {
+                    return Level.Two;
+                }
+            }
+
+            return Level.One;
+        };
+
+        const queryLevel = (request: Hapi.Request, options: FullSemaphoreOptions): Level => {
+            const reservedFields = ["page", "limit", "transform", "offset", "orderBy"];
+            const indices = options.queryLevelOptions.map((options) => options.field);
+
+            for (const key of Object.keys(request.query)) {
+                if (reservedFields.includes(key)) {
+                    continue;
+                }
+
+                if (!indices.includes(key)) {
+                    return Level.Two;
+                }
+            }
+
+            return Level.One;
+        };
+
+        const getRouteSemaphoreOptions = (request): SemaphoreOptions => {
+            const result: SemaphoreOptions = {
+                enabled: false,
+                type: "database",
+            };
+
+            if (request.route.settings.plugins.semaphore) {
+                return { ...result, ...request.route.settings.plugins.semaphore };
+            }
+
+            return result;
+        };
+    },
+};

--- a/packages/api/src/resources-new/block.ts
+++ b/packages/api/src/resources-new/block.ts
@@ -38,3 +38,15 @@ export const blockSortingSchemaWithoutUsernameOrGeneratorPublicKey = Schemas.cre
     [],
     false,
 );
+
+export const blockQueryLevelOptions = [
+    { field: "version", asc: true, desc: true, allowSecondOrderBy: false, diverse: false },
+    { field: "timestamp", asc: true, desc: true, allowSecondOrderBy: true, diverse: true },
+    { field: "height", asc: true, desc: true, allowSecondOrderBy: true, diverse: true },
+    { field: "numberOfTransactions", asc: true, desc: false, allowSecondOrderBy: false, diverse: false },
+    { field: "totalAmount", asc: true, desc: false, allowSecondOrderBy: false, diverse: false },
+    { field: "totalFee", asc: true, desc: false, allowSecondOrderBy: false, diverse: false },
+    { field: "reward", asc: true, desc: true, allowSecondOrderBy: false, diverse: false },
+    { field: "id", asc: false, desc: false, allowSecondOrderBy: false, diverse: true },
+    { field: "previousBlock", asc: false, desc: false, allowSecondOrderBy: false, diverse: true },
+];

--- a/packages/api/src/resources-new/missed-block.ts
+++ b/packages/api/src/resources-new/missed-block.ts
@@ -7,3 +7,9 @@ export const missedBlockSortingSchemaWithoutUsername = Schemas.createSortingSche
     [],
     false,
 );
+
+export const missedBlockQueryLevelOptions = [
+    { field: "timestamp", asc: true, desc: true, allowSecondOrderBy: true, diverse: true },
+    { field: "height", asc: true, desc: true, allowSecondOrderBy: true, diverse: true },
+    { field: "username", asc: true, desc: true, allowSecondOrderBy: true, diverse: true },
+];

--- a/packages/api/src/resources-new/transaction.ts
+++ b/packages/api/src/resources-new/transaction.ts
@@ -20,3 +20,17 @@ export const transactionCriteriaSchemaObject = {
 
 export const transactionParamSchema = transactionIdSchema;
 export const transactionSortingSchema = Schemas.createSortingSchema(Schemas.transactionCriteriaSchemas, [], false);
+
+export const transactionQueryLevelOptions = [
+    { field: "version", asc: true, desc: true, allowSecondOrderBy: false, diverse: false },
+    { field: "timestamp", asc: true, desc: true, allowSecondOrderBy: true, diverse: true },
+    { field: "type", asc: true, desc: false, allowSecondOrderBy: false, diverse: false },
+    { field: "amount", asc: true, desc: false, allowSecondOrderBy: false, diverse: false },
+    { field: "fee", asc: true, desc: false, allowSecondOrderBy: false, diverse: false },
+    { field: "typeGroup", asc: true, desc: true, allowSecondOrderBy: false, diverse: false },
+    { field: "nonce", asc: true, desc: true, allowSecondOrderBy: false, diverse: false },
+    { field: "id", asc: false, desc: false, allowSecondOrderBy: false, diverse: true },
+    { field: "blockId", asc: false, desc: false, allowSecondOrderBy: false, diverse: true },
+    { field: "senderPublicKey", asc: false, desc: false, allowSecondOrderBy: false, diverse: true },
+    { field: "recipientId", asc: false, desc: false, allowSecondOrderBy: false, diverse: true },
+];

--- a/packages/api/src/routes/blocks.ts
+++ b/packages/api/src/routes/blocks.ts
@@ -2,7 +2,13 @@ import Hapi from "@hapi/hapi";
 import Joi from "joi";
 
 import { BlocksController } from "../controllers/blocks";
-import { blockSortingSchema, missedBlockSortingSchema, transactionSortingSchema } from "../resources-new";
+import {
+    blockQueryLevelOptions,
+    blockSortingSchema,
+    missedBlockQueryLevelOptions,
+    missedBlockSortingSchema,
+    transactionSortingSchema,
+} from "../resources-new";
 import * as Schemas from "../schemas";
 
 export const register = (server: Hapi.Server): void => {
@@ -24,6 +30,11 @@ export const register = (server: Hapi.Server): void => {
                     .concat(Schemas.pagination),
             },
             plugins: {
+                semaphore: {
+                    enabled: true,
+                    type: "database",
+                    queryLevelOptions: blockQueryLevelOptions,
+                },
                 pagination: {
                     enabled: true,
                 },
@@ -45,6 +56,11 @@ export const register = (server: Hapi.Server): void => {
                     .concat(Schemas.pagination),
             },
             plugins: {
+                semaphore: {
+                    enabled: true,
+                    type: "database",
+                    queryLevelOptions: missedBlockQueryLevelOptions,
+                },
                 pagination: {
                     enabled: true,
                 },
@@ -91,6 +107,12 @@ export const register = (server: Hapi.Server): void => {
                     transform: Joi.bool().default(true),
                 }),
             },
+            plugins: {
+                semaphore: {
+                    enabled: true,
+                    type: "database",
+                },
+            },
         },
     });
 
@@ -112,6 +134,10 @@ export const register = (server: Hapi.Server): void => {
                     .concat(Schemas.pagination),
             },
             plugins: {
+                semaphore: {
+                    enabled: true,
+                    type: "database",
+                },
                 pagination: {
                     enabled: true,
                 },

--- a/packages/api/src/routes/delegates.ts
+++ b/packages/api/src/routes/delegates.ts
@@ -3,9 +3,11 @@ import Joi from "joi";
 
 import { DelegatesController } from "../controllers/delegates";
 import {
+    blockQueryLevelOptions,
     blockSortingSchemaWithoutUsernameOrGeneratorPublicKey,
     delegateCriteriaSchema,
     delegateSortingSchema,
+    missedBlockQueryLevelOptions,
     missedBlockSortingSchema,
     walletCriteriaSchema,
     walletParamSchema,
@@ -82,6 +84,11 @@ export const register = (server: Hapi.Server): void => {
                     .concat(Schemas.pagination),
             },
             plugins: {
+                semaphore: {
+                    enabled: true,
+                    type: "database",
+                    queryLevelOptions: blockQueryLevelOptions,
+                },
                 pagination: {
                     enabled: true,
                 },
@@ -106,6 +113,11 @@ export const register = (server: Hapi.Server): void => {
                     .concat(Schemas.pagination),
             },
             plugins: {
+                semaphore: {
+                    enabled: true,
+                    type: "database",
+                    queryLevelOptions: missedBlockQueryLevelOptions,
+                },
                 pagination: {
                     enabled: true,
                 },

--- a/packages/api/src/routes/locks.ts
+++ b/packages/api/src/routes/locks.ts
@@ -18,6 +18,10 @@ export const register = (server: Hapi.Server): void => {
                 query: Joi.object().concat(lockCriteriaSchema).concat(lockSortingSchema).concat(Schemas.pagination),
             },
             plugins: {
+                semaphore: {
+                    enabled: true,
+                    type: "memory",
+                },
                 pagination: { enabled: true },
             },
         },
@@ -50,6 +54,10 @@ export const register = (server: Hapi.Server): void => {
                 }).required(),
             },
             plugins: {
+                semaphore: {
+                    enabled: true,
+                    type: "database",
+                },
                 pagination: {
                     enabled: true,
                 },

--- a/packages/api/src/routes/node.ts
+++ b/packages/api/src/routes/node.ts
@@ -41,6 +41,12 @@ export const register = (server: Hapi.Server): void => {
                     days: Joi.number().integer().min(1).max(30),
                 }),
             },
+            plugins: {
+                semaphore: {
+                    enabled: true,
+                    type: "database",
+                },
+            },
         },
     });
 };

--- a/packages/api/src/routes/rounds.ts
+++ b/packages/api/src/routes/rounds.ts
@@ -17,6 +17,12 @@ export const register = (server: Hapi.Server): void => {
                     id: Joi.number().integer().min(1),
                 }),
             },
+            plugins: {
+                semaphore: {
+                    enabled: true,
+                    type: "database",
+                },
+            },
         },
     });
 };

--- a/packages/api/src/routes/transactions.ts
+++ b/packages/api/src/routes/transactions.ts
@@ -3,7 +3,7 @@ import { Container, Providers } from "@solar-network/kernel";
 import Joi from "joi";
 
 import { StoreRequest, TransactionsController } from "../controllers/transactions";
-import { transactionSortingSchema } from "../resources-new";
+import { transactionQueryLevelOptions, transactionSortingSchema } from "../resources-new";
 import * as Schemas from "../schemas";
 
 export const register = (server: Hapi.Server): void => {
@@ -25,6 +25,11 @@ export const register = (server: Hapi.Server): void => {
                     .concat(Schemas.pagination),
             },
             plugins: {
+                semaphore: {
+                    enabled: true,
+                    type: "database",
+                    queryLevelOptions: transactionQueryLevelOptions,
+                },
                 pagination: {
                     enabled: true,
                 },
@@ -69,6 +74,12 @@ export const register = (server: Hapi.Server): void => {
                 query: Joi.object({
                     transform: Joi.bool().default(true),
                 }),
+            },
+            plugins: {
+                semaphore: {
+                    enabled: true,
+                    type: "database",
+                },
             },
         },
     });

--- a/packages/api/src/routes/votes.ts
+++ b/packages/api/src/routes/votes.ts
@@ -2,7 +2,7 @@ import Hapi from "@hapi/hapi";
 import Joi from "joi";
 
 import { VotesController } from "../controllers/votes";
-import { transactionSortingSchema } from "../resources-new";
+import { transactionQueryLevelOptions, transactionSortingSchema } from "../resources-new";
 import * as Schemas from "../schemas";
 
 export const register = (server: Hapi.Server): void => {
@@ -24,6 +24,11 @@ export const register = (server: Hapi.Server): void => {
                     .concat(Schemas.pagination),
             },
             plugins: {
+                semaphore: {
+                    enabled: true,
+                    type: "database",
+                    queryLevelOptions: transactionQueryLevelOptions,
+                },
                 pagination: {
                     enabled: true,
                 },
@@ -43,6 +48,12 @@ export const register = (server: Hapi.Server): void => {
                 query: Joi.object({
                     transform: Joi.bool().default(true),
                 }),
+            },
+            plugins: {
+                semaphore: {
+                    enabled: true,
+                    type: "database",
+                },
             },
         },
     });

--- a/packages/api/src/routes/wallets.ts
+++ b/packages/api/src/routes/wallets.ts
@@ -5,6 +5,7 @@ import { WalletsController } from "../controllers/wallets";
 import {
     lockCriteriaSchema,
     lockSortingSchema,
+    transactionQueryLevelOptions,
     transactionSortingSchema,
     walletCriteriaSchema,
     walletParamSchema,
@@ -25,6 +26,10 @@ export const register = (server: Hapi.Server): void => {
                 query: Joi.object().concat(walletCriteriaSchema).concat(walletSortingSchema).concat(Schemas.pagination),
             },
             plugins: {
+                semaphore: {
+                    enabled: true,
+                    type: "memory",
+                },
                 pagination: { enabled: true },
             },
         },
@@ -39,6 +44,10 @@ export const register = (server: Hapi.Server): void => {
                 query: Joi.object().concat(walletCriteriaSchema).concat(walletSortingSchema).concat(Schemas.pagination),
             },
             plugins: {
+                semaphore: {
+                    enabled: true,
+                    type: "memory",
+                },
                 pagination: { enabled: true },
             },
         },
@@ -69,6 +78,10 @@ export const register = (server: Hapi.Server): void => {
                 query: Joi.object().concat(lockCriteriaSchema).concat(lockSortingSchema).concat(Schemas.pagination),
             },
             plugins: {
+                semaphore: {
+                    enabled: true,
+                    type: "memory",
+                },
                 pagination: { enabled: true },
             },
         },
@@ -92,6 +105,11 @@ export const register = (server: Hapi.Server): void => {
                     .concat(Schemas.pagination),
             },
             plugins: {
+                semaphore: {
+                    enabled: true,
+                    type: "database",
+                    queryLevelOptions: transactionQueryLevelOptions,
+                },
                 pagination: {
                     enabled: true,
                 },
@@ -117,6 +135,11 @@ export const register = (server: Hapi.Server): void => {
                     .concat(Schemas.pagination),
             },
             plugins: {
+                semaphore: {
+                    enabled: true,
+                    type: "database",
+                    queryLevelOptions: transactionQueryLevelOptions,
+                },
                 pagination: {
                     enabled: true,
                 },
@@ -142,6 +165,11 @@ export const register = (server: Hapi.Server): void => {
                     .concat(Schemas.pagination),
             },
             plugins: {
+                semaphore: {
+                    enabled: true,
+                    type: "database",
+                    queryLevelOptions: transactionQueryLevelOptions,
+                },
                 pagination: {
                     enabled: true,
                 },
@@ -167,6 +195,11 @@ export const register = (server: Hapi.Server): void => {
                     .concat(Schemas.pagination),
             },
             plugins: {
+                semaphore: {
+                    enabled: true,
+                    type: "database",
+                    queryLevelOptions: transactionQueryLevelOptions,
+                },
                 pagination: {
                     enabled: true,
                 },

--- a/packages/api/src/schemas.ts
+++ b/packages/api/src/schemas.ts
@@ -95,10 +95,12 @@ export const createSortingSchema = (
 
                 if (transform) {
                     sorting.push({ property, direction: direction as "asc" | "desc" });
-                } else {
-                    sorting.push(value);
                 }
             }
+        }
+
+        if (!transform) {
+            return value;
         }
 
         return sorting;

--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -115,7 +115,7 @@ export class Server {
         });
 
         this.server.ext("onPreResponse", (request, h) => {
-            if (isBoom(request.response) && request.response.isServer) {
+            if (isBoom(request.response) && request.response.isServer && request.response.name !== "QueryFailedError") {
                 this.logger.error(request.response.stack);
             }
             return h.continue;

--- a/packages/api/src/service-provider.ts
+++ b/packages/api/src/service-provider.ts
@@ -78,6 +78,31 @@ export class ServiceProvider extends Providers.ServiceProvider {
                     stdTTL: Joi.number().integer().min(0).required(),
                     checkperiod: Joi.number().integer().min(0).required(),
                 }).required(),
+                semaphore: Joi.object({
+                    enabled: Joi.bool().required(),
+                    database: Joi.object({
+                        levelOne: Joi.object({
+                            concurrency: Joi.number().integer().min(0).required(),
+                            queueLimit: Joi.number().integer().min(0).required(),
+                            maxOffset: Joi.number().integer().min(0).required(),
+                        }).required(),
+                        levelTwo: Joi.object({
+                            concurrency: Joi.number().integer().min(0).required(),
+                            queueLimit: Joi.number().integer().min(0).required(),
+                        }).required(),
+                    }).required(),
+                    memory: Joi.object({
+                        levelOne: Joi.object({
+                            concurrency: Joi.number().integer().min(0).required(),
+                            queueLimit: Joi.number().integer().min(0).required(),
+                            maxOffset: Joi.number().integer().min(0).required(),
+                        }).required(),
+                        levelTwo: Joi.object({
+                            concurrency: Joi.number().integer().min(0).required(),
+                            queueLimit: Joi.number().integer().min(0).required(),
+                        }).required(),
+                    }).required(),
+                }).required(),
                 rateLimit: Joi.object({
                     enabled: Joi.bool().required(),
                     points: Joi.number().integer().min(0).required(),

--- a/packages/api/src/services/delegate-search-service.ts
+++ b/packages/api/src/services/delegate-search-service.ts
@@ -33,11 +33,11 @@ export class DelegateSearchService {
         }
     }
 
-    public getDelegatesPage(
+    public async getDelegatesPage(
         pagination: Contracts.Search.Pagination,
         sorting: Contracts.Search.Sorting,
         ...criterias: DelegateCriteria[]
-    ): Contracts.Search.ResultsPage<DelegateResource> {
+    ): Promise<Contracts.Search.ResultsPage<DelegateResource>> {
         sorting = [...sorting, { property: "rank", direction: "asc" }, { property: "username", direction: "asc" }];
 
         return this.paginationService.getPage(pagination, sorting, this.getDelegates(...criterias));

--- a/packages/api/src/services/lock-search-service.ts
+++ b/packages/api/src/services/lock-search-service.ts
@@ -27,22 +27,22 @@ export class LockSearchService {
         }
     }
 
-    public getLocksPage(
+    public async getLocksPage(
         pagination: Contracts.Search.Pagination,
         sorting: Contracts.Search.Sorting,
         ...criterias: LockCriteria[]
-    ): Contracts.Search.ResultsPage<LockResource> {
+    ): Promise<Contracts.Search.ResultsPage<LockResource>> {
         sorting = [...sorting, { property: "timestamp.unix", direction: "desc" }];
 
         return this.paginationService.getPage(pagination, sorting, this.getLocks(...criterias));
     }
 
-    public getWalletLocksPage(
+    public async getWalletLocksPage(
         pagination: Contracts.Search.Pagination,
         sorting: Contracts.Search.Sorting,
         walletAddress: string,
         ...criterias: LockCriteria[]
-    ): Contracts.Search.ResultsPage<LockResource> {
+    ): Promise<Contracts.Search.ResultsPage<LockResource>> {
         sorting = [...sorting, { property: "timestamp.unix", direction: "desc" }];
 
         return this.paginationService.getPage(pagination, sorting, this.getWalletLocks(walletAddress, ...criterias));

--- a/packages/api/src/services/wallet-search-service.ts
+++ b/packages/api/src/services/wallet-search-service.ts
@@ -97,21 +97,21 @@ export class WalletSearchService {
             });
     }
 
-    public getWalletsPage(
+    public async getWalletsPage(
         pagination: Contracts.Search.Pagination,
         sorting: Contracts.Search.Sorting,
         ...criterias: WalletCriteria[]
-    ): Contracts.Search.ResultsPage<WalletResource> {
+    ): Promise<Contracts.Search.ResultsPage<WalletResource>> {
         sorting = [...sorting, { property: "balance", direction: "desc" }];
 
         return this.paginationService.getPage(pagination, sorting, this.getWallets(...criterias));
     }
 
-    public getActiveWalletsPage(
+    public async getActiveWalletsPage(
         pagination: Contracts.Search.Pagination,
         sorting: Contracts.Search.Sorting,
         ...criterias: WalletCriteria[]
-    ): Contracts.Search.ResultsPage<WalletResource> {
+    ): Promise<Contracts.Search.ResultsPage<WalletResource>> {
         sorting = [...sorting, { property: "balance", direction: "desc" }];
 
         return this.paginationService.getPage(pagination, sorting, this.getActiveWallets(...criterias));

--- a/packages/database/src/defaults.ts
+++ b/packages/database/src/defaults.ts
@@ -1,4 +1,5 @@
 export const defaults = {
+    apiConnectionTimeout: 3000,
     connection: {
         database: `${process.env.CORE_TOKEN}_${process.env.CORE_NETWORK_NAME}`,
         entityPrefix: "public.",

--- a/packages/database/src/service-provider.ts
+++ b/packages/database/src/service-provider.ts
@@ -24,25 +24,63 @@ export class ServiceProvider extends Providers.ServiceProvider {
 
         this.logger.info(`Connecting to database: ${(this.config().all().connection as any).database}`);
 
-        this.app.bind(Container.Identifiers.DatabaseConnection).toConstantValue(await this.connect());
+        this.app
+            .bind(Container.Identifiers.DatabaseConnection)
+            .toConstantValue(
+                await this.connect("api", {
+                    options: `-c statement_timeout=${this.config().getRequired("apiConnectionTimeout")}ms`,
+                }),
+            )
+            .when(Container.Selectors.anyAncestorOrTargetTaggedFirst("connection", "api"));
+        this.app
+            .bind(Container.Identifiers.DatabaseConnection)
+            .toConstantValue(await this.connect())
+            .when(Container.Selectors.noAncestorOrTargetTagged("connection"));
 
         this.logger.debug("Connection established");
 
-        this.app.bind(Container.Identifiers.DatabaseRoundRepository).toConstantValue(this.getRoundRepository());
+        this.app
+            .bind(Container.Identifiers.DatabaseRoundRepository)
+            .toConstantValue(this.getRoundRepository("api"))
+            .when(Container.Selectors.anyAncestorOrTargetTaggedFirst("connection", "api"));
+        this.app
+            .bind(Container.Identifiers.DatabaseRoundRepository)
+            .toConstantValue(this.getRoundRepository())
+            .when(Container.Selectors.noAncestorOrTargetTagged("connection"));
 
-        this.app.bind(Container.Identifiers.DatabaseBlockRepository).toConstantValue(this.getBlockRepository());
-        this.app.bind(Container.Identifiers.DatabaseBlockFilter).to(BlockFilter);
-        this.app.bind(Container.Identifiers.BlockHistoryService).to(BlockHistoryService);
+        this.app
+            .bind(Container.Identifiers.DatabaseBlockRepository)
+            .toConstantValue(this.getBlockRepository("api"))
+            .when(Container.Selectors.anyAncestorOrTargetTaggedFirst("connection", "api"));
+        this.app
+            .bind(Container.Identifiers.DatabaseBlockRepository)
+            .toConstantValue(this.getBlockRepository())
+            .when(Container.Selectors.noAncestorOrTargetTagged("connection"));
 
         this.app
             .bind(Container.Identifiers.DatabaseMissedBlockRepository)
-            .toConstantValue(this.getMissedBlockRepository());
-        this.app.bind(Container.Identifiers.DatabaseMissedBlockFilter).to(MissedBlockFilter);
-        this.app.bind(Container.Identifiers.MissedBlockHistoryService).to(MissedBlockHistoryService);
+            .toConstantValue(this.getMissedBlockRepository("api"))
+            .when(Container.Selectors.anyAncestorOrTargetTaggedFirst("connection", "api"));
+        this.app
+            .bind(Container.Identifiers.DatabaseMissedBlockRepository)
+            .toConstantValue(this.getMissedBlockRepository())
+            .when(Container.Selectors.noAncestorOrTargetTagged("connection"));
 
         this.app
             .bind(Container.Identifiers.DatabaseTransactionRepository)
-            .toConstantValue(this.getTransactionRepository());
+            .toConstantValue(this.getTransactionRepository("api"))
+            .when(Container.Selectors.anyAncestorOrTargetTaggedFirst("connection", "api"));
+        this.app
+            .bind(Container.Identifiers.DatabaseTransactionRepository)
+            .toConstantValue(this.getTransactionRepository())
+            .when(Container.Selectors.noAncestorOrTargetTagged("connection"));
+
+        this.app.bind(Container.Identifiers.DatabaseBlockFilter).to(BlockFilter);
+        this.app.bind(Container.Identifiers.BlockHistoryService).to(BlockHistoryService);
+
+        this.app.bind(Container.Identifiers.DatabaseMissedBlockFilter).to(MissedBlockFilter);
+        this.app.bind(Container.Identifiers.MissedBlockHistoryService).to(MissedBlockHistoryService);
+
         this.app.bind(Container.Identifiers.DatabaseTransactionFilter).to(TransactionFilter);
         this.app.bind(Container.Identifiers.TransactionHistoryService).to(TransactionHistoryService);
 
@@ -63,7 +101,7 @@ export class ServiceProvider extends Providers.ServiceProvider {
         return true;
     }
 
-    public async connect(): Promise<Connection> {
+    public async connect(connectionName = "default", extra = {}): Promise<Connection> {
         const connection: Record<string, any> = this.config().all().connection as any;
         this.app
             .get<Contracts.Kernel.EventDispatcher>(Container.Identifiers.EventDispatcherService)
@@ -88,7 +126,7 @@ export class ServiceProvider extends Providers.ServiceProvider {
                 }
             }
 
-            if (startPostgres) {
+            if (connectionName === "default" && startPostgres) {
                 chmodSync(connection.extra.host, "700");
                 sync(`${process.env.POSTGRES_DIR}/bin/pg_ctl -D ${connection.extra.host} start >/dev/null`, {
                     shell: true,
@@ -100,10 +138,11 @@ export class ServiceProvider extends Providers.ServiceProvider {
 
         const dbConnection: Connection = await createConnection({
             ...(connection as any),
-            extra: Object.assign(connection.extra, { logger: this.logger }),
+            extra: Object.assign(connection.extra, { ...extra, logger: this.logger }),
             namingStrategy: new SnakeNamingStrategy(),
             migrations: [__dirname + "/migrations/*.js"],
-            migrationsRun: true,
+            migrationsRun: connectionName === "default",
+            name: connectionName,
             entities: [__dirname + "/models/*.js"],
         });
 
@@ -133,24 +172,25 @@ export class ServiceProvider extends Providers.ServiceProvider {
         return dbConnection;
     }
 
-    public getRoundRepository(): RoundRepository {
-        return getCustomRepository(RoundRepository);
+    public getRoundRepository(connectionName = "default"): RoundRepository {
+        return getCustomRepository(RoundRepository, connectionName);
     }
 
-    public getBlockRepository(): BlockRepository {
-        return getCustomRepository(BlockRepository);
+    public getBlockRepository(connectionName = "default"): BlockRepository {
+        return getCustomRepository(BlockRepository, connectionName);
     }
 
-    public getMissedBlockRepository(): MissedBlockRepository {
-        return getCustomRepository(MissedBlockRepository);
+    public getMissedBlockRepository(connectionName = "default"): MissedBlockRepository {
+        return getCustomRepository(MissedBlockRepository, connectionName);
     }
 
-    public getTransactionRepository(): TransactionRepository {
-        return getCustomRepository(TransactionRepository);
+    public getTransactionRepository(connectionName = "default"): TransactionRepository {
+        return getCustomRepository(TransactionRepository, connectionName);
     }
 
     public configSchema(): object {
         return Joi.object({
+            apiConnectionTimeout: Joi.number().integer().min(1).required(),
             connection: Joi.object({
                 database: Joi.string().required(),
                 entityPrefix: Joi.string().required(),

--- a/packages/kernel/src/ioc/selectors.ts
+++ b/packages/kernel/src/ioc/selectors.ts
@@ -20,3 +20,21 @@ export const anyAncestorOrTargetTaggedFirst = (
         }
     };
 };
+
+export const noAncestorOrTargetTagged = (key: string | number | symbol): ((req: interfaces.Request) => boolean) => {
+    return (req: interfaces.Request) => {
+        for (;;) {
+            const targetTags = req.target.getCustomTags();
+            if (targetTags) {
+                const targetTag = targetTags.find((t) => t.key === key);
+                if (targetTag) {
+                    return false;
+                }
+            }
+            if (!req.parentRequest) {
+                return true;
+            }
+            req = req.parentRequest;
+        }
+    };
+};

--- a/packages/kernel/src/services/search/pagination-service.ts
+++ b/packages/kernel/src/services/search/pagination-service.ts
@@ -11,13 +11,13 @@ export class PaginationService {
         return { results: [], totalCount: 0, meta: { totalCountIsEstimate: false } };
     }
 
-    public getPage<T>(pagination: Pagination, sorting: Sorting, items: Iterable<T>): ResultsPage<T> {
+    public async getPage<T>(pagination: Pagination, sorting: Sorting, items: Iterable<T>): Promise<ResultsPage<T>> {
         const all = Array.from(items);
 
         const results =
             sorting.length === 0
                 ? all.slice(pagination.offset, pagination.offset + pagination.limit)
-                : this.getTop(sorting, pagination.offset + pagination.limit, all).slice(pagination.offset);
+                : (await this.getTop(sorting, pagination.offset + pagination.limit, all)).slice(pagination.offset);
 
         return {
             results,
@@ -26,7 +26,7 @@ export class PaginationService {
         };
     }
 
-    public getTop<T>(sorting: Sorting, count: number, items: Iterable<T>): T[] {
+    public async getTop<T>(sorting: Sorting, count: number, items: Iterable<T>): Promise<T[]> {
         if (count < 0) {
             throw new RangeError(`Count should be greater or equal than zero`);
         }
@@ -41,6 +41,12 @@ export class PaginationService {
 
         let i = 0;
         for (const item of items) {
+            if (i % 1000 === 0) {
+                await new Promise<void>((resolve) => {
+                    setImmediate(() => resolve());
+                });
+            }
+
             const key = {
                 index: i++,
                 item: item,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -119,6 +119,7 @@ importers:
       '@types/hapi__nes': 11.0.5
       '@types/ip': 1.1.0
       '@types/qs': 6.9.7
+      '@types/semaphore': 1.1.1
       '@types/semver': 6.2.3
       joi: 17.6.0
       lodash.clonedeep: 4.5.0
@@ -126,6 +127,7 @@ importers:
       node-cache: 5.1.2
       qs: 6.10.3
       rate-limiter-flexible: 1.3.2
+      semaphore: 1.1.0
       semver: 6.3.0
     dependencies:
       '@hapi/boom': 9.1.4
@@ -142,6 +144,7 @@ importers:
       node-cache: 5.1.2
       qs: 6.10.3
       rate-limiter-flexible: 1.3.2
+      semaphore: 1.1.0
       semver: 6.3.0
     devDependencies:
       '@types/hapi__boom': 7.4.1
@@ -150,6 +153,7 @@ importers:
       '@types/hapi__nes': 11.0.5
       '@types/ip': 1.1.0
       '@types/qs': 6.9.7
+      '@types/semaphore': 1.1.1
       '@types/semver': 6.2.3
       lodash.clonedeep: 4.5.0
 
@@ -4863,6 +4867,10 @@ packages:
     dependencies:
       '@types/node': 18.7.14
     dev: false
+
+  /@types/semaphore/1.1.1:
+    resolution: {integrity: sha512-jmFpMslMtBGOXY2s7x6O8vBebcj6zhkwl0Pd/viZApo1uZaPk733P8doPvaiBbCG+R7201OLOl4QP7l1mFyuyw==}
+    dev: true
 
   /@types/semver/6.2.3:
     resolution: {integrity: sha512-KQf+QAMWKMrtBMsB8/24w53tEsxllMj6TuA80TT/5igJalLI/zm0L3oXRbIAl4Ohfc85gyHX/jhMwsVkmhLU4A==}
@@ -11619,6 +11627,11 @@ packages:
       elliptic: 6.5.4
       node-addon-api: 2.0.2
       node-gyp-build: 4.5.0
+    dev: false
+
+  /semaphore/1.1.0:
+    resolution: {integrity: sha512-O4OZEaNtkMd/K0i6js9SL+gqy0ZCBMgUvlSqHKi4IBdjhe7wB8pwztUk1BbZ1fmrvpwFrPbHzqd2w5pTcJH6LA==}
+    engines: {node: '>=0.8.0'}
     dev: false
 
   /semver-compare/1.0.0:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -793,7 +793,6 @@ packages:
       strip-ansi: 6.0.1
     transitivePeerDependencies:
       - zen-observable
-      - zenObservable
     dev: false
 
   /@alessiodf/ora/0.0.2:
@@ -3937,8 +3936,6 @@ packages:
       promise-retry: 2.0.1
       semver: 7.3.7
       which: 2.0.2
-    transitivePeerDependencies:
-      - bluebird
     dev: true
 
   /@npmcli/installed-package-contents/1.0.7:
@@ -4364,10 +4361,8 @@ packages:
       zen-observable:
         optional: true
     dependencies:
-      any-observable: 0.3.0_rxjs@7.5.5
+      any-observable: 0.3.0
       rxjs: 7.5.5
-    transitivePeerDependencies:
-      - zenObservable
     dev: false
 
   /@scure/base/1.1.1:
@@ -5429,19 +5424,9 @@ packages:
     resolution: {integrity: sha512-QXu7BPrP29VllRxH8GwB7x5iX5qWKAAMLqKQGWTeLWVlNHNOpVMJ91dsxQAIWXpjuW5wqvxu3Jd/nRjrJ+0pqg==}
     dev: true
 
-  /any-observable/0.3.0_rxjs@7.5.5:
+  /any-observable/0.3.0:
     resolution: {integrity: sha512-/FQM1EDkTsf63Ub2C6O7GuYFDsSXUwsaZDurV0np41ocwq0jthUAYCmhBX9f+KwlaCgIuWyr/4WlUQUBfKfZog==}
     engines: {node: '>=6'}
-    peerDependencies:
-      rxjs: '*'
-      zenObservable: '*'
-    peerDependenciesMeta:
-      rxjs:
-        optional: true
-      zenObservable:
-        optional: true
-    dependencies:
-      rxjs: 7.5.5
     dev: false
 
   /any-promise/1.3.0:
@@ -5914,8 +5899,6 @@ packages:
       raw-body: 2.5.1
       type-is: 1.6.18
       unpipe: 1.0.0
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /boxen/5.1.2:
@@ -6130,8 +6113,6 @@ packages:
       ssri: 8.0.1
       tar: 6.1.11
       unique-filename: 1.1.1
-    transitivePeerDependencies:
-      - bluebird
     dev: true
 
   /cache-base/1.0.1:
@@ -6824,11 +6805,6 @@ packages:
 
   /debug/2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
     dependencies:
       ms: 2.0.0
     dev: false
@@ -7523,10 +7499,6 @@ packages:
       servify: 0.1.12
       ws: 3.3.3
       xhr-request-promise: 0.1.3
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
     dev: false
 
   /eth-lib/0.2.8:
@@ -7747,8 +7719,6 @@ packages:
       type-is: 1.6.18
       utils-merge: 1.0.1
       vary: 1.1.2
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /ext/1.7.0:
@@ -7892,8 +7862,6 @@ packages:
       parseurl: 1.3.3
       statuses: 2.0.1
       unpipe: 1.0.0
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /find-cache-dir/3.3.2:
@@ -9562,7 +9530,6 @@ packages:
       socks-proxy-agent: 6.2.1
       ssri: 8.0.1
     transitivePeerDependencies:
-      - bluebird
       - supports-color
     dev: true
 
@@ -10006,8 +9973,6 @@ packages:
       regex-not: 1.0.2
       snapdragon: 0.8.2
       to-regex: 3.0.2
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /napi-build-utils/1.0.2:
@@ -10242,7 +10207,6 @@ packages:
       spawn-please: 1.0.0
       update-notifier: 5.1.0
     transitivePeerDependencies:
-      - bluebird
       - supports-color
     dev: true
 
@@ -10297,7 +10261,6 @@ packages:
       minizlib: 2.1.2
       npm-package-arg: 8.1.5
     transitivePeerDependencies:
-      - bluebird
       - supports-color
     dev: true
 
@@ -10559,7 +10522,6 @@ packages:
       ssri: 8.0.1
       tar: 6.1.11
     transitivePeerDependencies:
-      - bluebird
       - supports-color
     dev: true
 
@@ -10951,11 +10913,6 @@ packages:
 
   /promise-inflight/1.0.1:
     resolution: {integrity: sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==}
-    peerDependencies:
-      bluebird: '*'
-    peerDependenciesMeta:
-      bluebird:
-        optional: true
     dev: true
 
   /promise-retry/2.0.1:
@@ -11724,8 +11681,6 @@ packages:
       on-finished: 2.4.1
       range-parser: 1.2.1
       statuses: 2.0.1
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /serialize-javascript/6.0.0:
@@ -11742,8 +11697,6 @@ packages:
       escape-html: 1.0.3
       parseurl: 1.3.3
       send: 0.18.0
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /servify/0.1.12:
@@ -11755,8 +11708,6 @@ packages:
       express: 4.18.1
       request: 2.88.2
       xhr: 2.6.0
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /set-blocking/2.0.0:
@@ -11904,8 +11855,6 @@ packages:
       source-map: 0.5.7
       source-map-resolve: 0.5.3
       use: 3.1.1
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /socks-proxy-agent/6.2.1:
@@ -12248,10 +12197,6 @@ packages:
       setimmediate: 1.0.5
       tar: 4.4.19
       xhr-request: 1.1.0
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
     dev: false
 
   /tapable/2.2.1:
@@ -12876,10 +12821,6 @@ packages:
       '@types/node': 12.20.55
       got: 11.8.5
       swarm-js: 0.1.40
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
     dev: false
 
   /web3-core-helpers/1.7.1:
@@ -12917,8 +12858,6 @@ packages:
       web3-providers-http: 1.7.1
       web3-providers-ipc: 1.7.1
       web3-providers-ws: 1.7.1
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /web3-core-subscriptions/1.7.1:
@@ -12940,8 +12879,6 @@ packages:
       web3-core-method: 1.7.1
       web3-core-requestmanager: 1.7.1
       web3-utils: 1.7.1
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /web3-eth-abi/1.7.1:
@@ -12967,8 +12904,6 @@ packages:
       web3-core-helpers: 1.7.1
       web3-core-method: 1.7.1
       web3-utils: 1.7.1
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /web3-eth-contract/1.7.1:
@@ -12983,8 +12918,6 @@ packages:
       web3-core-subscriptions: 1.7.1
       web3-eth-abi: 1.7.1
       web3-utils: 1.7.1
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /web3-eth-ens/1.7.1:
@@ -12999,8 +12932,6 @@ packages:
       web3-eth-abi: 1.7.1
       web3-eth-contract: 1.7.1
       web3-utils: 1.7.1
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /web3-eth-iban/1.7.1:
@@ -13021,8 +12952,6 @@ packages:
       web3-core-method: 1.7.1
       web3-net: 1.7.1
       web3-utils: 1.7.1
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /web3-eth/1.7.1:
@@ -13041,8 +12970,6 @@ packages:
       web3-eth-personal: 1.7.1
       web3-net: 1.7.1
       web3-utils: 1.7.1
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /web3-net/1.7.1:
@@ -13052,8 +12979,6 @@ packages:
       web3-core: 1.7.1
       web3-core-method: 1.7.1
       web3-utils: 1.7.1
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /web3-providers-http/1.7.1:
@@ -13079,8 +13004,6 @@ packages:
       eventemitter3: 4.0.4
       web3-core-helpers: 1.7.1
       websocket: 1.0.34
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /web3-shh/1.7.1:
@@ -13092,8 +13015,6 @@ packages:
       web3-core-method: 1.7.1
       web3-core-subscriptions: 1.7.1
       web3-net: 1.7.1
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /web3-utils/1.7.1:
@@ -13121,10 +13042,6 @@ packages:
       web3-net: 1.7.1
       web3-shh: 1.7.1
       web3-utils: 1.7.1
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
     dev: false
 
   /webidl-conversions/3.0.1:
@@ -13186,8 +13103,6 @@ packages:
       typedarray-to-buffer: 3.1.5
       utf-8-validate: 5.0.9
       yaeti: 0.0.6
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /whatwg-url/5.0.0:
@@ -13296,14 +13211,6 @@ packages:
 
   /ws/3.3.3:
     resolution: {integrity: sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==}
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: ^5.0.2
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
     dependencies:
       async-limiter: 1.0.1
       safe-buffer: 5.1.2


### PR DESCRIPTION
This PR implements some upstream database and Public API performance improvements. It is a composite of the following upstream pull requests:

ArkEcosystem/core#4760
ArkEcosystem/core#4761
ArkEcosystem/core#4764
ArkEcosystem/core#4772
ArkEcosystem/core#4773

We have diverged from the upstream implementation of the second database connection for the Public API in order to prevent a breaking change affecting existing Core plugins that use database repositories. The upstream approach introduces the requirement for a `default` tag when injecting database repositories outside of the Public API, but ours does not require any tag when used outside of the Public API so existing Core plugins that use database repositories should continue to work normally without needing any changes.