### PR TITLE
release: mainnet 4.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
         "typescript": "4.4.4",
         "typesync": "0.8.0",
         "uuid": "8.3.2",
-        "webpack": "5.73.0"
+        "webpack": "5.80.0"
     },
     "workspaces": [
         "packages/*",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/api",
-    "version": "4.3.0-next.2",
+    "version": "4.3.0",
     "description": "Public API for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/api",
-    "version": "4.2.1",
+    "version": "4.2.2-next.0",
     "description": "Public API for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/api",
-    "version": "4.3.0-next.0",
+    "version": "4.3.0-next.1",
     "description": "Public API for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/api",
-    "version": "4.3.0-next.1",
+    "version": "4.3.0-next.2",
     "description": "Public API for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/api",
-    "version": "4.2.2-next.0",
+    "version": "4.3.0-next.0",
     "description": "Public API for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -33,6 +33,7 @@
         "node-cache": "5.1.2",
         "qs": "6.10.3",
         "rate-limiter-flexible": "1.3.2",
+        "semaphore": "1.1.0",
         "semver": "6.3.0"
     },
     "devDependencies": {
@@ -42,6 +43,7 @@
         "@types/hapi__nes": "11.0.5",
         "@types/ip": "1.1.0",
         "@types/qs": "6.9.7",
+        "@types/semaphore": "1.1.1",
         "@types/semver": "6.2.3",
         "lodash.clonedeep": "4.5.0"
     }

--- a/packages/api/src/controllers/blockchain.ts
+++ b/packages/api/src/controllers/blockchain.ts
@@ -10,15 +10,18 @@ import { Controller } from "./controller";
 
 export class BlockchainController extends Controller {
     @Container.inject(Container.Identifiers.BlockHistoryService)
+    @Container.tagged("connection", "api")
     private readonly blockHistoryService!: Contracts.Shared.BlockHistoryService;
 
     @Container.inject(Container.Identifiers.StateStore)
     private readonly stateStore!: Contracts.State.StateStore;
 
     @Container.inject(Container.Identifiers.TransactionHistoryService)
+    @Container.tagged("connection", "api")
     private readonly transactionHistoryService!: Contracts.Shared.TransactionHistoryService;
 
     @Container.inject(Container.Identifiers.DatabaseTransactionRepository)
+    @Container.tagged("connection", "api")
     private readonly transactionRepository!: Repositories.TransactionRepository;
 
     @Container.inject(Container.Identifiers.WalletRepository)

--- a/packages/api/src/controllers/blocks.ts
+++ b/packages/api/src/controllers/blocks.ts
@@ -12,12 +12,15 @@ export class BlocksController extends Controller {
     private readonly blockchain!: Contracts.Blockchain.Blockchain;
 
     @Container.inject(Container.Identifiers.BlockHistoryService)
+    @Container.tagged("connection", "api")
     private readonly blockHistoryService!: Contracts.Shared.BlockHistoryService;
 
     @Container.inject(Container.Identifiers.MissedBlockHistoryService)
+    @Container.tagged("connection", "api")
     private readonly missedBlockHistoryService!: Contracts.Shared.MissedBlockHistoryService;
 
     @Container.inject(Container.Identifiers.TransactionHistoryService)
+    @Container.tagged("connection", "api")
     private readonly transactionHistoryService!: Contracts.Shared.TransactionHistoryService;
 
     public async index(request: Hapi.Request, h: Hapi.ResponseToolkit): Promise<object> {

--- a/packages/api/src/controllers/delegates.ts
+++ b/packages/api/src/controllers/delegates.ts
@@ -32,7 +32,10 @@ export class DelegatesController extends Controller {
     @Container.tagged("connection", "api")
     private readonly missedBlockHistoryService!: Contracts.Shared.MissedBlockHistoryService;
 
-    public index(request: Hapi.Request, h: Hapi.ResponseToolkit): Contracts.Search.ResultsPage<DelegateResource> {
+    public async index(
+        request: Hapi.Request,
+        h: Hapi.ResponseToolkit,
+    ): Promise<Contracts.Search.ResultsPage<DelegateResource>> {
         const pagination = this.getQueryPagination(request.query);
         const sorting = request.query.orderBy as Contracts.Search.Sorting;
         const criteria = this.getQueryCriteria(request.query, delegateCriteriaSchemaObject) as DelegateCriteria;
@@ -56,7 +59,10 @@ export class DelegatesController extends Controller {
         return { data: delegateResource };
     }
 
-    public voters(request: Hapi.Request, h: Hapi.ResponseToolkit): Contracts.Search.ResultsPage<WalletResource> | Boom {
+    public async voters(
+        request: Hapi.Request,
+        h: Hapi.ResponseToolkit,
+    ): Promise<Contracts.Search.ResultsPage<WalletResource> | Boom> {
         const walletId = request.params.id as string;
 
         const walletResource = this.walletSearchService.getWallet(walletId);

--- a/packages/api/src/controllers/delegates.ts
+++ b/packages/api/src/controllers/delegates.ts
@@ -25,9 +25,11 @@ export class DelegatesController extends Controller {
     private readonly walletSearchService!: WalletSearchService;
 
     @Container.inject(Container.Identifiers.BlockHistoryService)
+    @Container.tagged("connection", "api")
     private readonly blockHistoryService!: Contracts.Shared.BlockHistoryService;
 
     @Container.inject(Container.Identifiers.MissedBlockHistoryService)
+    @Container.tagged("connection", "api")
     private readonly missedBlockHistoryService!: Contracts.Shared.MissedBlockHistoryService;
 
     public index(request: Hapi.Request, h: Hapi.ResponseToolkit): Contracts.Search.ResultsPage<DelegateResource> {

--- a/packages/api/src/controllers/locks.ts
+++ b/packages/api/src/controllers/locks.ts
@@ -21,6 +21,7 @@ export class LocksController extends Controller {
     private readonly lockSearchService!: LockSearchService;
 
     @Container.inject(Container.Identifiers.TransactionHistoryService)
+    @Container.tagged("connection", "api")
     private readonly transactionHistoryService!: Contracts.Shared.TransactionHistoryService;
 
     public index(request: Hapi.Request, h: Hapi.ResponseToolkit): Contracts.Search.ResultsPage<LockResource> {

--- a/packages/api/src/controllers/locks.ts
+++ b/packages/api/src/controllers/locks.ts
@@ -24,7 +24,10 @@ export class LocksController extends Controller {
     @Container.tagged("connection", "api")
     private readonly transactionHistoryService!: Contracts.Shared.TransactionHistoryService;
 
-    public index(request: Hapi.Request, h: Hapi.ResponseToolkit): Contracts.Search.ResultsPage<LockResource> {
+    public async index(
+        request: Hapi.Request,
+        h: Hapi.ResponseToolkit,
+    ): Promise<Contracts.Search.ResultsPage<LockResource>> {
         const pagination = this.getQueryPagination(request.query);
         const sorting = request.query.orderBy as Contracts.Search.Sorting;
         const criteria = this.getQueryCriteria(request.query, lockCriteriaSchemaObject) as LockCriteria;

--- a/packages/api/src/controllers/node.ts
+++ b/packages/api/src/controllers/node.ts
@@ -27,6 +27,7 @@ export class NodeController extends Controller {
     private readonly networkMonitor!: Contracts.P2P.NetworkMonitor;
 
     @Container.inject(Container.Identifiers.DatabaseTransactionRepository)
+    @Container.tagged("connection", "api")
     private readonly transactionRepository!: Repositories.TransactionRepository;
 
     public async status(

--- a/packages/api/src/controllers/rounds.ts
+++ b/packages/api/src/controllers/rounds.ts
@@ -8,6 +8,7 @@ import { Controller } from "./controller";
 
 export class RoundsController extends Controller {
     @Container.inject(Container.Identifiers.DatabaseRoundRepository)
+    @Container.tagged("connection", "api")
     private readonly roundRepository!: Repositories.RoundRepository;
 
     public async delegates(request: Hapi.Request, h: Hapi.ResponseToolkit): Promise<object | Boom.Boom> {

--- a/packages/api/src/controllers/transactions.ts
+++ b/packages/api/src/controllers/transactions.ts
@@ -26,9 +26,11 @@ export class TransactionsController extends Controller {
     private readonly poolQuery!: Contracts.Pool.Query;
 
     @Container.inject(Container.Identifiers.TransactionHistoryService)
+    @Container.tagged("connection", "api")
     private readonly transactionHistoryService!: Contracts.Shared.TransactionHistoryService;
 
     @Container.inject(Container.Identifiers.BlockHistoryService)
+    @Container.tagged("connection", "api")
     private readonly blockHistoryService!: Contracts.Shared.BlockHistoryService;
 
     @Container.inject(Container.Identifiers.PoolProcessor)

--- a/packages/api/src/controllers/votes.ts
+++ b/packages/api/src/controllers/votes.ts
@@ -9,6 +9,7 @@ import { Controller } from "./controller";
 @Container.injectable()
 export class VotesController extends Controller {
     @Container.inject(Container.Identifiers.TransactionHistoryService)
+    @Container.tagged("connection", "api")
     private readonly transactionHistoryService!: Contracts.Shared.TransactionHistoryService;
 
     public async index(request: Hapi.Request, h: Hapi.ResponseToolkit): Promise<Contracts.Search.ResultsPage<object>> {

--- a/packages/api/src/controllers/wallets.ts
+++ b/packages/api/src/controllers/wallets.ts
@@ -28,6 +28,7 @@ export class WalletsController extends Controller {
     private readonly lockSearchService!: LockSearchService;
 
     @Container.inject(Container.Identifiers.TransactionHistoryService)
+    @Container.tagged("connection", "api")
     private readonly transactionHistoryService!: Contracts.Shared.TransactionHistoryService;
 
     public index(request: Hapi.Request, h: Hapi.ResponseToolkit): Contracts.Search.ResultsPage<WalletResource> {

--- a/packages/api/src/controllers/wallets.ts
+++ b/packages/api/src/controllers/wallets.ts
@@ -31,7 +31,10 @@ export class WalletsController extends Controller {
     @Container.tagged("connection", "api")
     private readonly transactionHistoryService!: Contracts.Shared.TransactionHistoryService;
 
-    public index(request: Hapi.Request, h: Hapi.ResponseToolkit): Contracts.Search.ResultsPage<WalletResource> {
+    public async index(
+        request: Hapi.Request,
+        h: Hapi.ResponseToolkit,
+    ): Promise<Contracts.Search.ResultsPage<WalletResource>> {
         const pagination = this.getQueryPagination(request.query);
         const sorting = request.query.orderBy as Contracts.Search.Sorting;
         const criteria = this.getQueryCriteria(request.query, walletCriteriaSchemaObject) as WalletCriteria;
@@ -39,7 +42,10 @@ export class WalletsController extends Controller {
         return this.walletSearchService.getWalletsPage(pagination, sorting, criteria);
     }
 
-    public top(request: Hapi.Request, h: Hapi.ResponseToolkit): Contracts.Search.ResultsPage<WalletResource> {
+    public async top(
+        request: Hapi.Request,
+        h: Hapi.ResponseToolkit,
+    ): Promise<Contracts.Search.ResultsPage<WalletResource>> {
         const pagination = this.getQueryPagination(request.query);
         const sorting = request.query.orderBy as Contracts.Search.Sorting;
         const criteria = this.getQueryCriteria(request.query, walletCriteriaSchemaObject) as WalletCriteria;
@@ -58,7 +64,10 @@ export class WalletsController extends Controller {
         return { data: walletResource };
     }
 
-    public locks(request: Hapi.Request, h: Hapi.ResponseToolkit): Contracts.Search.ResultsPage<LockResource> | Boom {
+    public async locks(
+        request: Hapi.Request,
+        h: Hapi.ResponseToolkit,
+    ): Promise<Contracts.Search.ResultsPage<LockResource> | Boom> {
         const walletId = request.params.id as string;
         const walletResource = this.walletSearchService.getWallet(walletId);
 

--- a/packages/api/src/defaults.ts
+++ b/packages/api/src/defaults.ts
@@ -27,6 +27,31 @@ export const defaults = {
             stdTTL: 8,
             checkperiod: 120,
         },
+        semaphore: {
+            enabled: !process.env.CORE_API_SEMAPHORE_DISABLED,
+            database: {
+                levelOne: {
+                    concurrency: 10,
+                    queueLimit: 100,
+                    maxOffset: 10000,
+                },
+                levelTwo: {
+                    concurrency: 1,
+                    queueLimit: 5,
+                },
+            },
+            memory: {
+                levelOne: {
+                    concurrency: 3,
+                    queueLimit: 30,
+                    maxOffset: 1000,
+                },
+                levelTwo: {
+                    concurrency: 1,
+                    queueLimit: 5,
+                },
+            },
+        },
         rateLimit: {
             enabled: !process.env.CORE_API_RATE_LIMIT_DISABLED,
             points: process.env.CORE_API_RATE_LIMIT_USER_LIMIT || 100,

--- a/packages/api/src/plugins/index.ts
+++ b/packages/api/src/plugins/index.ts
@@ -11,6 +11,7 @@ import { log } from "./log";
 import { pagination } from "./pagination";
 import { rateLimit } from "./rate-limit";
 import { responseHeaders } from "./response-headers";
+import { semaphore } from "./semaphore";
 import { whitelist } from "./whitelist";
 
 const isListed = (ip: string, patterns: string[]): boolean => {
@@ -79,6 +80,7 @@ export const preparePlugins = (config) => {
         },
         { plugin: commaArrayQuery },
         { plugin: dotSeparatedQuery },
+        { plugin: semaphore, options: config.semaphore },
         {
             plugin: cache,
             options: config.plugins.cache,

--- a/packages/api/src/plugins/semaphore.ts
+++ b/packages/api/src/plugins/semaphore.ts
@@ -1,0 +1,221 @@
+import Boom from "@hapi/boom";
+import Hapi from "@hapi/hapi";
+import makeSemaphore, { Semaphore } from "semaphore";
+
+type PluginOptions = {
+    enabled: boolean;
+    database: {
+        levelOne: LevelOneOptions;
+        levelTwo: LevelOptions;
+    };
+    memory: {
+        levelOne: LevelOneOptions;
+        levelTwo: LevelOptions;
+    };
+};
+
+type LevelOptions = {
+    concurrency: number;
+    queueLimit: number;
+};
+
+type LevelOneOptions = LevelOptions & {
+    maxOffset: number;
+};
+
+type QueryLevelOptions = {
+    field: string;
+    asc: boolean;
+    desc: boolean;
+    allowSecondOrderBy: boolean;
+    diverse: boolean;
+};
+
+type SemaphoreOptions = {
+    enabled: boolean;
+    type: "database" | "memory";
+    queryLevelOptions?: QueryLevelOptions[];
+};
+
+type FullSemaphoreOptions = Required<SemaphoreOptions>;
+
+enum Level {
+    One = 1,
+    Two = 2,
+}
+
+export const semaphore = {
+    name: "onPreHandler",
+    version: "1.0.0",
+    register(server: Hapi.Server, pluginOptions: PluginOptions): void {
+        if (!pluginOptions.enabled) {
+            return;
+        }
+
+        const semaphores = { database: new Map<Level, Semaphore>(), memory: new Map<Level, Semaphore>() };
+        semaphores.database.set(Level.One, makeSemaphore(pluginOptions.database.levelOne.concurrency));
+        semaphores.database.set(Level.Two, makeSemaphore(pluginOptions.database.levelTwo.concurrency));
+        semaphores.memory.set(Level.One, makeSemaphore(pluginOptions.memory.levelOne.concurrency));
+        semaphores.memory.set(Level.Two, makeSemaphore(pluginOptions.memory.levelTwo.concurrency));
+
+        const semaphoresConcurrency = { database: new Map<Level, number>(), memory: new Map<Level, number>() };
+        semaphoresConcurrency.database.set(Level.One, pluginOptions.database.levelOne.concurrency);
+        semaphoresConcurrency.database.set(Level.Two, pluginOptions.database.levelTwo.concurrency);
+        semaphoresConcurrency.memory.set(Level.One, pluginOptions.memory.levelOne.concurrency);
+        semaphoresConcurrency.memory.set(Level.Two, pluginOptions.memory.levelTwo.concurrency);
+
+        const semaphoresQueueLimit = { database: new Map<Level, number>(), memory: new Map<Level, number>() };
+        semaphoresQueueLimit.database.set(Level.One, pluginOptions.database.levelOne.queueLimit);
+        semaphoresQueueLimit.database.set(Level.Two, pluginOptions.database.levelTwo.queueLimit);
+        semaphoresQueueLimit.memory.set(Level.One, pluginOptions.memory.levelOne.queueLimit);
+        semaphoresQueueLimit.memory.set(Level.Two, pluginOptions.memory.levelTwo.queueLimit);
+
+        const requestLevels = new Map<Hapi.Request, Level>();
+
+        server.ext("onPreHandler", async (request: Hapi.Request, h: Hapi.ResponseToolkit) => {
+            const options = getRouteSemaphoreOptions(request);
+
+            if (options.enabled) {
+                const level = getLevel(request, options);
+                const sem = semaphores[options.type].get(level)!;
+
+                if (
+                    // @ts-ignore
+                    sem.queue.length(sem.current - semaphoresConcurrency[options.type].get(level)!) >=
+                    semaphoresQueueLimit[options.type].get(level)!
+                ) {
+                    return Boom.tooManyRequests();
+                }
+
+                requestLevels.set(request, level);
+
+                await new Promise<void>((resolve) => {
+                    sem.take(() => {
+                        resolve();
+                    });
+                });
+            }
+
+            return h.continue;
+        });
+
+        server.events.on("response", (request: Hapi.Request) => {
+            const options = getRouteSemaphoreOptions(request);
+
+            const level = requestLevels.get(request);
+
+            if (level) {
+                requestLevels.delete(request);
+                const sem = semaphores[options.type].get(level)!;
+
+                sem.leave();
+            }
+        });
+
+        const isFullSemaphoreOptions = (b: SemaphoreOptions): b is FullSemaphoreOptions => {
+            return !!b.queryLevelOptions;
+        };
+
+        const getLevel = (request: Hapi.Request, options: SemaphoreOptions): Level => {
+            if (isFullSemaphoreOptions(options)) {
+                if (usesDiverseIndex(request, options)) {
+                    return Level.One;
+                }
+
+                const levels = [
+                    orderByLevel(request, options),
+                    offsetLevel(request, options),
+                    queryLevel(request, options),
+                ];
+
+                return levels.includes(Level.Two) ? Level.Two : Level.One;
+            }
+
+            return offsetLevel(request, options);
+        };
+
+        const usesDiverseIndex = (request: Hapi.Request, options: FullSemaphoreOptions): boolean => {
+            const distributedIndices = options.queryLevelOptions
+                .filter((option) => option.diverse)
+                .map((option) => option.field);
+
+            for (const key of Object.keys(request.query)) {
+                if (distributedIndices.includes(key) && ["number", "string"].includes(typeof request.query[key])) {
+                    return true;
+                }
+            }
+
+            return false;
+        };
+
+        const orderByLevel = (request: Hapi.Request, options: FullSemaphoreOptions): Level => {
+            if (request.query.orderBy && request.query.orderBy.length) {
+                const orderBy = Array.isArray(request.query.orderBy) ? request.query.orderBy : [request.query.orderBy];
+
+                const [field, sortOrder]: [string, "asc" | "desc"] = orderBy[0].split(":");
+
+                const fieldOptions = options.queryLevelOptions.find((options) => options.field === field);
+
+                if (!fieldOptions) {
+                    return Level.Two;
+                }
+
+                if (!fieldOptions[sortOrder]) {
+                    return Level.Two;
+                }
+
+                if (!fieldOptions.allowSecondOrderBy && orderBy.length > 1) {
+                    return Level.Two;
+                }
+            }
+
+            return Level.One;
+        };
+
+        const offsetLevel = (request: Hapi.Request, options: SemaphoreOptions): Level => {
+            const offset = pluginOptions[options.type].levelOne.maxOffset;
+
+            if (request.query.offset && request.query.offset > offset) {
+                return Level.Two;
+            }
+
+            if (request.query.page && request.query.limit) {
+                if (request.query.page * request.query.limit > offset) {
+                    return Level.Two;
+                }
+            }
+
+            return Level.One;
+        };
+
+        const queryLevel = (request: Hapi.Request, options: FullSemaphoreOptions): Level => {
+            const reservedFields = ["page", "limit", "transform", "offset", "orderBy"];
+            const indices = options.queryLevelOptions.map((options) => options.field);
+
+            for (const key of Object.keys(request.query)) {
+                if (reservedFields.includes(key)) {
+                    continue;
+                }
+
+                if (!indices.includes(key)) {
+                    return Level.Two;
+                }
+            }
+
+            return Level.One;
+        };
+
+        const getRouteSemaphoreOptions = (request): SemaphoreOptions => {
+            const result: SemaphoreOptions = {
+                enabled: false,
+                type: "database",
+            };
+
+            if (request.route.settings.plugins.semaphore) {
+                return { ...result, ...request.route.settings.plugins.semaphore };
+            }
+
+            return result;
+        };
+    },
+};

--- a/packages/api/src/resources-new/block.ts
+++ b/packages/api/src/resources-new/block.ts
@@ -38,3 +38,15 @@ export const blockSortingSchemaWithoutUsernameOrGeneratorPublicKey = Schemas.cre
     [],
     false,
 );
+
+export const blockQueryLevelOptions = [
+    { field: "version", asc: true, desc: true, allowSecondOrderBy: false, diverse: false },
+    { field: "timestamp", asc: true, desc: true, allowSecondOrderBy: true, diverse: true },
+    { field: "height", asc: true, desc: true, allowSecondOrderBy: true, diverse: true },
+    { field: "numberOfTransactions", asc: true, desc: false, allowSecondOrderBy: false, diverse: false },
+    { field: "totalAmount", asc: true, desc: false, allowSecondOrderBy: false, diverse: false },
+    { field: "totalFee", asc: true, desc: false, allowSecondOrderBy: false, diverse: false },
+    { field: "reward", asc: true, desc: true, allowSecondOrderBy: false, diverse: false },
+    { field: "id", asc: false, desc: false, allowSecondOrderBy: false, diverse: true },
+    { field: "previousBlock", asc: false, desc: false, allowSecondOrderBy: false, diverse: true },
+];

--- a/packages/api/src/resources-new/missed-block.ts
+++ b/packages/api/src/resources-new/missed-block.ts
@@ -7,3 +7,9 @@ export const missedBlockSortingSchemaWithoutUsername = Schemas.createSortingSche
     [],
     false,
 );
+
+export const missedBlockQueryLevelOptions = [
+    { field: "timestamp", asc: true, desc: true, allowSecondOrderBy: true, diverse: true },
+    { field: "height", asc: true, desc: true, allowSecondOrderBy: true, diverse: true },
+    { field: "username", asc: true, desc: true, allowSecondOrderBy: true, diverse: true },
+];

--- a/packages/api/src/resources-new/transaction.ts
+++ b/packages/api/src/resources-new/transaction.ts
@@ -20,3 +20,17 @@ export const transactionCriteriaSchemaObject = {
 
 export const transactionParamSchema = transactionIdSchema;
 export const transactionSortingSchema = Schemas.createSortingSchema(Schemas.transactionCriteriaSchemas, [], false);
+
+export const transactionQueryLevelOptions = [
+    { field: "version", asc: true, desc: true, allowSecondOrderBy: false, diverse: false },
+    { field: "timestamp", asc: true, desc: true, allowSecondOrderBy: true, diverse: true },
+    { field: "type", asc: true, desc: false, allowSecondOrderBy: false, diverse: false },
+    { field: "amount", asc: true, desc: false, allowSecondOrderBy: false, diverse: false },
+    { field: "fee", asc: true, desc: false, allowSecondOrderBy: false, diverse: false },
+    { field: "typeGroup", asc: true, desc: true, allowSecondOrderBy: false, diverse: false },
+    { field: "nonce", asc: true, desc: true, allowSecondOrderBy: false, diverse: false },
+    { field: "id", asc: false, desc: false, allowSecondOrderBy: false, diverse: true },
+    { field: "blockId", asc: false, desc: false, allowSecondOrderBy: false, diverse: true },
+    { field: "senderPublicKey", asc: false, desc: false, allowSecondOrderBy: false, diverse: true },
+    { field: "recipientId", asc: false, desc: false, allowSecondOrderBy: false, diverse: true },
+];

--- a/packages/api/src/routes/blocks.ts
+++ b/packages/api/src/routes/blocks.ts
@@ -2,7 +2,13 @@ import Hapi from "@hapi/hapi";
 import Joi from "joi";
 
 import { BlocksController } from "../controllers/blocks";
-import { blockSortingSchema, missedBlockSortingSchema, transactionSortingSchema } from "../resources-new";
+import {
+    blockQueryLevelOptions,
+    blockSortingSchema,
+    missedBlockQueryLevelOptions,
+    missedBlockSortingSchema,
+    transactionSortingSchema,
+} from "../resources-new";
 import * as Schemas from "../schemas";
 
 export const register = (server: Hapi.Server): void => {
@@ -24,6 +30,11 @@ export const register = (server: Hapi.Server): void => {
                     .concat(Schemas.pagination),
             },
             plugins: {
+                semaphore: {
+                    enabled: true,
+                    type: "database",
+                    queryLevelOptions: blockQueryLevelOptions,
+                },
                 pagination: {
                     enabled: true,
                 },
@@ -45,6 +56,11 @@ export const register = (server: Hapi.Server): void => {
                     .concat(Schemas.pagination),
             },
             plugins: {
+                semaphore: {
+                    enabled: true,
+                    type: "database",
+                    queryLevelOptions: missedBlockQueryLevelOptions,
+                },
                 pagination: {
                     enabled: true,
                 },
@@ -91,6 +107,12 @@ export const register = (server: Hapi.Server): void => {
                     transform: Joi.bool().default(true),
                 }),
             },
+            plugins: {
+                semaphore: {
+                    enabled: true,
+                    type: "database",
+                },
+            },
         },
     });
 
@@ -112,6 +134,10 @@ export const register = (server: Hapi.Server): void => {
                     .concat(Schemas.pagination),
             },
             plugins: {
+                semaphore: {
+                    enabled: true,
+                    type: "database",
+                },
                 pagination: {
                     enabled: true,
                 },

--- a/packages/api/src/routes/delegates.ts
+++ b/packages/api/src/routes/delegates.ts
@@ -3,9 +3,11 @@ import Joi from "joi";
 
 import { DelegatesController } from "../controllers/delegates";
 import {
+    blockQueryLevelOptions,
     blockSortingSchemaWithoutUsernameOrGeneratorPublicKey,
     delegateCriteriaSchema,
     delegateSortingSchema,
+    missedBlockQueryLevelOptions,
     missedBlockSortingSchema,
     walletCriteriaSchema,
     walletParamSchema,
@@ -82,6 +84,11 @@ export const register = (server: Hapi.Server): void => {
                     .concat(Schemas.pagination),
             },
             plugins: {
+                semaphore: {
+                    enabled: true,
+                    type: "database",
+                    queryLevelOptions: blockQueryLevelOptions,
+                },
                 pagination: {
                     enabled: true,
                 },
@@ -106,6 +113,11 @@ export const register = (server: Hapi.Server): void => {
                     .concat(Schemas.pagination),
             },
             plugins: {
+                semaphore: {
+                    enabled: true,
+                    type: "database",
+                    queryLevelOptions: missedBlockQueryLevelOptions,
+                },
                 pagination: {
                     enabled: true,
                 },

--- a/packages/api/src/routes/locks.ts
+++ b/packages/api/src/routes/locks.ts
@@ -18,6 +18,10 @@ export const register = (server: Hapi.Server): void => {
                 query: Joi.object().concat(lockCriteriaSchema).concat(lockSortingSchema).concat(Schemas.pagination),
             },
             plugins: {
+                semaphore: {
+                    enabled: true,
+                    type: "memory",
+                },
                 pagination: { enabled: true },
             },
         },
@@ -50,6 +54,10 @@ export const register = (server: Hapi.Server): void => {
                 }).required(),
             },
             plugins: {
+                semaphore: {
+                    enabled: true,
+                    type: "database",
+                },
                 pagination: {
                     enabled: true,
                 },

--- a/packages/api/src/routes/node.ts
+++ b/packages/api/src/routes/node.ts
@@ -41,6 +41,12 @@ export const register = (server: Hapi.Server): void => {
                     days: Joi.number().integer().min(1).max(30),
                 }),
             },
+            plugins: {
+                semaphore: {
+                    enabled: true,
+                    type: "database",
+                },
+            },
         },
     });
 };

--- a/packages/api/src/routes/rounds.ts
+++ b/packages/api/src/routes/rounds.ts
@@ -17,6 +17,12 @@ export const register = (server: Hapi.Server): void => {
                     id: Joi.number().integer().min(1),
                 }),
             },
+            plugins: {
+                semaphore: {
+                    enabled: true,
+                    type: "database",
+                },
+            },
         },
     });
 };

--- a/packages/api/src/routes/transactions.ts
+++ b/packages/api/src/routes/transactions.ts
@@ -3,7 +3,7 @@ import { Container, Providers } from "@solar-network/kernel";
 import Joi from "joi";
 
 import { StoreRequest, TransactionsController } from "../controllers/transactions";
-import { transactionSortingSchema } from "../resources-new";
+import { transactionQueryLevelOptions, transactionSortingSchema } from "../resources-new";
 import * as Schemas from "../schemas";
 
 export const register = (server: Hapi.Server): void => {
@@ -25,6 +25,11 @@ export const register = (server: Hapi.Server): void => {
                     .concat(Schemas.pagination),
             },
             plugins: {
+                semaphore: {
+                    enabled: true,
+                    type: "database",
+                    queryLevelOptions: transactionQueryLevelOptions,
+                },
                 pagination: {
                     enabled: true,
                 },
@@ -69,6 +74,12 @@ export const register = (server: Hapi.Server): void => {
                 query: Joi.object({
                     transform: Joi.bool().default(true),
                 }),
+            },
+            plugins: {
+                semaphore: {
+                    enabled: true,
+                    type: "database",
+                },
             },
         },
     });

--- a/packages/api/src/routes/votes.ts
+++ b/packages/api/src/routes/votes.ts
@@ -2,7 +2,7 @@ import Hapi from "@hapi/hapi";
 import Joi from "joi";
 
 import { VotesController } from "../controllers/votes";
-import { transactionSortingSchema } from "../resources-new";
+import { transactionQueryLevelOptions, transactionSortingSchema } from "../resources-new";
 import * as Schemas from "../schemas";
 
 export const register = (server: Hapi.Server): void => {
@@ -24,6 +24,11 @@ export const register = (server: Hapi.Server): void => {
                     .concat(Schemas.pagination),
             },
             plugins: {
+                semaphore: {
+                    enabled: true,
+                    type: "database",
+                    queryLevelOptions: transactionQueryLevelOptions,
+                },
                 pagination: {
                     enabled: true,
                 },
@@ -43,6 +48,12 @@ export const register = (server: Hapi.Server): void => {
                 query: Joi.object({
                     transform: Joi.bool().default(true),
                 }),
+            },
+            plugins: {
+                semaphore: {
+                    enabled: true,
+                    type: "database",
+                },
             },
         },
     });

--- a/packages/api/src/routes/wallets.ts
+++ b/packages/api/src/routes/wallets.ts
@@ -5,6 +5,7 @@ import { WalletsController } from "../controllers/wallets";
 import {
     lockCriteriaSchema,
     lockSortingSchema,
+    transactionQueryLevelOptions,
     transactionSortingSchema,
     walletCriteriaSchema,
     walletParamSchema,
@@ -25,6 +26,10 @@ export const register = (server: Hapi.Server): void => {
                 query: Joi.object().concat(walletCriteriaSchema).concat(walletSortingSchema).concat(Schemas.pagination),
             },
             plugins: {
+                semaphore: {
+                    enabled: true,
+                    type: "memory",
+                },
                 pagination: { enabled: true },
             },
         },
@@ -39,6 +44,10 @@ export const register = (server: Hapi.Server): void => {
                 query: Joi.object().concat(walletCriteriaSchema).concat(walletSortingSchema).concat(Schemas.pagination),
             },
             plugins: {
+                semaphore: {
+                    enabled: true,
+                    type: "memory",
+                },
                 pagination: { enabled: true },
             },
         },
@@ -69,6 +78,10 @@ export const register = (server: Hapi.Server): void => {
                 query: Joi.object().concat(lockCriteriaSchema).concat(lockSortingSchema).concat(Schemas.pagination),
             },
             plugins: {
+                semaphore: {
+                    enabled: true,
+                    type: "memory",
+                },
                 pagination: { enabled: true },
             },
         },
@@ -92,6 +105,11 @@ export const register = (server: Hapi.Server): void => {
                     .concat(Schemas.pagination),
             },
             plugins: {
+                semaphore: {
+                    enabled: true,
+                    type: "database",
+                    queryLevelOptions: transactionQueryLevelOptions,
+                },
                 pagination: {
                     enabled: true,
                 },
@@ -117,6 +135,11 @@ export const register = (server: Hapi.Server): void => {
                     .concat(Schemas.pagination),
             },
             plugins: {
+                semaphore: {
+                    enabled: true,
+                    type: "database",
+                    queryLevelOptions: transactionQueryLevelOptions,
+                },
                 pagination: {
                     enabled: true,
                 },
@@ -142,6 +165,11 @@ export const register = (server: Hapi.Server): void => {
                     .concat(Schemas.pagination),
             },
             plugins: {
+                semaphore: {
+                    enabled: true,
+                    type: "database",
+                    queryLevelOptions: transactionQueryLevelOptions,
+                },
                 pagination: {
                     enabled: true,
                 },
@@ -167,6 +195,11 @@ export const register = (server: Hapi.Server): void => {
                     .concat(Schemas.pagination),
             },
             plugins: {
+                semaphore: {
+                    enabled: true,
+                    type: "database",
+                    queryLevelOptions: transactionQueryLevelOptions,
+                },
                 pagination: {
                     enabled: true,
                 },

--- a/packages/api/src/schemas.ts
+++ b/packages/api/src/schemas.ts
@@ -95,10 +95,12 @@ export const createSortingSchema = (
 
                 if (transform) {
                     sorting.push({ property, direction: direction as "asc" | "desc" });
-                } else {
-                    sorting.push(value);
                 }
             }
+        }
+
+        if (!transform) {
+            return value;
         }
 
         return sorting;

--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -115,7 +115,7 @@ export class Server {
         });
 
         this.server.ext("onPreResponse", (request, h) => {
-            if (isBoom(request.response) && request.response.isServer) {
+            if (isBoom(request.response) && request.response.isServer && request.response.name !== "QueryFailedError") {
                 this.logger.error(request.response.stack);
             }
             return h.continue;

--- a/packages/api/src/service-provider.ts
+++ b/packages/api/src/service-provider.ts
@@ -78,6 +78,31 @@ export class ServiceProvider extends Providers.ServiceProvider {
                     stdTTL: Joi.number().integer().min(0).required(),
                     checkperiod: Joi.number().integer().min(0).required(),
                 }).required(),
+                semaphore: Joi.object({
+                    enabled: Joi.bool().required(),
+                    database: Joi.object({
+                        levelOne: Joi.object({
+                            concurrency: Joi.number().integer().min(0).required(),
+                            queueLimit: Joi.number().integer().min(0).required(),
+                            maxOffset: Joi.number().integer().min(0).required(),
+                        }).required(),
+                        levelTwo: Joi.object({
+                            concurrency: Joi.number().integer().min(0).required(),
+                            queueLimit: Joi.number().integer().min(0).required(),
+                        }).required(),
+                    }).required(),
+                    memory: Joi.object({
+                        levelOne: Joi.object({
+                            concurrency: Joi.number().integer().min(0).required(),
+                            queueLimit: Joi.number().integer().min(0).required(),
+                            maxOffset: Joi.number().integer().min(0).required(),
+                        }).required(),
+                        levelTwo: Joi.object({
+                            concurrency: Joi.number().integer().min(0).required(),
+                            queueLimit: Joi.number().integer().min(0).required(),
+                        }).required(),
+                    }).required(),
+                }).required(),
                 rateLimit: Joi.object({
                     enabled: Joi.bool().required(),
                     points: Joi.number().integer().min(0).required(),

--- a/packages/api/src/services/delegate-search-service.ts
+++ b/packages/api/src/services/delegate-search-service.ts
@@ -33,11 +33,11 @@ export class DelegateSearchService {
         }
     }
 
-    public getDelegatesPage(
+    public async getDelegatesPage(
         pagination: Contracts.Search.Pagination,
         sorting: Contracts.Search.Sorting,
         ...criterias: DelegateCriteria[]
-    ): Contracts.Search.ResultsPage<DelegateResource> {
+    ): Promise<Contracts.Search.ResultsPage<DelegateResource>> {
         sorting = [...sorting, { property: "rank", direction: "asc" }, { property: "username", direction: "asc" }];
 
         return this.paginationService.getPage(pagination, sorting, this.getDelegates(...criterias));

--- a/packages/api/src/services/lock-search-service.ts
+++ b/packages/api/src/services/lock-search-service.ts
@@ -27,22 +27,22 @@ export class LockSearchService {
         }
     }
 
-    public getLocksPage(
+    public async getLocksPage(
         pagination: Contracts.Search.Pagination,
         sorting: Contracts.Search.Sorting,
         ...criterias: LockCriteria[]
-    ): Contracts.Search.ResultsPage<LockResource> {
+    ): Promise<Contracts.Search.ResultsPage<LockResource>> {
         sorting = [...sorting, { property: "timestamp.unix", direction: "desc" }];
 
         return this.paginationService.getPage(pagination, sorting, this.getLocks(...criterias));
     }
 
-    public getWalletLocksPage(
+    public async getWalletLocksPage(
         pagination: Contracts.Search.Pagination,
         sorting: Contracts.Search.Sorting,
         walletAddress: string,
         ...criterias: LockCriteria[]
-    ): Contracts.Search.ResultsPage<LockResource> {
+    ): Promise<Contracts.Search.ResultsPage<LockResource>> {
         sorting = [...sorting, { property: "timestamp.unix", direction: "desc" }];
 
         return this.paginationService.getPage(pagination, sorting, this.getWalletLocks(walletAddress, ...criterias));

--- a/packages/api/src/services/wallet-search-service.ts
+++ b/packages/api/src/services/wallet-search-service.ts
@@ -97,21 +97,21 @@ export class WalletSearchService {
             });
     }
 
-    public getWalletsPage(
+    public async getWalletsPage(
         pagination: Contracts.Search.Pagination,
         sorting: Contracts.Search.Sorting,
         ...criterias: WalletCriteria[]
-    ): Contracts.Search.ResultsPage<WalletResource> {
+    ): Promise<Contracts.Search.ResultsPage<WalletResource>> {
         sorting = [...sorting, { property: "balance", direction: "desc" }];
 
         return this.paginationService.getPage(pagination, sorting, this.getWallets(...criterias));
     }
 
-    public getActiveWalletsPage(
+    public async getActiveWalletsPage(
         pagination: Contracts.Search.Pagination,
         sorting: Contracts.Search.Sorting,
         ...criterias: WalletCriteria[]
-    ): Contracts.Search.ResultsPage<WalletResource> {
+    ): Promise<Contracts.Search.ResultsPage<WalletResource>> {
         sorting = [...sorting, { property: "balance", direction: "desc" }];
 
         return this.paginationService.getPage(pagination, sorting, this.getActiveWallets(...criterias));

--- a/packages/blockchain/package.json
+++ b/packages/blockchain/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/blockchain",
-    "version": "4.3.0-next.1",
+    "version": "4.3.0-next.2",
     "description": "Blockchain Manager for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/blockchain/package.json
+++ b/packages/blockchain/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/blockchain",
-    "version": "4.2.1",
+    "version": "4.2.2-next.0",
     "description": "Blockchain Manager for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/blockchain/package.json
+++ b/packages/blockchain/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/blockchain",
-    "version": "4.3.0-next.0",
+    "version": "4.3.0-next.1",
     "description": "Blockchain Manager for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/blockchain/package.json
+++ b/packages/blockchain/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/blockchain",
-    "version": "4.2.2-next.0",
+    "version": "4.3.0-next.0",
     "description": "Blockchain Manager for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/blockchain/package.json
+++ b/packages/blockchain/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/blockchain",
-    "version": "4.3.0-next.2",
+    "version": "4.3.0",
     "description": "Blockchain Manager for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/blockchain/src/state-machine/actions/syncing-complete.ts
+++ b/packages/blockchain/src/state-machine/actions/syncing-complete.ts
@@ -1,4 +1,4 @@
-import { Container, Contracts, Enums } from "@solar-network/kernel";
+import { Container, Contracts, Enums, Utils as AppUtils } from "@solar-network/kernel";
 
 import { Action } from "../contracts";
 
@@ -16,8 +16,28 @@ export class SyncingComplete implements Action {
     @Container.inject(Container.Identifiers.BlockchainService)
     private readonly blockchain!: Contracts.Blockchain.Blockchain;
 
+    @Container.inject(Container.Identifiers.WalletRepository)
+    @Container.tagged("state", "blockchain")
+    private readonly walletRepository!: Contracts.State.WalletRepository;
+
     public async handle(): Promise<void> {
         this.logger.info("Blockchain 100% in sync :100:");
+
+        const roundInfo: Contracts.Shared.RoundInfo = AppUtils.roundCalculator.calculateRound(
+            this.blockchain.getLastHeight(),
+        );
+        const ourKeys: string[] = AppUtils.getForgerDelegates();
+
+        for (const wallet of this.walletRepository.allByUsername()) {
+            if (wallet.hasPublicKey() && ourKeys.includes(wallet.getPublicKey()!)) {
+                wallet.setAttribute("delegate.version", { round: roundInfo.round, version: this.app.version() });
+            } else if (wallet.hasAttribute("delegate.version")) {
+                const { round } = wallet.getAttribute("delegate.version");
+                if (!round || round < roundInfo.round - 5) {
+                    wallet.forgetAttribute("delegate.version");
+                }
+            }
+        }
 
         this.events.dispatch(Enums.BlockchainEvent.Synced);
         this.blockchain.dispatch("SYNCFINISHED");

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/cli",
-    "version": "4.3.0-next.2",
+    "version": "4.3.0",
     "description": "Command Line Interface to manage the Core of the Solar Network Blockchain",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/cli",
-    "version": "4.3.0-next.0",
+    "version": "4.3.0-next.1",
     "description": "Command Line Interface to manage the Core of the Solar Network Blockchain",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/cli",
-    "version": "4.3.0-next.1",
+    "version": "4.3.0-next.2",
     "description": "Command Line Interface to manage the Core of the Solar Network Blockchain",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/cli",
-    "version": "4.2.2-next.0",
+    "version": "4.3.0-next.0",
     "description": "Command Line Interface to manage the Core of the Solar Network Blockchain",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/cli",
-    "version": "4.2.1",
+    "version": "4.2.2-next.0",
     "description": "Command Line Interface to manage the Core of the Solar Network Blockchain",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core",
-    "version": "4.3.0-next.0",
+    "version": "4.3.0-next.1",
     "description": "Core of the Solar Network Blockchain",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core",
-    "version": "4.3.0-next.1",
+    "version": "4.3.0-next.2",
     "description": "Core of the Solar Network Blockchain",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core",
-    "version": "4.2.2-next.0",
+    "version": "4.3.0-next.0",
     "description": "Core of the Solar Network Blockchain",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core",
-    "version": "4.2.1",
+    "version": "4.2.2-next.0",
     "description": "Core of the Solar Network Blockchain",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/core",
-    "version": "4.3.0-next.2",
+    "version": "4.3.0",
     "description": "Core of the Solar Network Blockchain",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/crypto",
-    "version": "4.3.0-next.2",
+    "version": "4.3.0",
     "description": "Crypto utilities for the Solar Network Blockchain",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/crypto",
-    "version": "4.2.2-next.0",
+    "version": "4.3.0-next.0",
     "description": "Crypto utilities for the Solar Network Blockchain",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/crypto",
-    "version": "4.3.0-next.0",
+    "version": "4.3.0-next.1",
     "description": "Crypto utilities for the Solar Network Blockchain",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/crypto",
-    "version": "4.3.0-next.1",
+    "version": "4.3.0-next.2",
     "description": "Crypto utilities for the Solar Network Blockchain",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/crypto",
-    "version": "4.2.1",
+    "version": "4.2.2-next.0",
     "description": "Crypto utilities for the Solar Network Blockchain",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/crypto/src/networks/mainnet/milestones.json
+++ b/packages/crypto/src/networks/mainnet/milestones.json
@@ -55,6 +55,7 @@
         "p2p": {
             "minimumVersions": [">=4.2.0"]
         },
+        "swapEnabled": true,
         "transfer": {
             "maximum": 256,
             "minimum": 1
@@ -163,5 +164,13 @@
     {
         "height": 2850000,
         "swapWalletSecondPublicKey": "0210caa3c13c5fef3a28a27202373dfc7fd584c122d18d83c980586358a5f76a0e"
+    },
+    {
+        "height": 5000000,
+        "legacyTransfer": false,
+        "p2p": {
+            "minimumVersions": [">=4.3.0"]
+        },
+        "swapEnabled": false
     }
 ]

--- a/packages/crypto/src/networks/testnet/milestones.json
+++ b/packages/crypto/src/networks/testnet/milestones.json
@@ -32,7 +32,7 @@
             },
             "minFee": 11299
         },
-        "epoch": "2022-07-20T18:00:00.000Z",
+        "epoch": "2023-01-25T23:00:00.000Z",
         "fees": {
             "staticFees": {
                 "burn": 0,
@@ -53,7 +53,7 @@
         "legacyTransfer": true,
         "legacyVote": true,
         "p2p": {
-            "minimumVersions": [">=4.1.2-next.0"]
+            "minimumVersions": [">=4.2.2-next.0"]
         },
         "transfer": {
             "maximum": 256,
@@ -133,7 +133,7 @@
         "bip340": true
     },
     {
-        "height": 502441,
+        "height": 502431,
         "acceptLegacySchnorrTransactions": false,
         "donations": {
             "DSXP3m8MJhqZvybUMCnUkfAP5PQ4aVjozy": {

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/database",
-    "version": "4.3.0-next.2",
+    "version": "4.3.0",
     "description": "Database Interface for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/database",
-    "version": "4.2.2-next.0",
+    "version": "4.3.0-next.0",
     "description": "Database Interface for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/database",
-    "version": "4.3.0-next.0",
+    "version": "4.3.0-next.1",
     "description": "Database Interface for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/database",
-    "version": "4.3.0-next.1",
+    "version": "4.3.0-next.2",
     "description": "Database Interface for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/database",
-    "version": "4.2.1",
+    "version": "4.2.2-next.0",
     "description": "Database Interface for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/database/src/defaults.ts
+++ b/packages/database/src/defaults.ts
@@ -1,4 +1,5 @@
 export const defaults = {
+    apiConnectionTimeout: 3000,
     connection: {
         database: `${process.env.CORE_TOKEN}_${process.env.CORE_NETWORK_NAME}`,
         entityPrefix: "public.",

--- a/packages/database/src/service-provider.ts
+++ b/packages/database/src/service-provider.ts
@@ -126,7 +126,7 @@ export class ServiceProvider extends Providers.ServiceProvider {
                 }
             }
 
-            if (connectionName === "default" && startPostgres) {
+            if (startPostgres) {
                 chmodSync(connection.extra.host, "700");
                 sync(`${process.env.POSTGRES_DIR}/bin/pg_ctl -D ${connection.extra.host} start >/dev/null`, {
                     shell: true,

--- a/packages/database/src/service-provider.ts
+++ b/packages/database/src/service-provider.ts
@@ -24,25 +24,63 @@ export class ServiceProvider extends Providers.ServiceProvider {
 
         this.logger.info(`Connecting to database: ${(this.config().all().connection as any).database}`);
 
-        this.app.bind(Container.Identifiers.DatabaseConnection).toConstantValue(await this.connect());
+        this.app
+            .bind(Container.Identifiers.DatabaseConnection)
+            .toConstantValue(
+                await this.connect("api", {
+                    options: `-c statement_timeout=${this.config().getRequired("apiConnectionTimeout")}ms`,
+                }),
+            )
+            .when(Container.Selectors.anyAncestorOrTargetTaggedFirst("connection", "api"));
+        this.app
+            .bind(Container.Identifiers.DatabaseConnection)
+            .toConstantValue(await this.connect())
+            .when(Container.Selectors.noAncestorOrTargetTagged("connection"));
 
         this.logger.debug("Connection established");
 
-        this.app.bind(Container.Identifiers.DatabaseRoundRepository).toConstantValue(this.getRoundRepository());
+        this.app
+            .bind(Container.Identifiers.DatabaseRoundRepository)
+            .toConstantValue(this.getRoundRepository("api"))
+            .when(Container.Selectors.anyAncestorOrTargetTaggedFirst("connection", "api"));
+        this.app
+            .bind(Container.Identifiers.DatabaseRoundRepository)
+            .toConstantValue(this.getRoundRepository())
+            .when(Container.Selectors.noAncestorOrTargetTagged("connection"));
 
-        this.app.bind(Container.Identifiers.DatabaseBlockRepository).toConstantValue(this.getBlockRepository());
-        this.app.bind(Container.Identifiers.DatabaseBlockFilter).to(BlockFilter);
-        this.app.bind(Container.Identifiers.BlockHistoryService).to(BlockHistoryService);
+        this.app
+            .bind(Container.Identifiers.DatabaseBlockRepository)
+            .toConstantValue(this.getBlockRepository("api"))
+            .when(Container.Selectors.anyAncestorOrTargetTaggedFirst("connection", "api"));
+        this.app
+            .bind(Container.Identifiers.DatabaseBlockRepository)
+            .toConstantValue(this.getBlockRepository())
+            .when(Container.Selectors.noAncestorOrTargetTagged("connection"));
 
         this.app
             .bind(Container.Identifiers.DatabaseMissedBlockRepository)
-            .toConstantValue(this.getMissedBlockRepository());
-        this.app.bind(Container.Identifiers.DatabaseMissedBlockFilter).to(MissedBlockFilter);
-        this.app.bind(Container.Identifiers.MissedBlockHistoryService).to(MissedBlockHistoryService);
+            .toConstantValue(this.getMissedBlockRepository("api"))
+            .when(Container.Selectors.anyAncestorOrTargetTaggedFirst("connection", "api"));
+        this.app
+            .bind(Container.Identifiers.DatabaseMissedBlockRepository)
+            .toConstantValue(this.getMissedBlockRepository())
+            .when(Container.Selectors.noAncestorOrTargetTagged("connection"));
 
         this.app
             .bind(Container.Identifiers.DatabaseTransactionRepository)
-            .toConstantValue(this.getTransactionRepository());
+            .toConstantValue(this.getTransactionRepository("api"))
+            .when(Container.Selectors.anyAncestorOrTargetTaggedFirst("connection", "api"));
+        this.app
+            .bind(Container.Identifiers.DatabaseTransactionRepository)
+            .toConstantValue(this.getTransactionRepository())
+            .when(Container.Selectors.noAncestorOrTargetTagged("connection"));
+
+        this.app.bind(Container.Identifiers.DatabaseBlockFilter).to(BlockFilter);
+        this.app.bind(Container.Identifiers.BlockHistoryService).to(BlockHistoryService);
+
+        this.app.bind(Container.Identifiers.DatabaseMissedBlockFilter).to(MissedBlockFilter);
+        this.app.bind(Container.Identifiers.MissedBlockHistoryService).to(MissedBlockHistoryService);
+
         this.app.bind(Container.Identifiers.DatabaseTransactionFilter).to(TransactionFilter);
         this.app.bind(Container.Identifiers.TransactionHistoryService).to(TransactionHistoryService);
 
@@ -63,7 +101,7 @@ export class ServiceProvider extends Providers.ServiceProvider {
         return true;
     }
 
-    public async connect(): Promise<Connection> {
+    public async connect(connectionName = "default", extra = {}): Promise<Connection> {
         const connection: Record<string, any> = this.config().all().connection as any;
         this.app
             .get<Contracts.Kernel.EventDispatcher>(Container.Identifiers.EventDispatcherService)
@@ -88,7 +126,7 @@ export class ServiceProvider extends Providers.ServiceProvider {
                 }
             }
 
-            if (startPostgres) {
+            if (connectionName === "default" && startPostgres) {
                 chmodSync(connection.extra.host, "700");
                 sync(`${process.env.POSTGRES_DIR}/bin/pg_ctl -D ${connection.extra.host} start >/dev/null`, {
                     shell: true,
@@ -100,10 +138,11 @@ export class ServiceProvider extends Providers.ServiceProvider {
 
         const dbConnection: Connection = await createConnection({
             ...(connection as any),
-            extra: Object.assign(connection.extra, { logger: this.logger }),
+            extra: Object.assign(connection.extra, { ...extra, logger: this.logger }),
             namingStrategy: new SnakeNamingStrategy(),
             migrations: [__dirname + "/migrations/*.js"],
-            migrationsRun: true,
+            migrationsRun: connectionName === "default",
+            name: connectionName,
             entities: [__dirname + "/models/*.js"],
         });
 
@@ -133,24 +172,25 @@ export class ServiceProvider extends Providers.ServiceProvider {
         return dbConnection;
     }
 
-    public getRoundRepository(): RoundRepository {
-        return getCustomRepository(RoundRepository);
+    public getRoundRepository(connectionName = "default"): RoundRepository {
+        return getCustomRepository(RoundRepository, connectionName);
     }
 
-    public getBlockRepository(): BlockRepository {
-        return getCustomRepository(BlockRepository);
+    public getBlockRepository(connectionName = "default"): BlockRepository {
+        return getCustomRepository(BlockRepository, connectionName);
     }
 
-    public getMissedBlockRepository(): MissedBlockRepository {
-        return getCustomRepository(MissedBlockRepository);
+    public getMissedBlockRepository(connectionName = "default"): MissedBlockRepository {
+        return getCustomRepository(MissedBlockRepository, connectionName);
     }
 
-    public getTransactionRepository(): TransactionRepository {
-        return getCustomRepository(TransactionRepository);
+    public getTransactionRepository(connectionName = "default"): TransactionRepository {
+        return getCustomRepository(TransactionRepository, connectionName);
     }
 
     public configSchema(): object {
         return Joi.object({
+            apiConnectionTimeout: Joi.number().integer().min(1).required(),
             connection: Joi.object({
                 database: Joi.string().required(),
                 entityPrefix: Joi.string().required(),

--- a/packages/database/src/service-provider.ts
+++ b/packages/database/src/service-provider.ts
@@ -26,54 +26,54 @@ export class ServiceProvider extends Providers.ServiceProvider {
 
         this.app
             .bind(Container.Identifiers.DatabaseConnection)
+            .toConstantValue(await this.connect())
+            .when(Container.Selectors.noAncestorOrTargetTagged("connection"));
+        this.app
+            .bind(Container.Identifiers.DatabaseConnection)
             .toConstantValue(
                 await this.connect("api", {
                     options: `-c statement_timeout=${this.config().getRequired("apiConnectionTimeout")}ms`,
                 }),
             )
             .when(Container.Selectors.anyAncestorOrTargetTaggedFirst("connection", "api"));
-        this.app
-            .bind(Container.Identifiers.DatabaseConnection)
-            .toConstantValue(await this.connect())
-            .when(Container.Selectors.noAncestorOrTargetTagged("connection"));
 
         this.logger.debug("Connection established");
 
         this.app
             .bind(Container.Identifiers.DatabaseRoundRepository)
-            .toConstantValue(this.getRoundRepository("api"))
-            .when(Container.Selectors.anyAncestorOrTargetTaggedFirst("connection", "api"));
-        this.app
-            .bind(Container.Identifiers.DatabaseRoundRepository)
             .toConstantValue(this.getRoundRepository())
             .when(Container.Selectors.noAncestorOrTargetTagged("connection"));
-
         this.app
-            .bind(Container.Identifiers.DatabaseBlockRepository)
-            .toConstantValue(this.getBlockRepository("api"))
+            .bind(Container.Identifiers.DatabaseRoundRepository)
+            .toConstantValue(this.getRoundRepository("api"))
             .when(Container.Selectors.anyAncestorOrTargetTaggedFirst("connection", "api"));
+
         this.app
             .bind(Container.Identifiers.DatabaseBlockRepository)
             .toConstantValue(this.getBlockRepository())
             .when(Container.Selectors.noAncestorOrTargetTagged("connection"));
-
         this.app
-            .bind(Container.Identifiers.DatabaseMissedBlockRepository)
-            .toConstantValue(this.getMissedBlockRepository("api"))
+            .bind(Container.Identifiers.DatabaseBlockRepository)
+            .toConstantValue(this.getBlockRepository("api"))
             .when(Container.Selectors.anyAncestorOrTargetTaggedFirst("connection", "api"));
+
         this.app
             .bind(Container.Identifiers.DatabaseMissedBlockRepository)
             .toConstantValue(this.getMissedBlockRepository())
             .when(Container.Selectors.noAncestorOrTargetTagged("connection"));
-
         this.app
-            .bind(Container.Identifiers.DatabaseTransactionRepository)
-            .toConstantValue(this.getTransactionRepository("api"))
+            .bind(Container.Identifiers.DatabaseMissedBlockRepository)
+            .toConstantValue(this.getMissedBlockRepository("api"))
             .when(Container.Selectors.anyAncestorOrTargetTaggedFirst("connection", "api"));
+
         this.app
             .bind(Container.Identifiers.DatabaseTransactionRepository)
             .toConstantValue(this.getTransactionRepository())
             .when(Container.Selectors.noAncestorOrTargetTagged("connection"));
+        this.app
+            .bind(Container.Identifiers.DatabaseTransactionRepository)
+            .toConstantValue(this.getTransactionRepository("api"))
+            .when(Container.Selectors.anyAncestorOrTargetTaggedFirst("connection", "api"));
 
         this.app.bind(Container.Identifiers.DatabaseBlockFilter).to(BlockFilter);
         this.app.bind(Container.Identifiers.BlockHistoryService).to(BlockHistoryService);

--- a/packages/forger/package.json
+++ b/packages/forger/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/forger",
-    "version": "4.2.1",
+    "version": "4.2.2-next.0",
     "description": "Forger for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/forger/package.json
+++ b/packages/forger/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/forger",
-    "version": "4.3.0-next.1",
+    "version": "4.3.0-next.2",
     "description": "Forger for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/forger/package.json
+++ b/packages/forger/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/forger",
-    "version": "4.2.2-next.0",
+    "version": "4.3.0-next.0",
     "description": "Forger for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/forger/package.json
+++ b/packages/forger/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/forger",
-    "version": "4.3.0-next.0",
+    "version": "4.3.0-next.1",
     "description": "Forger for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/forger/package.json
+++ b/packages/forger/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/forger",
-    "version": "4.3.0-next.2",
+    "version": "4.3.0",
     "description": "Forger for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/kernel/package.json
+++ b/packages/kernel/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/kernel",
-    "version": "4.3.0-next.1",
+    "version": "4.3.0-next.2",
     "description": "Kernel of Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/kernel/package.json
+++ b/packages/kernel/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/kernel",
-    "version": "4.2.1",
+    "version": "4.2.2-next.0",
     "description": "Kernel of Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/kernel/package.json
+++ b/packages/kernel/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/kernel",
-    "version": "4.3.0-next.2",
+    "version": "4.3.0",
     "description": "Kernel of Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/kernel/package.json
+++ b/packages/kernel/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/kernel",
-    "version": "4.2.2-next.0",
+    "version": "4.3.0-next.0",
     "description": "Kernel of Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/kernel/package.json
+++ b/packages/kernel/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/kernel",
-    "version": "4.3.0-next.0",
+    "version": "4.3.0-next.1",
     "description": "Kernel of Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/kernel/src/contracts/p2p/network-monitor.ts
+++ b/packages/kernel/src/contracts/p2p/network-monitor.ts
@@ -1,6 +1,7 @@
 import { Interfaces } from "@solar-network/crypto";
 
 import { Application } from "../kernel";
+import { WalletRepository } from "../state";
 import { NetworkState } from "./network-state";
 
 export interface NetworkStatus {
@@ -15,6 +16,7 @@ export interface IRateLimitStatus {
 
 export interface NetworkMonitor {
     app: Application;
+    walletRepository: WalletRepository;
     boot(): Promise<void>;
     updateNetworkStatus(initialRun?: boolean): Promise<void>;
     cleansePeers({

--- a/packages/kernel/src/contracts/p2p/peer.ts
+++ b/packages/kernel/src/contracts/p2p/peer.ts
@@ -1,5 +1,7 @@
 import { Dayjs } from "dayjs";
 
+import { WalletRepository } from "../state";
+
 export interface PeerPorts {
     [name: string]: number;
 }
@@ -30,7 +32,7 @@ export interface Peer {
     fastVerificationResult: FastPeerVerificationResult | undefined;
 
     addInfraction(): void;
-    isActiveDelegate(): boolean;
+    activeDelegates(walletRepository: WalletRepository): string[];
     isIgnored(): boolean;
     isVerified(): boolean;
     isForked(): boolean;

--- a/packages/kernel/src/ioc/selectors.ts
+++ b/packages/kernel/src/ioc/selectors.ts
@@ -20,3 +20,21 @@ export const anyAncestorOrTargetTaggedFirst = (
         }
     };
 };
+
+export const noAncestorOrTargetTagged = (key: string | number | symbol): ((req: interfaces.Request) => boolean) => {
+    return (req: interfaces.Request) => {
+        for (;;) {
+            const targetTags = req.target.getCustomTags();
+            if (targetTags) {
+                const targetTag = targetTags.find((t) => t.key === key);
+                if (targetTag) {
+                    return false;
+                }
+            }
+            if (!req.parentRequest) {
+                return true;
+            }
+            req = req.parentRequest;
+        }
+    };
+};

--- a/packages/kernel/src/services/search/pagination-service.ts
+++ b/packages/kernel/src/services/search/pagination-service.ts
@@ -11,13 +11,13 @@ export class PaginationService {
         return { results: [], totalCount: 0, meta: { totalCountIsEstimate: false } };
     }
 
-    public getPage<T>(pagination: Pagination, sorting: Sorting, items: Iterable<T>): ResultsPage<T> {
+    public async getPage<T>(pagination: Pagination, sorting: Sorting, items: Iterable<T>): Promise<ResultsPage<T>> {
         const all = Array.from(items);
 
         const results =
             sorting.length === 0
                 ? all.slice(pagination.offset, pagination.offset + pagination.limit)
-                : this.getTop(sorting, pagination.offset + pagination.limit, all).slice(pagination.offset);
+                : (await this.getTop(sorting, pagination.offset + pagination.limit, all)).slice(pagination.offset);
 
         return {
             results,
@@ -26,7 +26,7 @@ export class PaginationService {
         };
     }
 
-    public getTop<T>(sorting: Sorting, count: number, items: Iterable<T>): T[] {
+    public async getTop<T>(sorting: Sorting, count: number, items: Iterable<T>): Promise<T[]> {
         if (count < 0) {
             throw new RangeError(`Count should be greater or equal than zero`);
         }
@@ -41,6 +41,12 @@ export class PaginationService {
 
         let i = 0;
         for (const item of items) {
+            if (i % 1000 === 0) {
+                await new Promise<void>((resolve) => {
+                    setImmediate(() => resolve());
+                });
+            }
+
             const key = {
                 index: i++,
                 item: item,

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/logger",
-    "version": "4.2.1",
+    "version": "4.2.2-next.0",
     "description": "Webhooks for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/logger",
-    "version": "4.3.0-next.0",
+    "version": "4.3.0-next.1",
     "description": "Webhooks for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/logger",
-    "version": "4.3.0-next.2",
+    "version": "4.3.0",
     "description": "Webhooks for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/logger",
-    "version": "4.3.0-next.1",
+    "version": "4.3.0-next.2",
     "description": "Webhooks for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/logger",
-    "version": "4.2.2-next.0",
+    "version": "4.3.0-next.0",
     "description": "Webhooks for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/nes/package.json
+++ b/packages/nes/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/nes",
-    "version": "4.2.1",
+    "version": "4.2.2-next.0",
     "description": "Websocket client and server for Solar Core",
     "license": "BSD-3-Clause",
     "contributors": [

--- a/packages/nes/package.json
+++ b/packages/nes/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/nes",
-    "version": "4.3.0-next.2",
+    "version": "4.3.0",
     "description": "Websocket client and server for Solar Core",
     "license": "BSD-3-Clause",
     "contributors": [

--- a/packages/nes/package.json
+++ b/packages/nes/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/nes",
-    "version": "4.3.0-next.1",
+    "version": "4.3.0-next.2",
     "description": "Websocket client and server for Solar Core",
     "license": "BSD-3-Clause",
     "contributors": [

--- a/packages/nes/package.json
+++ b/packages/nes/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/nes",
-    "version": "4.2.2-next.0",
+    "version": "4.3.0-next.0",
     "description": "Websocket client and server for Solar Core",
     "license": "BSD-3-Clause",
     "contributors": [

--- a/packages/nes/package.json
+++ b/packages/nes/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/nes",
-    "version": "4.3.0-next.0",
+    "version": "4.3.0-next.1",
     "description": "Websocket client and server for Solar Core",
     "license": "BSD-3-Clause",
     "contributors": [

--- a/packages/p2p/package.json
+++ b/packages/p2p/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/p2p",
-    "version": "4.2.1",
+    "version": "4.2.2-next.0",
     "description": "P2P API for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/p2p/package.json
+++ b/packages/p2p/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/p2p",
-    "version": "4.3.0-next.0",
+    "version": "4.3.0-next.1",
     "description": "P2P API for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/p2p/package.json
+++ b/packages/p2p/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/p2p",
-    "version": "4.3.0-next.2",
+    "version": "4.3.0",
     "description": "P2P API for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/p2p/package.json
+++ b/packages/p2p/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/p2p",
-    "version": "4.2.2-next.0",
+    "version": "4.3.0-next.0",
     "description": "P2P API for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/p2p/package.json
+++ b/packages/p2p/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/p2p",
-    "version": "4.3.0-next.1",
+    "version": "4.3.0-next.2",
     "description": "P2P API for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/p2p/src/network-monitor.ts
+++ b/packages/p2p/src/network-monitor.ts
@@ -19,6 +19,10 @@ export class NetworkMonitor implements Contracts.P2P.NetworkMonitor {
     @Container.inject(Container.Identifiers.Application)
     public readonly app!: Contracts.Kernel.Application;
 
+    @Container.inject(Container.Identifiers.WalletRepository)
+    @Container.tagged("state", "blockchain")
+    public readonly walletRepository!: Contracts.State.WalletRepository;
+
     @Container.inject(Container.Identifiers.PluginConfiguration)
     @Container.tagged("plugin", "@solar-network/p2p")
     private readonly configuration!: Providers.PluginConfiguration;
@@ -43,10 +47,6 @@ export class NetworkMonitor implements Contracts.P2P.NetworkMonitor {
 
     @Container.inject(Container.Identifiers.TriggerService)
     private readonly triggers!: Services.Triggers.Triggers;
-
-    @Container.inject(Container.Identifiers.WalletRepository)
-    @Container.tagged("state", "blockchain")
-    private readonly walletRepository!: Contracts.State.WalletRepository;
 
     public config: any;
     public nextUpdateNetworkStatusScheduled: boolean | undefined;
@@ -369,8 +369,9 @@ export class NetworkMonitor implements Contracts.P2P.NetworkMonitor {
         peers.push(localPeer);
 
         for (const peer of peers) {
-            if (peer.isActiveDelegate()) {
-                for (let i = 0; i < peer.publicKeys.length; i++) {
+            const activeDelegates: string[] = peer.activeDelegates(this.walletRepository);
+            if (activeDelegates.length > 0) {
+                for (let i = 0; i < activeDelegates.length; i++) {
                     includedPeers.push(peer);
                 }
             } else if (peer.state && peer.state.height! > lastBlock.data.height) {

--- a/packages/p2p/src/peer.ts
+++ b/packages/p2p/src/peer.ts
@@ -1,3 +1,4 @@
+import { Managers } from "@solar-network/crypto";
 import { Contracts } from "@solar-network/kernel";
 import dayjs, { Dayjs } from "dayjs";
 
@@ -128,8 +129,19 @@ export class Peer implements Contracts.P2P.Peer {
      * @returns {boolean}
      * @memberof Peer
      */
-    public isActiveDelegate(): boolean {
-        return this.publicKeys.length > 0;
+    public activeDelegates(walletRepository: Contracts.State.WalletRepository): string[] {
+        const { activeDelegates } = Managers.configManager.getMilestone();
+        return this.publicKeys.filter((publicKey: string) => {
+            if (walletRepository.hasByPublicKey(publicKey)) {
+                const wallet: Contracts.State.Wallet = walletRepository.findByPublicKey(publicKey);
+                if (wallet.hasAttribute("delegate.rank")) {
+                    const rank: number = wallet.getAttribute("delegate.rank");
+                    return rank <= activeDelegates;
+                }
+            }
+
+            return false;
+        });
     }
 
     /**

--- a/packages/pool/package.json
+++ b/packages/pool/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/pool",
-    "version": "4.2.2-next.0",
+    "version": "4.3.0-next.0",
     "description": "Pool Manager for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/pool/package.json
+++ b/packages/pool/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/pool",
-    "version": "4.2.1",
+    "version": "4.2.2-next.0",
     "description": "Pool Manager for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/pool/package.json
+++ b/packages/pool/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/pool",
-    "version": "4.3.0-next.2",
+    "version": "4.3.0",
     "description": "Pool Manager for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/pool/package.json
+++ b/packages/pool/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/pool",
-    "version": "4.3.0-next.0",
+    "version": "4.3.0-next.1",
     "description": "Pool Manager for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/pool/package.json
+++ b/packages/pool/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/pool",
-    "version": "4.3.0-next.1",
+    "version": "4.3.0-next.2",
     "description": "Pool Manager for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/snapshots/package.json
+++ b/packages/snapshots/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/snapshots",
-    "version": "4.2.1",
+    "version": "4.2.2-next.0",
     "description": "Provides live local streamed snapshots functionality for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/snapshots/package.json
+++ b/packages/snapshots/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/snapshots",
-    "version": "4.3.0-next.0",
+    "version": "4.3.0-next.1",
     "description": "Provides live local streamed snapshots functionality for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/snapshots/package.json
+++ b/packages/snapshots/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/snapshots",
-    "version": "4.3.0-next.2",
+    "version": "4.3.0",
     "description": "Provides live local streamed snapshots functionality for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/snapshots/package.json
+++ b/packages/snapshots/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/snapshots",
-    "version": "4.3.0-next.1",
+    "version": "4.3.0-next.2",
     "description": "Provides live local streamed snapshots functionality for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/snapshots/package.json
+++ b/packages/snapshots/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/snapshots",
-    "version": "4.2.2-next.0",
+    "version": "4.3.0-next.0",
     "description": "Provides live local streamed snapshots functionality for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/state/package.json
+++ b/packages/state/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/state",
-    "version": "4.3.0-next.0",
+    "version": "4.3.0-next.1",
     "description": "State Management for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/state/package.json
+++ b/packages/state/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/state",
-    "version": "4.2.2-next.0",
+    "version": "4.3.0-next.0",
     "description": "State Management for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/state/package.json
+++ b/packages/state/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/state",
-    "version": "4.3.0-next.2",
+    "version": "4.3.0",
     "description": "State Management for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/state/package.json
+++ b/packages/state/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/state",
-    "version": "4.2.1",
+    "version": "4.2.2-next.0",
     "description": "State Management for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [
@@ -29,5 +29,5 @@
         "semver": "6.3.0",
         "xstate": "4.23.4"
     },
-    "minimumSavedStateVersion": "4.2.1"
+    "minimumSavedStateVersion": "4.2.2-next.0"
 }

--- a/packages/state/package.json
+++ b/packages/state/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/state",
-    "version": "4.3.0-next.1",
+    "version": "4.3.0-next.2",
     "description": "State Management for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/state/src/round-state.ts
+++ b/packages/state/src/round-state.ts
@@ -187,6 +187,19 @@ export class RoundState implements Contracts.State.RoundState {
 
             this.blocksInCurrentRound = [];
 
+            const ourKeys: string[] = AppUtils.getForgerDelegates();
+
+            for (const wallet of this.walletRepository.allByUsername()) {
+                if (wallet.hasPublicKey() && ourKeys.includes(wallet.getPublicKey()!)) {
+                    wallet.setAttribute("delegate.version", { round: roundInfo.round, version: this.app.version() });
+                } else if (wallet.hasAttribute("delegate.version")) {
+                    const { round } = wallet.getAttribute("delegate.version");
+                    if (!round || round < roundInfo.round - 5) {
+                        wallet.forgetAttribute("delegate.version");
+                    }
+                }
+            }
+
             this.events.dispatch(Enums.RoundEvent.Applied);
         }
     }

--- a/packages/state/src/wallets/wallet.ts
+++ b/packages/state/src/wallets/wallet.ts
@@ -361,6 +361,10 @@ export class Wallet implements Contracts.State.Wallet {
             attributes.delegate.resigned = resigned;
         }
 
+        if (attributes.delegate?.version?.version) {
+            attributes.delegate.version = attributes.delegate.version.version;
+        }
+
         if (attributes.delegate && !isNaN(attributes.delegate.round)) {
             delete attributes.delegate.round;
         }

--- a/packages/transactions/package.json
+++ b/packages/transactions/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/transactions",
-    "version": "4.2.1",
+    "version": "4.2.2-next.0",
     "description": "Transaction Services for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/transactions/package.json
+++ b/packages/transactions/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/transactions",
-    "version": "4.3.0-next.1",
+    "version": "4.3.0-next.2",
     "description": "Transaction Services for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/transactions/package.json
+++ b/packages/transactions/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/transactions",
-    "version": "4.3.0-next.2",
+    "version": "4.3.0",
     "description": "Transaction Services for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/transactions/package.json
+++ b/packages/transactions/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/transactions",
-    "version": "4.3.0-next.0",
+    "version": "4.3.0-next.1",
     "description": "Transaction Services for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/transactions/package.json
+++ b/packages/transactions/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/transactions",
-    "version": "4.2.2-next.0",
+    "version": "4.3.0-next.0",
     "description": "Transaction Services for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/transactions/src/handlers/core/delegate-resignation.ts
+++ b/packages/transactions/src/handlers/core/delegate-resignation.ts
@@ -150,6 +150,18 @@ export class DelegateResignationTransactionHandler extends TransactionHandler {
                 "ERR_PENDING",
             );
         }
+
+        if (transaction.data.asset && transaction.data.asset.resignationType === Enums.DelegateStatus.NotResigned) {
+            if (this.walletRepository.hasByAddress(transaction.data.senderId)) {
+                const wallet = this.walletRepository.findByAddress(transaction.data.senderId);
+                if (wallet.isDelegate() && !wallet.hasAttribute("delegate.version")) {
+                    throw new Contracts.Pool.PoolError(
+                        `${wallet.getAttribute("delegate.username")} is not operating a node on the network`,
+                        "ERR_OFFLINE",
+                    );
+                }
+            }
+        }
     }
 
     public async applyToSender(transaction: Interfaces.ITransaction): Promise<void> {

--- a/packages/transactions/src/handlers/solar/vote.ts
+++ b/packages/transactions/src/handlers/solar/vote.ts
@@ -123,7 +123,7 @@ export class VoteTransactionHandler extends TransactionHandler {
         for (const delegate of votes) {
             if (this.walletRepository.hasByUsername(delegate)) {
                 const wallet = this.walletRepository.findByUsername(delegate);
-                if (!wallet.hasAttribute("delegate.version")) {
+                if (!wallet.hasAttribute("delegate.resigned") && !wallet.hasAttribute("delegate.version")) {
                     throw new Contracts.Pool.PoolError(
                         `${delegate} is not operating a node on the network`,
                         "ERR_OFFLINE",

--- a/packages/transactions/src/handlers/solar/vote.ts
+++ b/packages/transactions/src/handlers/solar/vote.ts
@@ -116,6 +116,21 @@ export class VoteTransactionHandler extends TransactionHandler {
                 "ERR_PENDING",
             );
         }
+
+        AppUtils.assert.defined<string[]>(transaction.data.asset?.votes);
+        const votes = Object.keys(transaction.data.asset.votes);
+
+        for (const delegate of votes) {
+            if (this.walletRepository.hasByUsername(delegate)) {
+                const wallet = this.walletRepository.findByUsername(delegate);
+                if (!wallet.hasAttribute("delegate.version")) {
+                    throw new Contracts.Pool.PoolError(
+                        `${delegate} is not operating a node on the network`,
+                        "ERR_OFFLINE",
+                    );
+                }
+            }
+        }
     }
 
     public async applyToSender(transaction: Interfaces.ITransaction): Promise<void> {

--- a/packages/webhooks/package.json
+++ b/packages/webhooks/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/webhooks",
-    "version": "4.2.1",
+    "version": "4.2.2-next.0",
     "description": "Webhooks for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/webhooks/package.json
+++ b/packages/webhooks/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/webhooks",
-    "version": "4.3.0-next.0",
+    "version": "4.3.0-next.1",
     "description": "Webhooks for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/webhooks/package.json
+++ b/packages/webhooks/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/webhooks",
-    "version": "4.3.0-next.2",
+    "version": "4.3.0",
     "description": "Webhooks for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/webhooks/package.json
+++ b/packages/webhooks/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/webhooks",
-    "version": "4.3.0-next.1",
+    "version": "4.3.0-next.2",
     "description": "Webhooks for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/packages/webhooks/package.json
+++ b/packages/webhooks/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solar-network/webhooks",
-    "version": "4.2.2-next.0",
+    "version": "4.3.0-next.0",
     "description": "Webhooks for Solar Core",
     "license": "CC-BY-ND-4.0",
     "contributors": [

--- a/plugins/sxp-swap/src/errors.ts
+++ b/plugins/sxp-swap/src/errors.ts
@@ -8,7 +8,7 @@ export class ApiCommunicationError extends Error {
 
 export class MemoIncorrectError extends Error {
     public constructor() {
-        super("The memo of the transaction from the swap source wallet must adhere to the correct format");
+        super("The memo of the transaction from the swap wallet must adhere to the correct format");
     }
 }
 
@@ -82,7 +82,7 @@ export class TransactionIdInvalidError extends Error {
 
 export class TransactionTypeNotPermittedError extends Error {
     public constructor() {
-        super("Swap source wallet is restricted to transfer transactions only");
+        super("Swap wallet is restricted to a subset of transaction types only");
     }
 }
 
@@ -116,6 +116,6 @@ export class WrongTokenError extends Error {
 
 export class WrongSecondSignaturePublicKeyError extends Error {
     public constructor() {
-        super("The public key of the second signature registration for the swap source wallet is incorrect");
+        super("The public key of the second signature registration for the swap wallet is incorrect");
     }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -119,6 +119,7 @@ importers:
       '@types/hapi__nes': 11.0.5
       '@types/ip': 1.1.0
       '@types/qs': 6.9.7
+      '@types/semaphore': 1.1.1
       '@types/semver': 6.2.3
       joi: 17.6.0
       lodash.clonedeep: 4.5.0
@@ -126,6 +127,7 @@ importers:
       node-cache: 5.1.2
       qs: 6.10.3
       rate-limiter-flexible: 1.3.2
+      semaphore: 1.1.0
       semver: 6.3.0
     dependencies:
       '@hapi/boom': 9.1.4
@@ -142,6 +144,7 @@ importers:
       node-cache: 5.1.2
       qs: 6.10.3
       rate-limiter-flexible: 1.3.2
+      semaphore: 1.1.0
       semver: 6.3.0
     devDependencies:
       '@types/hapi__boom': 7.4.1
@@ -150,6 +153,7 @@ importers:
       '@types/hapi__nes': 11.0.5
       '@types/ip': 1.1.0
       '@types/qs': 6.9.7
+      '@types/semaphore': 1.1.1
       '@types/semver': 6.2.3
       lodash.clonedeep: 4.5.0
 
@@ -4863,6 +4867,10 @@ packages:
     dependencies:
       '@types/node': 18.7.14
     dev: false
+
+  /@types/semaphore/1.1.1:
+    resolution: {integrity: sha512-jmFpMslMtBGOXY2s7x6O8vBebcj6zhkwl0Pd/viZApo1uZaPk733P8doPvaiBbCG+R7201OLOl4QP7l1mFyuyw==}
+    dev: true
 
   /@types/semver/6.2.3:
     resolution: {integrity: sha512-KQf+QAMWKMrtBMsB8/24w53tEsxllMj6TuA80TT/5igJalLI/zm0L3oXRbIAl4Ohfc85gyHX/jhMwsVkmhLU4A==}
@@ -11619,6 +11627,11 @@ packages:
       elliptic: 6.5.4
       node-addon-api: 2.0.2
       node-gyp-build: 4.5.0
+    dev: false
+
+  /semaphore/1.1.0:
+    resolution: {integrity: sha512-O4OZEaNtkMd/K0i6js9SL+gqy0ZCBMgUvlSqHKi4IBdjhe7wB8pwztUk1BbZ1fmrvpwFrPbHzqd2w5pTcJH6LA==}
+    engines: {node: '>=0.8.0'}
     dev: false
 
   /semver-compare/1.0.0:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,7 +53,7 @@ importers:
       typescript: 4.4.4
       typesync: 0.8.0
       uuid: 8.3.2
-      webpack: 5.73.0
+      webpack: 5.80.0
     devDependencies:
       '@babel/core': 7.16.0
       '@babel/preset-env': 7.16.0_@babel+core@7.16.0
@@ -70,7 +70,7 @@ importers:
       '@types/uuid': 8.3.1
       '@typescript-eslint/eslint-plugin': 5.14.0_d1b83841c62a8cd61c29155c2f670361
       '@typescript-eslint/parser': 5.14.0_eslint@8.1.0+typescript@4.4.4
-      babel-loader: 8.2.3_a082d5c26dd04df3d2bea169691e6845
+      babel-loader: 8.2.3_ba43380777aa0fc3c779f041bf3076cc
       capture-console: 1.0.1
       chalk: 4.1.2
       create-hash: 1.2.0
@@ -100,7 +100,7 @@ importers:
       typescript: 4.4.4
       typesync: 0.8.0
       uuid: 8.3.2
-      webpack: 5.73.0
+      webpack: 5.80.0
 
   packages/api:
     specifiers:
@@ -3835,12 +3835,17 @@ packages:
     engines: {node: '>=6.0.0'}
     dependencies:
       '@jridgewell/set-array': 1.1.1
-      '@jridgewell/sourcemap-codec': 1.4.11
-      '@jridgewell/trace-mapping': 0.3.15
+      '@jridgewell/sourcemap-codec': 1.4.14
+      '@jridgewell/trace-mapping': 0.3.18
     dev: true
 
   /@jridgewell/resolve-uri/3.0.5:
     resolution: {integrity: sha512-VPeQ7+wH0itvQxnG+lIzWgkysKIr3L9sslimFW55rHMdGu/qCQ5z5h9zq4gI8uBtqkpHhsF4Z/OwExufUCThew==}
+    engines: {node: '>=6.0.0'}
+    dev: true
+
+  /@jridgewell/resolve-uri/3.1.0:
+    resolution: {integrity: sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==}
     engines: {node: '>=6.0.0'}
     dev: true
 
@@ -3853,11 +3858,15 @@ packages:
     resolution: {integrity: sha512-m7O9o2uR8k2ObDysZYzdfhb08VuEml5oWGiosa1VdaPZ/A6QyPkAJuwN0Q1lhULOf6B7MtQmHENS743hWtCrgw==}
     dependencies:
       '@jridgewell/gen-mapping': 0.3.1
-      '@jridgewell/trace-mapping': 0.3.15
+      '@jridgewell/trace-mapping': 0.3.18
     dev: true
 
   /@jridgewell/sourcemap-codec/1.4.11:
     resolution: {integrity: sha512-Fg32GrJo61m+VqYSdRSjRXMjQ06j8YIYfcTqndLYVAaHmroZHLJZCydsWBOTDqXS2v+mjxohBWEMfg97GXmYQg==}
+    dev: true
+
+  /@jridgewell/sourcemap-codec/1.4.14:
+    resolution: {integrity: sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==}
     dev: true
 
   /@jridgewell/trace-mapping/0.3.15:
@@ -3865,6 +3874,13 @@ packages:
     dependencies:
       '@jridgewell/resolve-uri': 3.0.5
       '@jridgewell/sourcemap-codec': 1.4.11
+    dev: true
+
+  /@jridgewell/trace-mapping/0.3.18:
+    resolution: {integrity: sha512-w+niJYzMHdd7USdiH2U6869nqhD2nbfZXND5Yp93qIbEmnDNk7PD48o+YchRVpzMU7M6jVCbenTR7PA1FLQ9pA==}
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.0
+      '@jridgewell/sourcemap-codec': 1.4.14
     dev: true
 
   /@mapbox/node-pre-gyp/1.0.8:
@@ -4558,10 +4574,6 @@ packages:
     resolution: {integrity: sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==}
     dev: true
 
-  /@types/estree/0.0.51:
-    resolution: {integrity: sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==}
-    dev: true
-
   /@types/estree/1.0.0:
     resolution: {integrity: sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ==}
     dev: true
@@ -5099,109 +5111,109 @@ packages:
     resolution: {integrity: sha512-dTyhTIRmGXBjxJE+skC8tTWCGLCVc4wQgRRLt8+O9p5ewBAjoBwtCAkLPrtToSr1xltoe3st21Pv953aOZ7alg==}
     dev: true
 
-  /@webassemblyjs/ast/1.11.1:
-    resolution: {integrity: sha512-ukBh14qFLjxTQNTXocdyksN5QdM28S1CxHt2rdskFyL+xFV7VremuBLVbmCePj+URalXBENx/9Lm7lnhihtCSw==}
+  /@webassemblyjs/ast/1.11.5:
+    resolution: {integrity: sha512-LHY/GSAZZRpsNQH+/oHqhRQ5FT7eoULcBqgfyTB5nQHogFnK3/7QoN7dLnwSE/JkUAF0SrRuclT7ODqMFtWxxQ==}
     dependencies:
-      '@webassemblyjs/helper-numbers': 1.11.1
-      '@webassemblyjs/helper-wasm-bytecode': 1.11.1
+      '@webassemblyjs/helper-numbers': 1.11.5
+      '@webassemblyjs/helper-wasm-bytecode': 1.11.5
     dev: true
 
-  /@webassemblyjs/floating-point-hex-parser/1.11.1:
-    resolution: {integrity: sha512-iGRfyc5Bq+NnNuX8b5hwBrRjzf0ocrJPI6GWFodBFzmFnyvrQ83SHKhmilCU/8Jv67i4GJZBMhEzltxzcNagtQ==}
+  /@webassemblyjs/floating-point-hex-parser/1.11.5:
+    resolution: {integrity: sha512-1j1zTIC5EZOtCplMBG/IEwLtUojtwFVwdyVMbL/hwWqbzlQoJsWCOavrdnLkemwNoC/EOwtUFch3fuo+cbcXYQ==}
     dev: true
 
-  /@webassemblyjs/helper-api-error/1.11.1:
-    resolution: {integrity: sha512-RlhS8CBCXfRUR/cwo2ho9bkheSXG0+NwooXcc3PAILALf2QLdFyj7KGsKRbVc95hZnhnERon4kW/D3SZpp6Tcg==}
+  /@webassemblyjs/helper-api-error/1.11.5:
+    resolution: {integrity: sha512-L65bDPmfpY0+yFrsgz8b6LhXmbbs38OnwDCf6NpnMUYqa+ENfE5Dq9E42ny0qz/PdR0LJyq/T5YijPnU8AXEpA==}
     dev: true
 
-  /@webassemblyjs/helper-buffer/1.11.1:
-    resolution: {integrity: sha512-gwikF65aDNeeXa8JxXa2BAk+REjSyhrNC9ZwdT0f8jc4dQQeDQ7G4m0f2QCLPJiMTTO6wfDmRmj/pW0PsUvIcA==}
+  /@webassemblyjs/helper-buffer/1.11.5:
+    resolution: {integrity: sha512-fDKo1gstwFFSfacIeH5KfwzjykIE6ldh1iH9Y/8YkAZrhmu4TctqYjSh7t0K2VyDSXOZJ1MLhht/k9IvYGcIxg==}
     dev: true
 
-  /@webassemblyjs/helper-numbers/1.11.1:
-    resolution: {integrity: sha512-vDkbxiB8zfnPdNK9Rajcey5C0w+QJugEglN0of+kmO8l7lDb77AnlKYQF7aarZuCrv+l0UvqL+68gSDr3k9LPQ==}
+  /@webassemblyjs/helper-numbers/1.11.5:
+    resolution: {integrity: sha512-DhykHXM0ZABqfIGYNv93A5KKDw/+ywBFnuWybZZWcuzWHfbp21wUfRkbtz7dMGwGgT4iXjWuhRMA2Mzod6W4WA==}
     dependencies:
-      '@webassemblyjs/floating-point-hex-parser': 1.11.1
-      '@webassemblyjs/helper-api-error': 1.11.1
+      '@webassemblyjs/floating-point-hex-parser': 1.11.5
+      '@webassemblyjs/helper-api-error': 1.11.5
       '@xtuc/long': 4.2.2
     dev: true
 
-  /@webassemblyjs/helper-wasm-bytecode/1.11.1:
-    resolution: {integrity: sha512-PvpoOGiJwXeTrSf/qfudJhwlvDQxFgelbMqtq52WWiXC6Xgg1IREdngmPN3bs4RoO83PnL/nFrxucXj1+BX62Q==}
+  /@webassemblyjs/helper-wasm-bytecode/1.11.5:
+    resolution: {integrity: sha512-oC4Qa0bNcqnjAowFn7MPCETQgDYytpsfvz4ujZz63Zu/a/v71HeCAAmZsgZ3YVKec3zSPYytG3/PrRCqbtcAvA==}
     dev: true
 
-  /@webassemblyjs/helper-wasm-section/1.11.1:
-    resolution: {integrity: sha512-10P9No29rYX1j7F3EVPX3JvGPQPae+AomuSTPiF9eBQeChHI6iqjMIwR9JmOJXwpnn/oVGDk7I5IlskuMwU/pg==}
+  /@webassemblyjs/helper-wasm-section/1.11.5:
+    resolution: {integrity: sha512-uEoThA1LN2NA+K3B9wDo3yKlBfVtC6rh0i4/6hvbz071E8gTNZD/pT0MsBf7MeD6KbApMSkaAK0XeKyOZC7CIA==}
     dependencies:
-      '@webassemblyjs/ast': 1.11.1
-      '@webassemblyjs/helper-buffer': 1.11.1
-      '@webassemblyjs/helper-wasm-bytecode': 1.11.1
-      '@webassemblyjs/wasm-gen': 1.11.1
+      '@webassemblyjs/ast': 1.11.5
+      '@webassemblyjs/helper-buffer': 1.11.5
+      '@webassemblyjs/helper-wasm-bytecode': 1.11.5
+      '@webassemblyjs/wasm-gen': 1.11.5
     dev: true
 
-  /@webassemblyjs/ieee754/1.11.1:
-    resolution: {integrity: sha512-hJ87QIPtAMKbFq6CGTkZYJivEwZDbQUgYd3qKSadTNOhVY7p+gfP6Sr0lLRVTaG1JjFj+r3YchoqRYxNH3M0GQ==}
+  /@webassemblyjs/ieee754/1.11.5:
+    resolution: {integrity: sha512-37aGq6qVL8A8oPbPrSGMBcp38YZFXcHfiROflJn9jxSdSMMM5dS5P/9e2/TpaJuhE+wFrbukN2WI6Hw9MH5acg==}
     dependencies:
       '@xtuc/ieee754': 1.2.0
     dev: true
 
-  /@webassemblyjs/leb128/1.11.1:
-    resolution: {integrity: sha512-BJ2P0hNZ0u+Th1YZXJpzW6miwqQUGcIHT1G/sf72gLVD9DZ5AdYTqPNbHZh6K1M5VmKvFXwGSWZADz+qBWxeRw==}
+  /@webassemblyjs/leb128/1.11.5:
+    resolution: {integrity: sha512-ajqrRSXaTJoPW+xmkfYN6l8VIeNnR4vBOTQO9HzR7IygoCcKWkICbKFbVTNMjMgMREqXEr0+2M6zukzM47ZUfQ==}
     dependencies:
       '@xtuc/long': 4.2.2
     dev: true
 
-  /@webassemblyjs/utf8/1.11.1:
-    resolution: {integrity: sha512-9kqcxAEdMhiwQkHpkNiorZzqpGrodQQ2IGrHHxCy+Ozng0ofyMA0lTqiLkVs1uzTRejX+/O0EOT7KxqVPuXosQ==}
+  /@webassemblyjs/utf8/1.11.5:
+    resolution: {integrity: sha512-WiOhulHKTZU5UPlRl53gHR8OxdGsSOxqfpqWeA2FmcwBMaoEdz6b2x2si3IwC9/fSPLfe8pBMRTHVMk5nlwnFQ==}
     dev: true
 
-  /@webassemblyjs/wasm-edit/1.11.1:
-    resolution: {integrity: sha512-g+RsupUC1aTHfR8CDgnsVRVZFJqdkFHpsHMfJuWQzWU3tvnLC07UqHICfP+4XyL2tnr1amvl1Sdp06TnYCmVkA==}
+  /@webassemblyjs/wasm-edit/1.11.5:
+    resolution: {integrity: sha512-C0p9D2fAu3Twwqvygvf42iGCQ4av8MFBLiTb+08SZ4cEdwzWx9QeAHDo1E2k+9s/0w1DM40oflJOpkZ8jW4HCQ==}
     dependencies:
-      '@webassemblyjs/ast': 1.11.1
-      '@webassemblyjs/helper-buffer': 1.11.1
-      '@webassemblyjs/helper-wasm-bytecode': 1.11.1
-      '@webassemblyjs/helper-wasm-section': 1.11.1
-      '@webassemblyjs/wasm-gen': 1.11.1
-      '@webassemblyjs/wasm-opt': 1.11.1
-      '@webassemblyjs/wasm-parser': 1.11.1
-      '@webassemblyjs/wast-printer': 1.11.1
+      '@webassemblyjs/ast': 1.11.5
+      '@webassemblyjs/helper-buffer': 1.11.5
+      '@webassemblyjs/helper-wasm-bytecode': 1.11.5
+      '@webassemblyjs/helper-wasm-section': 1.11.5
+      '@webassemblyjs/wasm-gen': 1.11.5
+      '@webassemblyjs/wasm-opt': 1.11.5
+      '@webassemblyjs/wasm-parser': 1.11.5
+      '@webassemblyjs/wast-printer': 1.11.5
     dev: true
 
-  /@webassemblyjs/wasm-gen/1.11.1:
-    resolution: {integrity: sha512-F7QqKXwwNlMmsulj6+O7r4mmtAlCWfO/0HdgOxSklZfQcDu0TpLiD1mRt/zF25Bk59FIjEuGAIyn5ei4yMfLhA==}
+  /@webassemblyjs/wasm-gen/1.11.5:
+    resolution: {integrity: sha512-14vteRlRjxLK9eSyYFvw1K8Vv+iPdZU0Aebk3j6oB8TQiQYuO6hj9s4d7qf6f2HJr2khzvNldAFG13CgdkAIfA==}
     dependencies:
-      '@webassemblyjs/ast': 1.11.1
-      '@webassemblyjs/helper-wasm-bytecode': 1.11.1
-      '@webassemblyjs/ieee754': 1.11.1
-      '@webassemblyjs/leb128': 1.11.1
-      '@webassemblyjs/utf8': 1.11.1
+      '@webassemblyjs/ast': 1.11.5
+      '@webassemblyjs/helper-wasm-bytecode': 1.11.5
+      '@webassemblyjs/ieee754': 1.11.5
+      '@webassemblyjs/leb128': 1.11.5
+      '@webassemblyjs/utf8': 1.11.5
     dev: true
 
-  /@webassemblyjs/wasm-opt/1.11.1:
-    resolution: {integrity: sha512-VqnkNqnZlU5EB64pp1l7hdm3hmQw7Vgqa0KF/KCNO9sIpI6Fk6brDEiX+iCOYrvMuBWDws0NkTOxYEb85XQHHw==}
+  /@webassemblyjs/wasm-opt/1.11.5:
+    resolution: {integrity: sha512-tcKwlIXstBQgbKy1MlbDMlXaxpucn42eb17H29rawYLxm5+MsEmgPzeCP8B1Cl69hCice8LeKgZpRUAPtqYPgw==}
     dependencies:
-      '@webassemblyjs/ast': 1.11.1
-      '@webassemblyjs/helper-buffer': 1.11.1
-      '@webassemblyjs/wasm-gen': 1.11.1
-      '@webassemblyjs/wasm-parser': 1.11.1
+      '@webassemblyjs/ast': 1.11.5
+      '@webassemblyjs/helper-buffer': 1.11.5
+      '@webassemblyjs/wasm-gen': 1.11.5
+      '@webassemblyjs/wasm-parser': 1.11.5
     dev: true
 
-  /@webassemblyjs/wasm-parser/1.11.1:
-    resolution: {integrity: sha512-rrBujw+dJu32gYB7/Lup6UhdkPx9S9SnobZzRVL7VcBH9Bt9bCBLEuX/YXOOtBsOZ4NQrRykKhffRWHvigQvOA==}
+  /@webassemblyjs/wasm-parser/1.11.5:
+    resolution: {integrity: sha512-SVXUIwsLQlc8srSD7jejsfTU83g7pIGr2YYNb9oHdtldSxaOhvA5xwvIiWIfcX8PlSakgqMXsLpLfbbJ4cBYew==}
     dependencies:
-      '@webassemblyjs/ast': 1.11.1
-      '@webassemblyjs/helper-api-error': 1.11.1
-      '@webassemblyjs/helper-wasm-bytecode': 1.11.1
-      '@webassemblyjs/ieee754': 1.11.1
-      '@webassemblyjs/leb128': 1.11.1
-      '@webassemblyjs/utf8': 1.11.1
+      '@webassemblyjs/ast': 1.11.5
+      '@webassemblyjs/helper-api-error': 1.11.5
+      '@webassemblyjs/helper-wasm-bytecode': 1.11.5
+      '@webassemblyjs/ieee754': 1.11.5
+      '@webassemblyjs/leb128': 1.11.5
+      '@webassemblyjs/utf8': 1.11.5
     dev: true
 
-  /@webassemblyjs/wast-printer/1.11.1:
-    resolution: {integrity: sha512-IQboUWM4eKzWW+N/jij2sRatKMh99QEelo3Eb2q0qXkvPRISAj8Qxtmw5itwqK+TTkBuUIE45AxYPToqPtL5gg==}
+  /@webassemblyjs/wast-printer/1.11.5:
+    resolution: {integrity: sha512-f7Pq3wvg3GSPUPzR0F6bmI89Hdb+u9WXrSKc4v+N0aV0q6r42WoF92Jp2jEorBEBRoRNXgjp53nBniDXcqZYPA==}
     dependencies:
-      '@webassemblyjs/ast': 1.11.1
+      '@webassemblyjs/ast': 1.11.5
       '@xtuc/long': 4.2.2
     dev: true
 
@@ -5649,7 +5661,7 @@ packages:
       - debug
     dev: true
 
-  /babel-loader/8.2.3_a082d5c26dd04df3d2bea169691e6845:
+  /babel-loader/8.2.3_ba43380777aa0fc3c779f041bf3076cc:
     resolution: {integrity: sha512-n4Zeta8NC3QAsuyiizu0GkmRcQ6clkV9WFUnUf1iXP//IeSKbWjofW3UHyZVwlOB4y039YQKefawyTn64Zwbuw==}
     engines: {node: '>= 8.9'}
     peerDependencies:
@@ -5661,7 +5673,7 @@ packages:
       loader-utils: 1.4.0
       make-dir: 3.1.0
       schema-utils: 2.7.1
-      webpack: 5.73.0
+      webpack: 5.80.0
     dev: true
 
   /babel-plugin-dynamic-import-node/2.3.3:
@@ -7183,8 +7195,8 @@ packages:
     dependencies:
       once: 1.4.0
 
-  /enhanced-resolve/5.10.0:
-    resolution: {integrity: sha512-T0yTFjdpldGY8PmuXXR0PyQ1ufZpEGiHVrp7zHKB7jdR4qlmZHhONVM5AQOAWXuF/w3dnHbEQVrNptJgt7F+cQ==}
+  /enhanced-resolve/5.13.0:
+    resolution: {integrity: sha512-eyV8f0y1+bzyfh8xAwW/WTSZpLbjhqc4ne9eGSH4Zo2ejdyiNG9pU6mf9DG8a7+Auk6MFTlNOT4Y2y/9k8GKVg==}
     engines: {node: '>=10.13.0'}
     dependencies:
       graceful-fs: 4.2.10
@@ -7254,8 +7266,8 @@ packages:
       string.prototype.trimstart: 1.0.5
       unbox-primitive: 1.0.2
 
-  /es-module-lexer/0.9.3:
-    resolution: {integrity: sha512-1HQ2M2sPtxwnvOvT1ZClHyQDiggdNjURWpY2we6aMKCQiUVxTmVs2UYPLIrD84sS+kMdUwfBSylbJPwNnBrnHQ==}
+  /es-module-lexer/1.2.1:
+    resolution: {integrity: sha512-9978wrXM50Y4rTMmW5kXIC09ZdXQZqkE4mxhwkd8VbzsGkXGPgV4zWuqQJgCEzYngdo2dYDa0l8xhX4fkSwJSg==}
     dev: true
 
   /es-to-primitive/1.2.1:
@@ -11598,8 +11610,8 @@ packages:
       ajv-keywords: 3.5.2_ajv@6.12.6
     dev: true
 
-  /schema-utils/3.1.1:
-    resolution: {integrity: sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==}
+  /schema-utils/3.1.2:
+    resolution: {integrity: sha512-pvjEHOgWc9OWA/f/DE3ohBWTD6EleVLf7iFUkoSwAxttdBhB9QUebQgxER2kWueOvRJXPHNnyrvvh9eZINB8Eg==}
     engines: {node: '>= 10.13.0'}
     dependencies:
       '@types/json-schema': 7.0.11
@@ -11696,8 +11708,8 @@ packages:
       statuses: 2.0.1
     dev: false
 
-  /serialize-javascript/6.0.0:
-    resolution: {integrity: sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==}
+  /serialize-javascript/6.0.1:
+    resolution: {integrity: sha512-owoXEFjWRllis8/M1Q+Cw5k8ZH40e3zhp/ovX+Xr/vi1qj6QesbyXXViFbpNvWvPNAD62SutwEXavefrLJWj7w==}
     dependencies:
       randombytes: 2.1.0
     dev: true
@@ -12259,8 +12271,8 @@ packages:
       mkdirp: 1.0.4
       yallist: 4.0.0
 
-  /terser-webpack-plugin/5.3.6_webpack@5.73.0:
-    resolution: {integrity: sha512-kfLFk+PoLUQIbLmB1+PZDMRSZS99Mp+/MHqDNmMA6tOItzRt+Npe3E+fsMs5mfcM0wCtrrdU387UnV+vnSffXQ==}
+  /terser-webpack-plugin/5.3.7_webpack@5.80.0:
+    resolution: {integrity: sha512-AfKwIktyP7Cu50xNjXF/6Qb5lBNzYaWpU6YfoX3uZicTx0zTy0stDDCsvjDapKsSDvOeWo5MEq4TmdBy2cNoHw==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
       '@swc/core': '*'
@@ -12275,16 +12287,16 @@ packages:
       uglify-js:
         optional: true
     dependencies:
-      '@jridgewell/trace-mapping': 0.3.15
+      '@jridgewell/trace-mapping': 0.3.18
       jest-worker: 27.5.1
-      schema-utils: 3.1.1
-      serialize-javascript: 6.0.0
-      terser: 5.15.0
-      webpack: 5.73.0
+      schema-utils: 3.1.2
+      serialize-javascript: 6.0.1
+      terser: 5.17.1
+      webpack: 5.80.0
     dev: true
 
-  /terser/5.15.0:
-    resolution: {integrity: sha512-L1BJiXVmheAQQy+as0oF3Pwtlo4s3Wi1X2zNZ2NxOB4wx9bdS9Vk67XQENLFdLYGCK/Z2di53mTj/hBafR+dTA==}
+  /terser/5.17.1:
+    resolution: {integrity: sha512-hVl35zClmpisy6oaoKALOpS0rDYLxRFLHhRuDlEGTKey9qHjS1w9GMORjuwIMt70Wan4lwsLYyWDVnWgF+KUEw==}
     engines: {node: '>=10'}
     hasBin: true
     dependencies:
@@ -13066,8 +13078,8 @@ packages:
     engines: {node: '>=10.13.0'}
     dev: true
 
-  /webpack/5.73.0:
-    resolution: {integrity: sha512-svjudQRPPa0YiOYa2lM/Gacw0r6PvxptHj4FuEKQ2kX05ZLkjbVc5MnPs6its5j7IZljnIqSVo/OsY2X0IpHGA==}
+  /webpack/5.80.0:
+    resolution: {integrity: sha512-OIMiq37XK1rWO8mH9ssfFKZsXg4n6klTEDL7S8/HqbAOBBaiy8ABvXvz0dDCXeEF9gqwxSvVk611zFPjS8hJxA==}
     engines: {node: '>=10.13.0'}
     hasBin: true
     peerDependencies:
@@ -13077,16 +13089,16 @@ packages:
         optional: true
     dependencies:
       '@types/eslint-scope': 3.7.4
-      '@types/estree': 0.0.51
-      '@webassemblyjs/ast': 1.11.1
-      '@webassemblyjs/wasm-edit': 1.11.1
-      '@webassemblyjs/wasm-parser': 1.11.1
+      '@types/estree': 1.0.0
+      '@webassemblyjs/ast': 1.11.5
+      '@webassemblyjs/wasm-edit': 1.11.5
+      '@webassemblyjs/wasm-parser': 1.11.5
       acorn: 8.8.0
       acorn-import-assertions: 1.8.0_acorn@8.8.0
       browserslist: 4.21.3
       chrome-trace-event: 1.0.3
-      enhanced-resolve: 5.10.0
-      es-module-lexer: 0.9.3
+      enhanced-resolve: 5.13.0
+      es-module-lexer: 1.2.1
       eslint-scope: 5.1.1
       events: 3.3.0
       glob-to-regexp: 0.4.1
@@ -13095,9 +13107,9 @@ packages:
       loader-runner: 4.3.0
       mime-types: 2.1.35
       neo-async: 2.6.2
-      schema-utils: 3.1.1
+      schema-utils: 3.1.2
       tapable: 2.2.1
-      terser-webpack-plugin: 5.3.6_webpack@5.73.0
+      terser-webpack-plugin: 5.3.7_webpack@5.80.0
       watchpack: 2.4.0
       webpack-sources: 3.2.3
     transitivePeerDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -793,7 +793,6 @@ packages:
       strip-ansi: 6.0.1
     transitivePeerDependencies:
       - zen-observable
-      - zenObservable
     dev: false
 
   /@alessiodf/ora/0.0.2:
@@ -3937,8 +3936,6 @@ packages:
       promise-retry: 2.0.1
       semver: 7.3.7
       which: 2.0.2
-    transitivePeerDependencies:
-      - bluebird
     dev: true
 
   /@npmcli/installed-package-contents/1.0.7:
@@ -4364,10 +4361,8 @@ packages:
       zen-observable:
         optional: true
     dependencies:
-      any-observable: 0.3.0_rxjs@7.5.5
+      any-observable: 0.3.0
       rxjs: 7.5.5
-    transitivePeerDependencies:
-      - zenObservable
     dev: false
 
   /@scure/base/1.1.1:
@@ -5429,19 +5424,9 @@ packages:
     resolution: {integrity: sha512-QXu7BPrP29VllRxH8GwB7x5iX5qWKAAMLqKQGWTeLWVlNHNOpVMJ91dsxQAIWXpjuW5wqvxu3Jd/nRjrJ+0pqg==}
     dev: true
 
-  /any-observable/0.3.0_rxjs@7.5.5:
+  /any-observable/0.3.0:
     resolution: {integrity: sha512-/FQM1EDkTsf63Ub2C6O7GuYFDsSXUwsaZDurV0np41ocwq0jthUAYCmhBX9f+KwlaCgIuWyr/4WlUQUBfKfZog==}
     engines: {node: '>=6'}
-    peerDependencies:
-      rxjs: '*'
-      zenObservable: '*'
-    peerDependenciesMeta:
-      rxjs:
-        optional: true
-      zenObservable:
-        optional: true
-    dependencies:
-      rxjs: 7.5.5
     dev: false
 
   /any-promise/1.3.0:
@@ -5914,8 +5899,6 @@ packages:
       raw-body: 2.5.1
       type-is: 1.6.18
       unpipe: 1.0.0
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /boxen/5.1.2:
@@ -6130,8 +6113,6 @@ packages:
       ssri: 8.0.1
       tar: 6.1.11
       unique-filename: 1.1.1
-    transitivePeerDependencies:
-      - bluebird
     dev: true
 
   /cache-base/1.0.1:
@@ -6824,11 +6805,6 @@ packages:
 
   /debug/2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
     dependencies:
       ms: 2.0.0
     dev: false
@@ -7523,10 +7499,6 @@ packages:
       servify: 0.1.12
       ws: 3.3.3
       xhr-request-promise: 0.1.3
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
     dev: false
 
   /eth-lib/0.2.8:
@@ -7747,8 +7719,6 @@ packages:
       type-is: 1.6.18
       utils-merge: 1.0.1
       vary: 1.1.2
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /ext/1.7.0:
@@ -7892,8 +7862,6 @@ packages:
       parseurl: 1.3.3
       statuses: 2.0.1
       unpipe: 1.0.0
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /find-cache-dir/3.3.2:
@@ -9562,7 +9530,6 @@ packages:
       socks-proxy-agent: 6.2.1
       ssri: 8.0.1
     transitivePeerDependencies:
-      - bluebird
       - supports-color
     dev: true
 
@@ -10006,8 +9973,6 @@ packages:
       regex-not: 1.0.2
       snapdragon: 0.8.2
       to-regex: 3.0.2
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /napi-build-utils/1.0.2:
@@ -10242,7 +10207,6 @@ packages:
       spawn-please: 1.0.0
       update-notifier: 5.1.0
     transitivePeerDependencies:
-      - bluebird
       - supports-color
     dev: true
 
@@ -10297,7 +10261,6 @@ packages:
       minizlib: 2.1.2
       npm-package-arg: 8.1.5
     transitivePeerDependencies:
-      - bluebird
       - supports-color
     dev: true
 
@@ -10559,7 +10522,6 @@ packages:
       ssri: 8.0.1
       tar: 6.1.11
     transitivePeerDependencies:
-      - bluebird
       - supports-color
     dev: true
 
@@ -10951,11 +10913,6 @@ packages:
 
   /promise-inflight/1.0.1:
     resolution: {integrity: sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==}
-    peerDependencies:
-      bluebird: '*'
-    peerDependenciesMeta:
-      bluebird:
-        optional: true
     dev: true
 
   /promise-retry/2.0.1:
@@ -11724,8 +11681,6 @@ packages:
       on-finished: 2.4.1
       range-parser: 1.2.1
       statuses: 2.0.1
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /serialize-javascript/6.0.0:
@@ -11742,8 +11697,6 @@ packages:
       escape-html: 1.0.3
       parseurl: 1.3.3
       send: 0.18.0
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /servify/0.1.12:
@@ -11755,8 +11708,6 @@ packages:
       express: 4.18.1
       request: 2.88.2
       xhr: 2.6.0
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /set-blocking/2.0.0:
@@ -11904,8 +11855,6 @@ packages:
       source-map: 0.5.7
       source-map-resolve: 0.5.3
       use: 3.1.1
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /socks-proxy-agent/6.2.1:
@@ -12248,10 +12197,6 @@ packages:
       setimmediate: 1.0.5
       tar: 4.4.19
       xhr-request: 1.1.0
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
     dev: false
 
   /tapable/2.2.1:
@@ -12876,10 +12821,6 @@ packages:
       '@types/node': 12.20.55
       got: 11.8.5
       swarm-js: 0.1.40
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
     dev: false
 
   /web3-core-helpers/1.7.1:
@@ -12917,8 +12858,6 @@ packages:
       web3-providers-http: 1.7.1
       web3-providers-ipc: 1.7.1
       web3-providers-ws: 1.7.1
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /web3-core-subscriptions/1.7.1:
@@ -12940,8 +12879,6 @@ packages:
       web3-core-method: 1.7.1
       web3-core-requestmanager: 1.7.1
       web3-utils: 1.7.1
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /web3-eth-abi/1.7.1:
@@ -12967,8 +12904,6 @@ packages:
       web3-core-helpers: 1.7.1
       web3-core-method: 1.7.1
       web3-utils: 1.7.1
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /web3-eth-contract/1.7.1:
@@ -12983,8 +12918,6 @@ packages:
       web3-core-subscriptions: 1.7.1
       web3-eth-abi: 1.7.1
       web3-utils: 1.7.1
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /web3-eth-ens/1.7.1:
@@ -12999,8 +12932,6 @@ packages:
       web3-eth-abi: 1.7.1
       web3-eth-contract: 1.7.1
       web3-utils: 1.7.1
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /web3-eth-iban/1.7.1:
@@ -13021,8 +12952,6 @@ packages:
       web3-core-method: 1.7.1
       web3-net: 1.7.1
       web3-utils: 1.7.1
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /web3-eth/1.7.1:
@@ -13041,8 +12970,6 @@ packages:
       web3-eth-personal: 1.7.1
       web3-net: 1.7.1
       web3-utils: 1.7.1
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /web3-net/1.7.1:
@@ -13052,8 +12979,6 @@ packages:
       web3-core: 1.7.1
       web3-core-method: 1.7.1
       web3-utils: 1.7.1
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /web3-providers-http/1.7.1:
@@ -13079,8 +13004,6 @@ packages:
       eventemitter3: 4.0.4
       web3-core-helpers: 1.7.1
       websocket: 1.0.34
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /web3-shh/1.7.1:
@@ -13092,8 +13015,6 @@ packages:
       web3-core-method: 1.7.1
       web3-core-subscriptions: 1.7.1
       web3-net: 1.7.1
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /web3-utils/1.7.1:
@@ -13121,10 +13042,6 @@ packages:
       web3-net: 1.7.1
       web3-shh: 1.7.1
       web3-utils: 1.7.1
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
     dev: false
 
   /webidl-conversions/3.0.1:
@@ -13186,8 +13103,6 @@ packages:
       typedarray-to-buffer: 3.1.5
       utf-8-validate: 5.0.9
       yaeti: 0.0.6
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /whatwg-url/5.0.0:
@@ -13296,14 +13211,6 @@ packages:
 
   /ws/3.3.3:
     resolution: {integrity: sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==}
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: ^5.0.2
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
     dependencies:
       async-limiter: 1.0.1
       safe-buffer: 5.1.2


### PR DESCRIPTION
This PR releases Solar Core 4.3.0 for mainnet.

Changes since 4.2.2:

### New Features
\- only accept votes and resignation revocations in the pool for block producers running nodes
### Maintenance
\- upstream database and api performance improvements
\- update milestones to deprecate sxp-swap
\- relax sxp-swap restrictions to permit voting

It is expected that the 4.3.x series will be relatively short-lived, with 4.4.x following soon.