### PR TITLE
feat: only allow votes in pool for block producers running nodes

### DIFF
--- a/packages/blockchain/src/state-machine/actions/syncing-complete.ts
+++ b/packages/blockchain/src/state-machine/actions/syncing-complete.ts
@@ -1,4 +1,4 @@
-import { Container, Contracts, Enums } from "@solar-network/kernel";
+import { Container, Contracts, Enums, Utils as AppUtils } from "@solar-network/kernel";
 
 import { Action } from "../contracts";
 
@@ -16,8 +16,28 @@ export class SyncingComplete implements Action {
     @Container.inject(Container.Identifiers.BlockchainService)
     private readonly blockchain!: Contracts.Blockchain.Blockchain;
 
+    @Container.inject(Container.Identifiers.WalletRepository)
+    @Container.tagged("state", "blockchain")
+    private readonly walletRepository!: Contracts.State.WalletRepository;
+
     public async handle(): Promise<void> {
         this.logger.info("Blockchain 100% in sync :100:");
+
+        const roundInfo: Contracts.Shared.RoundInfo = AppUtils.roundCalculator.calculateRound(
+            this.blockchain.getLastHeight(),
+        );
+        const ourKeys: string[] = AppUtils.getForgerDelegates();
+
+        for (const wallet of this.walletRepository.allByUsername()) {
+            if (wallet.hasPublicKey() && ourKeys.includes(wallet.getPublicKey()!)) {
+                wallet.setAttribute("delegate.version", { round: roundInfo.round, version: this.app.version() });
+            } else if (wallet.hasAttribute("delegate.version")) {
+                const { round } = wallet.getAttribute("delegate.version");
+                if (!round || round < roundInfo.round - 5) {
+                    wallet.forgetAttribute("delegate.version");
+                }
+            }
+        }
 
         this.events.dispatch(Enums.BlockchainEvent.Synced);
         this.blockchain.dispatch("SYNCFINISHED");

--- a/packages/kernel/src/contracts/p2p/network-monitor.ts
+++ b/packages/kernel/src/contracts/p2p/network-monitor.ts
@@ -1,6 +1,7 @@
 import { Interfaces } from "@solar-network/crypto";
 
 import { Application } from "../kernel";
+import { WalletRepository } from "../state";
 import { NetworkState } from "./network-state";
 
 export interface NetworkStatus {
@@ -15,6 +16,7 @@ export interface IRateLimitStatus {
 
 export interface NetworkMonitor {
     app: Application;
+    walletRepository: WalletRepository;
     boot(): Promise<void>;
     updateNetworkStatus(initialRun?: boolean): Promise<void>;
     cleansePeers({

--- a/packages/kernel/src/contracts/p2p/peer.ts
+++ b/packages/kernel/src/contracts/p2p/peer.ts
@@ -1,5 +1,7 @@
 import { Dayjs } from "dayjs";
 
+import { WalletRepository } from "../state";
+
 export interface PeerPorts {
     [name: string]: number;
 }
@@ -30,7 +32,7 @@ export interface Peer {
     fastVerificationResult: FastPeerVerificationResult | undefined;
 
     addInfraction(): void;
-    isActiveDelegate(): boolean;
+    activeDelegates(walletRepository: WalletRepository): string[];
     isIgnored(): boolean;
     isVerified(): boolean;
     isForked(): boolean;

--- a/packages/p2p/src/network-monitor.ts
+++ b/packages/p2p/src/network-monitor.ts
@@ -19,6 +19,10 @@ export class NetworkMonitor implements Contracts.P2P.NetworkMonitor {
     @Container.inject(Container.Identifiers.Application)
     public readonly app!: Contracts.Kernel.Application;
 
+    @Container.inject(Container.Identifiers.WalletRepository)
+    @Container.tagged("state", "blockchain")
+    public readonly walletRepository!: Contracts.State.WalletRepository;
+
     @Container.inject(Container.Identifiers.PluginConfiguration)
     @Container.tagged("plugin", "@solar-network/p2p")
     private readonly configuration!: Providers.PluginConfiguration;
@@ -43,10 +47,6 @@ export class NetworkMonitor implements Contracts.P2P.NetworkMonitor {
 
     @Container.inject(Container.Identifiers.TriggerService)
     private readonly triggers!: Services.Triggers.Triggers;
-
-    @Container.inject(Container.Identifiers.WalletRepository)
-    @Container.tagged("state", "blockchain")
-    private readonly walletRepository!: Contracts.State.WalletRepository;
 
     public config: any;
     public nextUpdateNetworkStatusScheduled: boolean | undefined;
@@ -369,8 +369,9 @@ export class NetworkMonitor implements Contracts.P2P.NetworkMonitor {
         peers.push(localPeer);
 
         for (const peer of peers) {
-            if (peer.isActiveDelegate()) {
-                for (let i = 0; i < peer.publicKeys.length; i++) {
+            const activeDelegates: string[] = peer.activeDelegates(this.walletRepository);
+            if (activeDelegates.length > 0) {
+                for (let i = 0; i < activeDelegates.length; i++) {
                     includedPeers.push(peer);
                 }
             } else if (peer.state && peer.state.height! > lastBlock.data.height) {

--- a/packages/p2p/src/peer.ts
+++ b/packages/p2p/src/peer.ts
@@ -1,3 +1,4 @@
+import { Managers } from "@solar-network/crypto";
 import { Contracts } from "@solar-network/kernel";
 import dayjs, { Dayjs } from "dayjs";
 
@@ -128,8 +129,19 @@ export class Peer implements Contracts.P2P.Peer {
      * @returns {boolean}
      * @memberof Peer
      */
-    public isActiveDelegate(): boolean {
-        return this.publicKeys.length > 0;
+    public activeDelegates(walletRepository: Contracts.State.WalletRepository): string[] {
+        const { activeDelegates } = Managers.configManager.getMilestone();
+        return this.publicKeys.filter((publicKey: string) => {
+            if (walletRepository.hasByPublicKey(publicKey)) {
+                const wallet: Contracts.State.Wallet = walletRepository.findByPublicKey(publicKey);
+                if (wallet.hasAttribute("delegate.rank")) {
+                    const rank: number = wallet.getAttribute("delegate.rank");
+                    return rank <= activeDelegates;
+                }
+            }
+
+            return false;
+        });
     }
 
     /**

--- a/packages/state/src/round-state.ts
+++ b/packages/state/src/round-state.ts
@@ -187,6 +187,19 @@ export class RoundState implements Contracts.State.RoundState {
 
             this.blocksInCurrentRound = [];
 
+            const ourKeys: string[] = AppUtils.getForgerDelegates();
+
+            for (const wallet of this.walletRepository.allByUsername()) {
+                if (wallet.hasPublicKey() && ourKeys.includes(wallet.getPublicKey()!)) {
+                    wallet.setAttribute("delegate.version", { round: roundInfo.round, version: this.app.version() });
+                } else if (wallet.hasAttribute("delegate.version")) {
+                    const { round } = wallet.getAttribute("delegate.version");
+                    if (!round || round < roundInfo.round - 5) {
+                        wallet.forgetAttribute("delegate.version");
+                    }
+                }
+            }
+
             this.events.dispatch(Enums.RoundEvent.Applied);
         }
     }

--- a/packages/transactions/src/handlers/solar/vote.ts
+++ b/packages/transactions/src/handlers/solar/vote.ts
@@ -116,6 +116,21 @@ export class VoteTransactionHandler extends TransactionHandler {
                 "ERR_PENDING",
             );
         }
+
+        AppUtils.assert.defined<string[]>(transaction.data.asset?.votes);
+        const votes = Object.keys(transaction.data.asset.votes);
+
+        for (const delegate of votes) {
+            if (this.walletRepository.hasByUsername(delegate)) {
+                const wallet = this.walletRepository.findByUsername(delegate);
+                if (!wallet.hasAttribute("delegate.version")) {
+                    throw new Contracts.Pool.PoolError(
+                        `${delegate} is not operating a node on the network`,
+                        "ERR_OFFLINE",
+                    );
+                }
+            }
+        }
     }
 
     public async applyToSender(transaction: Interfaces.ITransaction): Promise<void> {


### PR DESCRIPTION
This PR prevents votes for offline block producers being accepted in the pool. Each voted block producer is checked against the node's peer list to ensure it is signalling that it is online with a valid `version`. If no `version` is present, the block producer is considered to be offline and the vote transaction is rejected in the pool.

The `version` is updated every round and removed if it is more than 5 rounds old.

This also means that all block producers now signal a `version` if they are online, rather than the previous behaviour where only the active top 53 block producers did so.